### PR TITLE
Hook improvements

### DIFF
--- a/bosk-core/src/main/java/works/bosk/HookRegistrar.java
+++ b/bosk-core/src/main/java/works/bosk/HookRegistrar.java
@@ -15,6 +15,7 @@ import works.bosk.exceptions.InvalidTypeException;
 
 import static java.lang.reflect.Modifier.isPrivate;
 import static java.lang.reflect.Modifier.isStatic;
+import static works.bosk.util.ReflectionHelpers.getDeclaredMethodsInOrder;
 
 @RequiredArgsConstructor
 class HookRegistrar {
@@ -25,7 +26,7 @@ class HookRegistrar {
 			receiverClass != null;
 			receiverClass = receiverClass.getSuperclass()
 		) {
-			for (Method method : receiverClass.getDeclaredMethods()) {
+			for (Method method : getDeclaredMethodsInOrder(receiverClass)) {
 				Hook hookAnnotation = method.getAnnotation(Hook.class);
 				if (hookAnnotation == null) {
 					continue;

--- a/bosk-core/src/main/java/works/bosk/HookRegistrar.java
+++ b/bosk-core/src/main/java/works/bosk/HookRegistrar.java
@@ -38,7 +38,20 @@ class HookRegistrar {
 				}
 				method.setAccessible(true);
 				Path path = Path.parseParameterized(hookAnnotation.value());
-				Reference<Object> scope = bosk.rootReference().then(Object.class, path);
+
+				Reference<?> plainRef = bosk.rootReference().then(Object.class, path);
+				// Now substitute one of the handy Reference subtypes where possible
+				Reference<?> scope;
+				if (Catalog.class.isAssignableFrom(plainRef.targetClass())) {
+					scope = bosk.rootReference().thenCatalog(Entity.class, path);
+				} else if (Listing.class.isAssignableFrom(plainRef.targetClass())) {
+					scope = bosk.rootReference().thenListing(Entity.class, path);
+				} else if (SideTable.class.isAssignableFrom(plainRef.targetClass())) {
+					scope = bosk.rootReference().thenSideTable(Entity.class, Object.class, path);
+				} else {
+					scope = plainRef;
+				}
+
 				List<Function<Reference<?>, Object>> argumentFunctions = new ArrayList<>(method.getParameterCount());
 				argumentFunctions.add(ref -> receiverObject); // The "this" pointer
 				for (Parameter p : method.getParameters()) {
@@ -46,12 +59,12 @@ class HookRegistrar {
 						if (ReferenceUtils.parameterType(p.getParameterizedType(), Reference.class, 0).equals(scope.targetType())) {
 							argumentFunctions.add(ref -> ref);
 						} else {
-							throw new IllegalArgumentException("Expected reference to " + scope.targetType() + ": " + method.getName() + " parameter " + p.getName());
+							throw new IllegalArgumentException("Expected reference to " + scope.targetType() + ": " + method.getName() + " parameter " + p);
 						}
 					} else if (p.getType().isAssignableFrom(BindingEnvironment.class)) {
 						argumentFunctions.add(ref -> scope.parametersFrom(ref.path()));
 					} else {
-						throw new IllegalArgumentException("Unsupported parameter type " + p.getType() + ": " + method.getName() + " parameter " + p.getName());
+						throw new IllegalArgumentException("Unsupported parameter type " + p.getType() + ": " + method.getName() + " parameter " + p);
 					}
 				}
 				MethodHandle hook;

--- a/bosk-core/src/main/java/works/bosk/dereferencers/PathCompiler.java
+++ b/bosk-core/src/main/java/works/bosk/dereferencers/PathCompiler.java
@@ -207,7 +207,7 @@ public final class PathCompiler {
 		// Construction
 		//
 
-		public StepwiseDereferencerBuilder(Path path, StackTraceElement sourceFileOrigin) throws InvalidTypeException {
+		public StepwiseDereferencerBuilder(Path path, StackWalker.StackFrame sourceFileOrigin) throws InvalidTypeException {
 			super("DEREFERENCER", rawClass(sourceType).getClassLoader(), sourceFileOrigin);
 			assert !path.isEmpty();
 			steps = new ArrayList<>();

--- a/bosk-core/src/main/java/works/bosk/dereferencers/SkeletonDereferencerBuilder.java
+++ b/bosk-core/src/main/java/works/bosk/dereferencers/SkeletonDereferencerBuilder.java
@@ -22,7 +22,7 @@ import works.bosk.bytecode.ClassBuilder;
 abstract class SkeletonDereferencerBuilder implements DereferencerBuilder {
 	protected final ClassBuilder<Dereferencer> cb;
 
-	public SkeletonDereferencerBuilder(String className, ClassLoader parentClassLoader, StackTraceElement sourceFileOrigin) {
+	public SkeletonDereferencerBuilder(String className, ClassLoader parentClassLoader, StackWalker.StackFrame sourceFileOrigin) {
 		this.cb = new ClassBuilder<>(className, DereferencerRuntime.class, parentClassLoader, sourceFileOrigin);
 	}
 

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -1,0 +1,129 @@
+package works.bosk.drivers;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import works.bosk.BoskDriver;
+import works.bosk.DriverFactory;
+import works.bosk.Identifier;
+import works.bosk.Reference;
+import works.bosk.RootReference;
+import works.bosk.StateTreeNode;
+import works.bosk.exceptions.InvalidTypeException;
+
+/**
+ * A pool of bosks arranged such that submitting an update to any of them submits to all of them.
+ * New bosks can be added any time by initializing them with {@link #driverFactory()} in their driver stack.
+ * <p>
+ * Note that this isn't used for true distributed replica sets with one bosk in each JVM process,
+ * but rather for constructing a local replica set within a single JVM process.
+ * <p>
+ * <em>Evolution note</em>: This kind of subsumes the functionality of both {@link ForwardingDriver}
+ * and {@link MirroringDriver}. Seems like this class could either use or replace those.
+ * Perhaps {@link ForwardingDriver} should do the {@link Replica#correspondingReference} logic that
+ * {@link MirroringDriver} does, making the latter unnecessary; and then this class could
+ * simply be a {@link ForwardingDriver} whose list of downstream drivers is mutable.
+ */
+public class ReplicaSet<R extends StateTreeNode> {
+	final Queue<Replica<R>> replicas = new ConcurrentLinkedQueue<>();
+
+	/**
+	 * We can actually use the same driver for every bosk in the replica set
+	 * because they all do the same thing!
+	 */
+	final BroadcastShim shim = new BroadcastShim();
+
+	public DriverFactory<R> driverFactory() {
+		return (b,d) -> {
+			replicas.add(new Replica<>(b.rootReference(), d));
+			return shim;
+		};
+	}
+
+	final class BroadcastShim implements BoskDriver<R> {
+		/**
+		 * @return The result of calling <code>initialRoot</code> on the first downstream driver
+		 * that doesn't throw {@link UnsupportedOperationException}. Other exceptions are propagated as-is,
+		 * and abort the initialization immediately.
+		 */
+		@Override
+		public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+			List<UnsupportedOperationException> exceptions = new ArrayList<>();
+			for (var r: replicas) {
+				try {
+					return r.driver().initialRoot(rootType);
+				} catch (UnsupportedOperationException e) {
+					exceptions.add(e);
+				}
+			}
+
+			// Oh dear.
+			UnsupportedOperationException exception = new UnsupportedOperationException("Unable to forward initialRoot request");
+			exceptions.forEach(exception::addSuppressed);
+			throw exception;
+		}
+
+		@Override
+		public <T> void submitReplacement(Reference<T> target, T newValue) {
+			replicas.forEach(r -> r.driver
+				.submitReplacement(
+					r.correspondingReference(target), newValue));
+		}
+
+		@Override
+		public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+			replicas.forEach(r -> r.driver
+				.submitConditionalReplacement(
+					r.correspondingReference(target), newValue,
+					r.correspondingReference(precondition), requiredValue));
+		}
+
+		@Override
+		public <T> void submitInitialization(Reference<T> target, T newValue) {
+			replicas.forEach(r -> r.driver
+				.submitInitialization(
+					r.correspondingReference(target), newValue));
+		}
+
+		@Override
+		public <T> void submitDeletion(Reference<T> target) {
+			replicas.forEach(r -> r.driver
+				.submitDeletion(
+					r.correspondingReference(target)));
+		}
+
+		@Override
+		public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+			replicas.forEach(r -> r.driver
+				.submitConditionalDeletion(
+					r.correspondingReference(target),
+					r.correspondingReference(precondition), requiredValue));
+		}
+
+		@Override
+		public void flush() throws IOException, InterruptedException {
+			for (var r : replicas) {
+				r.driver().flush();
+			}
+		}
+
+	}
+
+	record Replica<R extends StateTreeNode>(
+		RootReference<R> root,
+		BoskDriver<R> driver
+	){
+		@SuppressWarnings("unchecked")
+		private <T> Reference<T> correspondingReference(Reference<T> original) {
+			try {
+				return (Reference<T>) root.then(Object.class, original.path());
+			} catch (InvalidTypeException e) {
+				throw new AssertionError("Every reference should support a target class of Object", e);
+			}
+		}
+	}
+
+}

--- a/bosk-core/src/main/java/works/bosk/logging/MdcKeys.java
+++ b/bosk-core/src/main/java/works/bosk/logging/MdcKeys.java
@@ -7,8 +7,25 @@ package works.bosk.logging;
  * For now, only bosk-mongo uses these.
  */
 public final class MdcKeys {
-	public static final String BOSK_NAME        = "bosk.name";
+	/**
+	 * The value of {@link Bosk#name()}.
+	 */
+	public static final String BOSK_NAME = "bosk.name";
+
+	/**
+	 * The value of {@link Bosk#instanceID()}.
+	 */
 	public static final String BOSK_INSTANCE_ID = "bosk.instanceID";
-	public static final String EVENT            = "bosk.MongoDriver.event";
-	public static final String TRANSACTION      = "bosk.MongoDriver.transaction";
+
+	/**
+	 * A unique string generated for each MongoDB change event received by a particular bosk.
+	 */
+	public static final String EVENT = "bosk.MongoDriver.event";
+
+	/**
+	 * A unique string generated for each MongoDB {@link ClientSession}.
+	 * Technically, not every session is a transaction, but we do use them for
+	 * transactions, and this name seemed to convey the intent better than "session".
+	 */
+	public static final String TRANSACTION = "bosk.MongoDriver.transaction";
 }

--- a/bosk-core/src/main/java/works/bosk/util/ReflectionHelpers.java
+++ b/bosk-core/src/main/java/works/bosk/util/ReflectionHelpers.java
@@ -1,10 +1,27 @@
 package works.bosk.util;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 import static java.lang.reflect.Modifier.isPrivate;
+import static java.util.Objects.requireNonNull;
+import static org.objectweb.asm.ClassReader.SKIP_CODE;
+import static org.objectweb.asm.ClassReader.SKIP_DEBUG;
+import static org.objectweb.asm.ClassReader.SKIP_FRAMES;
+import static org.objectweb.asm.Opcodes.ASM9;
+import static org.objectweb.asm.Type.ARRAY;
+import static org.objectweb.asm.Type.OBJECT;
 
 public final class ReflectionHelpers {
 
@@ -31,4 +48,89 @@ public final class ReflectionHelpers {
 		object.setAccessible(true);
 	}
 
+	/**
+	 * @param type must be defined in a classfile accessible by passing {@link Class#getResourceAsStream(String)}
+	 *             the class's own name followed by <code>.class</code>.
+	 *             In particular, this can't be a dynamically generated class.
+	 * @return like {@link Class#getDeclaredMethods()} except in bytecode order.
+	 */
+	public static List<Method> getDeclaredMethodsInOrder(Class<?> type) {
+		// Won't someone please tell me why getDeclaredMethods doesn't already work this way?
+		List<Method> result = new ArrayList<>();
+		ClassLoader loader = type.getClassLoader();
+		ClassReader cr;
+		try {
+			String typeName = type.getName();
+			String fileName = typeName.substring(typeName.lastIndexOf('.') + 1) + ".class";
+			InputStream resource = type.getResourceAsStream(fileName);
+			if (resource == null) {
+				throw new IOException("No resource called \"" + fileName + "\"");
+			}
+			cr = new ClassReader(resource);
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to open the classfile corresponding to " + type, e);
+		}
+		cr.accept(new ClassVisitor(ASM9) {
+			@Override
+			public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+				if (name.equals("<init>") || name.equals("<clinit>")) {
+					// getDeclaredMethods explicitly excludes these
+					return null;
+				} else if ((access & Opcodes.ACC_SYNTHETIC) != 0) {
+					return null;
+				}
+				Type[] argumentTypes = Type.getArgumentTypes(descriptor);
+				Class<?>[] argumentClasses = new Class<?>[argumentTypes.length];
+				for (int i = 0; i < argumentTypes.length; i++) {
+					argumentClasses[i] = findClass(argumentTypes[i], loader);
+				}
+				try {
+					result.add(type.getDeclaredMethod(name, argumentClasses));
+				} catch (NoSuchMethodException e) {
+					throw new IllegalStateException(e);
+				}
+				return null;
+			}
+		}, SKIP_CODE | SKIP_DEBUG | SKIP_FRAMES);
+		return result;
+	}
+
+	private static Class<?> findClass(Type argumentType, ClassLoader loader) {
+		try {
+			return switch (argumentType.getSort()) {
+				case OBJECT ->
+					requireNonNull(Class.forName(argumentType.getClassName(), false, loader));
+				case ARRAY ->
+					findClass(argumentType.getElementType(), loader).arrayType();
+				default ->
+					requireNonNull(classForPrimitiveName(argumentType.getClassName()));
+			};
+		} catch (ClassNotFoundException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	/**
+	 * Stolen shamelessly from Java 22
+	 */
+	private static Class<?> classForPrimitiveName(String primitiveName) {
+		return switch(primitiveName) {
+			// Integral types
+			case "int"     -> int.class;
+			case "long"    -> long.class;
+			case "short"   -> short.class;
+			case "char"    -> char.class;
+			case "byte"    -> byte.class;
+
+			// Floating-point types
+			case "float"   -> float.class;
+			case "double"  -> double.class;
+
+			// Other types
+			case "boolean" -> boolean.class;
+			case "void"    -> void.class;
+
+			default        -> null;
+		};
+	}
 }

--- a/bosk-core/src/test/java/works/bosk/HooksTest.java
+++ b/bosk-core/src/test/java/works/bosk/HooksTest.java
@@ -27,6 +27,9 @@ public class HooksTest extends AbstractBoskTest {
 	public interface Refs {
 		@ReferencePath("/id") Reference<Identifier> rootID();
 		@ReferencePath("/entities/parent") Reference<TestEntity> parent();
+		@ReferencePath("/entities/parent/children") CatalogReference<TestChild> parentChildren();
+		@ReferencePath("/entities/parent/oddChildren") ListingReference<TestChild> parentOddChildren();
+		@ReferencePath("/entities/parent/stringSideTable") SideTableReference<TestChild, String> parentStringSideTable();
 		@ReferencePath("/entities/parent/string") Reference<String> parentString();
 		@ReferencePath("/entities/-parent-/children/-child-") Reference<TestChild> anyChild();
 		@ReferencePath("/entities/parent/children/-child-") Reference<TestChild> child(Identifier child);
@@ -508,6 +511,42 @@ public class HooksTest extends AbstractBoskTest {
 			super(bosk);
 		}
 	}
+
+	@ParameterizedTest
+	@ValueSource(classes = {ReferenceSubclassHooks.class})
+	void registerHooks_referenceSubclasses_works(Class<? extends ReferenceSubclassHooks> receiverClass) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+		ReferenceSubclassHooks receiver = receiverClass.getConstructor(Bosk.class).newInstance(bosk);
+		List<List<Object>> expected = asList(
+			// At registration time, the hook is called on all existing nodes
+			asList("childrenChanged", refs.parentChildren()),
+			asList("oddChildrenChanged", refs.parentOddChildren()),
+			asList("stringSideTableChanged", refs.parentStringSideTable())
+		);
+		assertEquals(expected, receiver.hookCalls);
+	}
+
+	public static class ReferenceSubclassHooks {
+		final List<List<Object>> hookCalls = new ArrayList<>();
+		public ReferenceSubclassHooks(Bosk<?> bosk) throws InvalidTypeException {
+			bosk.registerHooks(this);
+		}
+
+		@Hook("/entities/parent/children")
+		void childrenChanged(CatalogReference<TestChild> ref) {
+			hookCalls.add(asList("childrenChanged", ref));
+		}
+
+		@Hook("/entities/parent/oddChildren")
+		void oddChildrenChanged(ListingReference<TestChild> ref) {
+			hookCalls.add(asList("oddChildrenChanged", ref));
+		}
+
+		@Hook("/entities/parent/stringSideTable")
+		void stringSideTableChanged(SideTableReference<TestChild, String> ref) {
+			hookCalls.add(asList("stringSideTableChanged", ref));
+		}
+	}
+
 
 	interface Submit {
 		<T> void replacement(Bosk<?> bosk, Refs refs, Reference<T> target, T newValue);

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
@@ -1,0 +1,35 @@
+package works.bosk.drivers;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import works.bosk.Bosk;
+import works.bosk.drivers.state.TestEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReplicaSetConformanceTest extends DriverConformanceTest {
+	Bosk<TestEntity> replicaBosk;
+
+	@BeforeEach
+	void setupDriverFactory() {
+		ReplicaSet<TestEntity> replicaSet = new ReplicaSet<>();
+		replicaBosk = new Bosk<TestEntity>(
+			"Replica bosk",
+			TestEntity.class,
+			AbstractDriverTest::initialRoot,
+			replicaSet.driverFactory());
+		driverFactory = replicaSet.driverFactory();
+	}
+
+	@AfterEach
+	void checkFinalState() {
+		TestEntity expected, actual;
+		try (@SuppressWarnings("unused") Bosk<TestEntity>.ReadContext context = canonicalBosk.readContext()) {
+			expected = canonicalBosk.rootReference().value();
+		}
+		try (@SuppressWarnings("unused") Bosk<TestEntity>.ReadContext context = replicaBosk.readContext()) {
+			actual = replicaBosk.rootReference().value();
+		}
+		assertEquals(expected, actual);
+	}
+}

--- a/bosk-core/src/test/java/works/bosk/util/ReflectionHelpersTest.java
+++ b/bosk-core/src/test/java/works/bosk/util/ReflectionHelpersTest.java
@@ -1,0 +1,43 @@
+package works.bosk.util;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReflectionHelpersTest {
+
+	@Test
+	void getDeclaredMethodsInOrder_correctOrder() throws NoSuchMethodException {
+		List<Method> actual = ReflectionHelpers.getDeclaredMethodsInOrder(ClassWithSomeMethods.class);
+		List<Method> expected = List.of(
+			ClassWithSomeMethods.class.getDeclaredMethod("first"),
+			ClassWithSomeMethods.class.getDeclaredMethod("secondOverloaded", int.class),
+			ClassWithSomeMethods.class.getDeclaredMethod("secondOverloaded", long.class),
+			ClassWithSomeMethods.class.getDeclaredMethod("secondOverloaded", float.class),
+			ClassWithSomeMethods.class.getDeclaredMethod("secondOverloaded", String.class),
+			ClassWithSomeMethods.class.getDeclaredMethod("third")
+		);
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void getDeclaredMethodsInOrder_worksWithBuiltInClasses() throws NoSuchMethodException {
+		List<Method> actual = ReflectionHelpers.getDeclaredMethodsInOrder(Runnable.class);
+		List<Method> expected = List.of(
+			Runnable.class.getDeclaredMethod("run")
+		);
+		assertEquals(expected, actual);
+	}
+
+	public interface ClassWithSomeMethods {
+		void first();
+		void secondOverloaded(int x);
+		void secondOverloaded(long x);
+		void secondOverloaded(float x);
+		void secondOverloaded(String s);
+		void third();
+	}
+
+}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/AbstractMongoDriverTest.java
@@ -33,6 +33,7 @@ import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.logback.BoskLogFilter;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static works.bosk.drivers.mongo.MainDriver.COLLECTION_NAME;
 
 abstract class AbstractMongoDriverTest {
 	protected static final Identifier entity123 = Identifier.from("123");
@@ -63,6 +64,7 @@ abstract class AbstractMongoDriverTest {
 		// Start with a clean slate
 		mongoService.client()
 			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME)
 			.drop();
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoCursorTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoCursorTest.java
@@ -142,7 +142,7 @@ public class MongoCursorTest {
 
 	@AfterEach
 	void teardown() {
-		database.drop();
+		collection.drop();
 	}
 
 	private static final String DATABASE = "MongoCursorTest_DB";

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverConformanceTest.java
@@ -64,6 +64,7 @@ class MongoDriverConformanceTest extends DriverConformanceTest {
 				driver.close();
 				mongoService.client()
 					.getDatabase(driverSettings.database())
+					.getCollection(MainDriver.COLLECTION_NAME)
 					.drop();
 			});
 			return driver;

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverHanoiTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverHanoiTest.java
@@ -11,6 +11,8 @@ import works.bosk.DriverStack;
 import works.bosk.drivers.HanoiTest;
 import works.bosk.junit.ParametersByName;
 
+import static works.bosk.drivers.mongo.MainDriver.COLLECTION_NAME;
+
 @UsesMongoService
 public class MongoDriverHanoiTest extends HanoiTest {
 	private static MongoService mongoService;
@@ -29,6 +31,7 @@ public class MongoDriverHanoiTest extends HanoiTest {
 		);
 		mongoService.client()
 			.getDatabase(settings.database())
+			.getCollection(COLLECTION_NAME)
 			.drop();
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
@@ -26,6 +26,7 @@ import static ch.qos.logback.classic.Level.ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
+import static works.bosk.drivers.mongo.MainDriver.COLLECTION_NAME;
 
 /**
  * Tests the kinds of recovery actions a human operator might take to try to get a busted service running again.
@@ -135,6 +136,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 			LOGGER.debug("Drop database");
 			mongoService.client()
 				.getDatabase(driverSettings.database())
+				.getCollection(COLLECTION_NAME)
 				.drop();
 		}, (b) -> initializeDatabase("after drop"));
 	}
@@ -146,7 +148,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 			LOGGER.debug("Drop collection");
 			mongoService.client()
 				.getDatabase(driverSettings.database())
-				.getCollection(MainDriver.COLLECTION_NAME)
+				.getCollection(COLLECTION_NAME)
 				.drop();
 		}, (b) -> initializeDatabase("after drop"));
 	}
@@ -158,7 +160,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 			LOGGER.debug("Delete document");
 			mongoService.client()
 				.getDatabase(driverSettings.database())
-				.getCollection(MainDriver.COLLECTION_NAME)
+				.getCollection(COLLECTION_NAME)
 				.deleteMany(new BsonDocument());
 		}, (b) -> initializeDatabase("after deletion"));
 	}
@@ -168,7 +170,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 	void documentReappears_recovers() throws InvalidTypeException, InterruptedException, IOException {
 		MongoCollection<Document> collection = mongoService.client()
 			.getDatabase(driverSettings.database())
-			.getCollection(MainDriver.COLLECTION_NAME);
+			.getCollection(COLLECTION_NAME);
 		AtomicReference<Document> originalDocument = new AtomicReference<>();
 		BsonString rootDocumentID = (driverSettings.preferredDatabaseFormat() == MongoDriverSettings.DatabaseFormat.SEQUOIA)?
 			SequoiaFormatDriver.DOCUMENT_ID :
@@ -215,7 +217,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		LOGGER.debug("Delete revision field");
 		mongoService.client()
 			.getDatabase(driverSettings.database())
-			.getCollection(MainDriver.COLLECTION_NAME)
+			.getCollection(COLLECTION_NAME)
 			.updateOne(
 				new BsonDocument(),
 				new BsonDocument("$unset", new BsonDocument(Formatter.DocumentFields.revision.name(), new BsonNull())) // Value is ignored
@@ -240,7 +242,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 	private void setRevision(long revisionNumber) {
 		mongoService.client()
 			.getDatabase(driverSettings.database())
-			.getCollection(MainDriver.COLLECTION_NAME)
+			.getCollection(COLLECTION_NAME)
 			.updateOne(
 				new BsonDocument(),
 				new BsonDocument("$set", new BsonDocument(Formatter.DocumentFields.revision.name(), new BsonInt64(revisionNumber))) // Value is ignored

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -48,10 +48,10 @@ public abstract class AbstractDriverTest {
 
 	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
 		// This is the bosk whose behaviour we'll consider to be correct by definition
-		canonicalBosk = new Bosk<TestEntity>("Canonical bosk", TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
+		canonicalBosk = new Bosk<TestEntity>(getClass().getSimpleName() + "-canonical", TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
 
 		// This is the bosk we're testing
-		bosk = new Bosk<TestEntity>("Test bosk", TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
+		bosk = new Bosk<TestEntity>(getClass().getSimpleName(), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
 			MirroringDriver.targeting(canonicalBosk),
 			DriverStateVerifier.wrap(driverFactory, TestEntity.class, AbstractDriverTest::initialRoot)
 		));

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -51,7 +51,7 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject, Type rootType, Bosk.DefaultRootFunction<RR> defaultRootFunction) {
 		Bosk<RR> stateTrackingBosk = new Bosk<>(
-			"Tracking",
+			DriverStateVerifier.class.getSimpleName(),
 			rootType, defaultRootFunction,
 			Bosk::simpleDriver
 		);

--- a/bosk-testing/src/main/java/works/bosk/drivers/HanoiTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/HanoiTest.java
@@ -58,7 +58,7 @@ public abstract class HanoiTest {
 	@BeforeEach
 	void setup() throws InvalidTypeException {
 		bosk = new Bosk<HanoiState>(
-			"Hanoi" + boskCounter.incrementAndGet(),
+			getClass().getSimpleName() + "_" + boskCounter.incrementAndGet(),
 			HanoiState.class,
 			this::defaultRoot,
 			driverFactory


### PR DESCRIPTION
- Register `@Hook` methods in bytecode order.
- Support `Reference` subtypes in `@Hook` method parameters.
- New `ReplicaSet` driver for local testing of replica set behaviour
- Various other improvements (see commit messages)
