### PR TITLE
Add `VariantNode`

### DIFF
--- a/bosk-annotations/src/main/java/works/bosk/annotations/VariantCaseMap.java
+++ b/bosk-annotations/src/main/java/works/bosk/annotations/VariantCaseMap.java
@@ -1,0 +1,12 @@
+package works.bosk.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({ FIELD }) // TODO: Also METHOD
+public @interface VariantCaseMap {
+}

--- a/bosk-core/src/main/java/works/bosk/MapValue.java
+++ b/bosk-core/src/main/java/works/bosk/MapValue.java
@@ -1,7 +1,6 @@
 package works.bosk;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -53,14 +52,24 @@ public final class MapValue<V> implements Map<String, V> {
 		return new MapValue<>(OrderedPMap.from(map));
 	}
 
+	/**
+	 * Use {@link #copyOf}.
+	 */
+	@Deprecated(forRemoval = true)
 	public static <VV> MapValue<VV> fromOrderedMap(Map<String, VV> entries) {
-		return fromEntries(entries.entrySet().iterator());
+		return copyOf(entries);
 	}
 
-	private static <VV> MapValue<VV> fromEntries(Iterator<Entry<String, VV>> entrySet) {
-		LinkedHashMap<String,VV> map = new LinkedHashMap<>();
-		entrySet.forEachRemaining(entry -> addToMap(map, entry.getKey(), entry.getValue()));
-		return new MapValue<>(OrderedPMap.from(map));
+	/**
+	 * Preserves the order, if any, of the entries in <code>map</code>.
+	 */
+	public static <VV> MapValue<VV> copyOf(Map<String, VV> contents) {
+		OrderedPMap<String, VV> map = OrderedPMap.from(contents);
+		map.forEach((k,v) -> {
+			requireNonNull(k);
+			requireNonNull(v);
+		});
+		return new MapValue<>(map);
 	}
 
 	private static <VV> void addToMap(LinkedHashMap<String, VV> map, String key, VV newValue) {
@@ -101,7 +110,7 @@ public final class MapValue<V> implements Map<String, V> {
 	 * an unmodifiableMap so it's exception-compatible.
 	 */
 	@SuppressWarnings("rawtypes")
-	private static final MapValue EMPTY = fromOrderedMap(emptyMap());
+	private static final MapValue EMPTY = copyOf(emptyMap());
 
 	///////////////////////
 	//

--- a/bosk-core/src/main/java/works/bosk/Phantom.java
+++ b/bosk-core/src/main/java/works/bosk/Phantom.java
@@ -3,9 +3,19 @@ package works.bosk;
 /**
  * Used to create a thing that can be referenced (eg. as the domain
  * of a {@link Listing}) but that is not actually serialized or instantiated.
- *
- * <p>
  * Behaves like an {@link java.util.Optional Optional} that is always empty.
+ * <p>
+ * Why would anyone want such a thing?
+ * <p>
+ * The domain of a {@link Listing} plays a role somewhat like a datatype:
+ * it indicates the nature of the values it can reference.
+ * Often, the domain is a {@link Catalog} that explicitly lists all the allowed values,
+ * but sometimes you don't want to list all the possible values in the bosk state;
+ * you just want to be clear about what the allowed values are.
+ * For example, there may be a large or infinite number of possible values;
+ * or there might be nothing to store about the value besides its ID.
+ * In that case, you can use a <code>Phantom&lt;Catalog&lt;T>></code>,
+ * and reference that as your domain.
  */
 public final class Phantom<T> {
 	public static <T> Phantom<T> empty() {

--- a/bosk-core/src/main/java/works/bosk/ReferenceUtils.java
+++ b/bosk-core/src/main/java/works/bosk/ReferenceUtils.java
@@ -22,7 +22,6 @@ import works.bosk.util.Types;
 
 import static java.lang.String.format;
 import static java.lang.reflect.Modifier.STATIC;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Collection of utilities for implementing {@link Reference}s.
@@ -277,9 +276,11 @@ C&lt;String> someField;
 	public static <T> Constructor<T> theOnlyConstructorFor(Class<T> nodeClass) {
 		List<Constructor<?>> constructors = Stream.of(nodeClass.getDeclaredConstructors())
 				.filter(ctor -> !ctor.isSynthetic())
-				.collect(toList());
-		if (constructors.size() != 1) {
-			throw new IllegalArgumentException("Ambiguous constructor list: " + constructors);
+				.toList();
+		if (constructors.isEmpty()) {
+			throw new IllegalArgumentException("No suitable constructor for " + nodeClass.getSimpleName());
+		} else if (constructors.size() >= 2) {
+			throw new IllegalArgumentException("Ambiguous constructor list for " + nodeClass.getSimpleName() + ": " + constructors);
 		}
 		@SuppressWarnings("unchecked")
 		Constructor<T> theConstructor = (Constructor<T>) constructors.get(0);

--- a/bosk-core/src/main/java/works/bosk/SideTable.java
+++ b/bosk-core/src/main/java/works/bosk/SideTable.java
@@ -21,6 +21,7 @@ import org.pcollections.OrderedPMap;
 import org.pcollections.OrderedPSet;
 
 import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 
 @EqualsAndHashCode
 @RequiredArgsConstructor(access=AccessLevel.PRIVATE)
@@ -113,8 +114,21 @@ public final class SideTable<K extends Entity, V> implements EnumerableByIdentif
 		return of(domain, key.id(), value);
 	}
 
+	/**
+	 * Use {@link #copyOf}.
+	 */
+	@Deprecated(forRemoval = true)
 	public static <KK extends Entity,VV> SideTable<KK,VV> fromOrderedMap(Reference<Catalog<KK>> domain, Map<Identifier, VV> contents) {
-		return new SideTable<>(CatalogReference.from(domain), OrderedPMap.from(new LinkedHashMap<>(contents)));
+		return copyOf(domain, contents);
+	}
+
+	public static <KK extends Entity,VV> SideTable<KK,VV> copyOf(Reference<Catalog<KK>> domain, Map<Identifier, VV> contents) {
+		OrderedPMap<Identifier, VV> map = OrderedPMap.from(contents);
+		map.forEach((k,v) -> {
+			requireNonNull(k);
+			requireNonNull(v);
+		});
+		return new SideTable<>(CatalogReference.from(domain), map);
 	}
 
 	public static <KK extends Entity,VV> SideTable<KK,VV> fromFunction(Reference<Catalog<KK>> domain, Stream<Identifier> keyIDs, Function<Identifier, VV> function) {

--- a/bosk-core/src/main/java/works/bosk/VariantNode.java
+++ b/bosk-core/src/main/java/works/bosk/VariantNode.java
@@ -1,0 +1,5 @@
+package works.bosk;
+
+public interface VariantNode extends StateTreeNode {
+	String tag(); // TODO: Identifier?
+}

--- a/bosk-core/src/main/java/works/bosk/dereferencers/DereferencerRuntime.java
+++ b/bosk-core/src/main/java/works/bosk/dereferencers/DereferencerRuntime.java
@@ -66,4 +66,11 @@ public abstract class DereferencerRuntime implements Dereferencer {
 		}
 	}
 
+	protected static Object instanceofOrNonexistent(Object object, Class<?> desiredClass, Reference<?> ref) throws NonexistentEntryException {
+		if (desiredClass.isInstance(object)) {
+			return object;
+		} else {
+			throw new NonexistentEntryException(ref.path());
+		}
+	}
 }

--- a/bosk-core/src/main/java/works/bosk/dereferencers/PathCompiler.java
+++ b/bosk-core/src/main/java/works/bosk/dereferencers/PathCompiler.java
@@ -19,6 +19,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import lombok.experimental.Delegate;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,8 +32,10 @@ import works.bosk.ListingEntry;
 import works.bosk.Path;
 import works.bosk.Phantom;
 import works.bosk.Reference;
+import works.bosk.SerializationPlugin;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
+import works.bosk.annotations.VariantCaseMap;
 import works.bosk.bytecode.LocalVariable;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
@@ -212,14 +215,16 @@ public final class PathCompiler {
 			assert !path.isEmpty();
 			steps = new ArrayList<>();
 			Type currentType = sourceType;
+			Step priorStep = null;
 			for (int i = 0; i < path.length(); i++) {
-				Step step = newSegmentStep(currentType, path.segment(i), i);
+				Step step = newSegmentStep(currentType, path.segment(i), i, priorStep);
 				steps.add(step);
 				currentType = step.targetType();
+				priorStep = step;
 			}
 		}
 
-		private Step newSegmentStep(Type currentType, String segment, int segmentNum) throws InvalidTypeException {
+		private Step newSegmentStep(Type currentType, String segment, int segmentNum, Step priorStep) throws InvalidTypeException {
 			Class<?> currentClass = rawClass(currentType);
 			if (Catalog.class.isAssignableFrom(currentClass)) {
 				return new CatalogEntryStep(parameterType(currentType, Catalog.class, 0), segmentNum);
@@ -229,6 +234,8 @@ public final class PathCompiler {
 				Type keyType = parameterType(currentType, SideTable.class, 0);
 				Type targetType = parameterType(currentType, SideTable.class, 1);
 				return new SideTableEntryStep(keyType, targetType, segmentNum);
+			} else if (priorStep instanceof VariantFieldStep v) {
+				return new VariantCaseStep(segment, v.caseType(segment));
 			} else if (StateTreeNode.class.isAssignableFrom(currentClass)) {
 				if (isParameterSegment(segment)) {
 					throw new InvalidTypeException("Invalid parameter location: expected a field of " + currentClass.getSimpleName());
@@ -243,7 +250,10 @@ public final class PathCompiler {
 
 				Step fieldStep = newFieldStep(segment, getters, theOnlyConstructorFor(currentClass));
 				Class<?> fieldClass = rawClass(fieldStep.targetType());
-				if (Optional.class.isAssignableFrom(fieldClass)) {
+				Map<String, Type> typeMap = SerializationPlugin.getVariantCaseMapIfAny(fieldStep.targetClass());
+				if (typeMap != null) {
+					return new VariantFieldStep(typeMap, fieldStep);
+				} else if (Optional.class.isAssignableFrom(fieldClass)) {
 					return new OptionalValueStep(parameterType(fieldStep.targetType(), Optional.class, 0), fieldStep);
 				} else if (Phantom.class.isAssignableFrom(fieldClass)) {
 					return new PhantomValueStep(parameterType(fieldStep.targetType(), Phantom.class, 0), segment);
@@ -544,6 +554,64 @@ public final class PathCompiler {
 			@Override public void generate_without() { /* No effect */ }
 		}
 
+		/**
+		 * Augments another step to capture info for fields using
+		 * {@link VariantCaseMap}.
+		 */
+		public record VariantFieldStep(
+			Map<String, Type> variantMap,
+			@Delegate Step fieldStep
+		) implements Step {
+			public Type caseType(String caseName) throws InvalidTypeException {
+				Type result = variantMap.get(caseName);
+				if (result == null) {
+					throw new InvalidTypeException("Unknown variant case \"" + caseName + "\" of " + fieldStep.targetClass().getSimpleName() + "." + fieldStep.fullyParameterizedPathSegment());
+				} else {
+					return result;
+				}
+			}
+		}
+
+		@Value
+		public class VariantCaseStep implements Step {
+			String name;
+			Type targetType;
+
+			@Override
+			public Type targetType() {
+				return targetType;
+			}
+
+			@Override
+			public String fullyParameterizedPathSegment() {
+				return name;
+			}
+
+			/**
+			 * The "containing object" is actually the object we want.
+			 * If it's the right type,
+			 * then picking one case of a variant is nothing but a downcast,
+			 * which {@link StepwiseDereferencerBuilder#generate_get} already does.
+			 * If it's the wrong type, then we want to treat that as nonexistent.
+			 */
+			@Override
+			public void generate_get() {
+				cb.pushObject(targetClass().getSimpleName(), targetClass(), Class.class);
+				pushReference();
+				invoke(INSTANCEOF_OR_NONEXISTENT);
+			}
+
+			/**
+			 * We actually replace the entire "containing object".
+			 * Simply discard the old value and return the new one.
+			 */
+			@Override
+			public void generate_with() {
+				swap(); // Move old value to top of stack
+				pop();  // Discard old value
+			}
+		}
+
 		@Value
 		public class CustomStep implements Step {
 			Type targetType;
@@ -584,13 +652,14 @@ public final class PathCompiler {
 	static final Method SIDE_TABLE_GET, SIDE_TABLE_WITH, SIDE_TABLE_WITHOUT;
 	static final Method OPTIONAL_OF, OPTIONAL_OR_THROW, OPTIONAL_EMPTY;
 	static final Method THROW_NONEXISTENT_ENTRY, THROW_CANNOT_REPLACE_PHANTOM;
-	static final Method INVALID_WITHOUT;
+	static final Method INSTANCEOF_OR_NONEXISTENT, INVALID_WITHOUT;
 
 	static {
 		try {
 			CATALOG_GET = DereferencerRuntime.class.getDeclaredMethod("catalogEntryOrThrow", Catalog.class, Identifier.class, Reference.class);
 			CATALOG_WITH = Catalog.class.getDeclaredMethod("with", Entity.class);
 			CATALOG_WITHOUT = Catalog.class.getDeclaredMethod("without", Identifier.class);
+			INSTANCEOF_OR_NONEXISTENT = DereferencerRuntime.class.getDeclaredMethod("instanceofOrNonexistent", Object.class, Class.class, Reference.class);
 			LISTING_GET = DereferencerRuntime.class.getDeclaredMethod("listingEntryOrThrow", Listing.class, Identifier.class, Reference.class);
 			LISTING_WITH = DereferencerRuntime.class.getDeclaredMethod("listingWith", Listing.class, Identifier.class, Object.class);
 			LISTING_WITHOUT = Listing.class.getDeclaredMethod("withoutID", Identifier.class);

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -18,6 +18,7 @@ import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static works.bosk.BoskTestUtils.boskName;
 import static works.bosk.TypeValidationTest.SimpleTypes.MyEnum.LEFT;
 
 /**
@@ -28,7 +29,7 @@ public class BoskConstructorTest {
 
 	@Test
 	void basicProperties_correctValues() {
-		String name = "Name";
+		String name = boskName();
 		Type rootType = SimpleTypes.class;
 		StateTreeNode root = newEntity();
 
@@ -63,7 +64,7 @@ public class BoskConstructorTest {
 	void invalidRootType_throws() {
 		assertThrows(IllegalArgumentException.class, ()->
 			new Bosk<MutableField>(
-				"Invalid root type",
+				boskName("Invalid root type"),
 				MutableField.class,
 				bosk -> new MutableField(),
 				Bosk::simpleDriver));
@@ -89,7 +90,7 @@ public class BoskConstructorTest {
 	void mismatchedRootType_throws() {
 		assertThrows(ClassCastException.class, ()->
 			new Bosk<Entity> (
-				"Mismatched root",
+				boskName("Mismatched root"),
 				BoxedPrimitives.class, // Valid but wrong
 				bosk -> newEntity(),
 				Bosk::simpleDriver
@@ -101,7 +102,7 @@ public class BoskConstructorTest {
 	void driverInitialRoot_matches() {
 		SimpleTypes root = newEntity();
 		Bosk<StateTreeNode> bosk = new Bosk<StateTreeNode>(
-			"By value",
+			boskName(),
 			SimpleTypes.class,
 			__ -> {throw new AssertionError("Shouldn't be called");},
 			initialRootDriver(()->root));
@@ -114,14 +115,14 @@ public class BoskConstructorTest {
 	void defaultRoot_matches() {
 		SimpleTypes root = newEntity();
 		{
-			Bosk<StateTreeNode> valueBosk = new Bosk<>("By value", SimpleTypes.class, root, Bosk::simpleDriver);
+			Bosk<StateTreeNode> valueBosk = new Bosk<>(boskName(), SimpleTypes.class, root, Bosk::simpleDriver);
 			try (val __ = valueBosk.readContext()) {
 				assertSame(root, valueBosk.rootReference().value());
 			}
 		}
 
 		{
-			Bosk<StateTreeNode> functionBosk = new Bosk<StateTreeNode>("By value", SimpleTypes.class, __ -> root, Bosk::simpleDriver);
+			Bosk<StateTreeNode> functionBosk = new Bosk<StateTreeNode>(boskName(), SimpleTypes.class, __ -> root, Bosk::simpleDriver);
 			try (val __ = functionBosk.readContext()) {
 				assertSame(root, functionBosk.rootReference().value());
 			}
@@ -135,7 +136,7 @@ public class BoskConstructorTest {
 
 	private static void assertInitialRootThrows(Class<? extends Throwable> expectedType, InitialRootFunction initialRootFunction) {
 		assertThrows(expectedType, () -> new Bosk<>(
-			"Throw test",
+			boskName(),
 			SimpleTypes.class,
 			newEntity(),
 			initialRootDriver(initialRootFunction)
@@ -144,7 +145,7 @@ public class BoskConstructorTest {
 
 	private static void assertDefaultRootThrows(Class<? extends Throwable> expectedType, DefaultRootFunction<StateTreeNode> defaultRootFunction) {
 		assertThrows(expectedType, () -> new Bosk<>(
-			"Throw test",
+			boskName(),
 			SimpleTypes.class,
 			defaultRootFunction,
 			Bosk::simpleDriver

--- a/bosk-core/src/test/java/works/bosk/BoskDiagnosticContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskDiagnosticContextTest.java
@@ -13,6 +13,7 @@ import works.bosk.exceptions.InvalidTypeException;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static works.bosk.BoskTestUtils.boskName;
 
 /**
  * Note that context propagation for driver operations is tested by {@link DriverConformanceTest}.
@@ -27,7 +28,7 @@ class BoskDiagnosticContextTest extends AbstractDriverTest {
 	@BeforeEach
 	void setupBosk() throws InvalidTypeException {
 		bosk = new Bosk<TestEntity>(
-			BoskDiagnosticContextTest.class.getSimpleName(),
+			boskName(),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,
 			Bosk::simpleDriver

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static works.bosk.BoskTestUtils.boskName;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 import static works.bosk.ReferenceUtils.rawClass;
 
@@ -55,6 +56,7 @@ import static works.bosk.ReferenceUtils.rawClass;
  *
  */
 class BoskLocalReferenceTest {
+	String boskName;
 	Bosk<Root> bosk;
 	Root root;
 	Refs refs;
@@ -66,8 +68,9 @@ class BoskLocalReferenceTest {
 
 	@BeforeEach
 	void initializeBosk() throws InvalidTypeException {
+		boskName = boskName();
 		Root initialRoot = new Root(1, Catalog.empty());
-		bosk = new Bosk<>(BOSK_NAME, Root.class, initialRoot, Bosk::simpleDriver);
+		bosk = new Bosk<>(boskName, Root.class, initialRoot, Bosk::simpleDriver);
 		refs = bosk.rootReference().buildReferences(Refs.class);
 		Identifier ernieID = Identifier.from("ernie");
 		Identifier bertID = Identifier.from("bert");
@@ -255,7 +258,7 @@ class BoskLocalReferenceTest {
 
 	@Test
 	void testName() {
-		assertEquals(BOSK_NAME, bosk.name());
+		assertEquals(boskName, bosk.name());
 	}
 
 	@Test
@@ -270,15 +273,15 @@ class BoskLocalReferenceTest {
 				this.mutableString = str;
 			}
 		}
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>("invalid", InvalidRoot.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>("invalid", String.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
+		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
+		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
 	}
 
 	@Test
 	void testDriver() {
 		// This doesn't test the operation of the driver; merely that the right driver is returned
 		AtomicReference<BoskDriver<Root>> driver = new AtomicReference<>();
-		Bosk<Root> myBosk = new Bosk<>("My bosk", Root.class, new Root(123, Catalog.empty()), (b,d) -> {
+		Bosk<Root> myBosk = new Bosk<>(boskName(), Root.class, new Root(123, Catalog.empty()), (b,d) -> {
 			BoskDriver<Root> bd = new ProxyDriver(d);
 			driver.set(bd);
 			return bd;
@@ -446,6 +449,4 @@ class BoskLocalReferenceTest {
 			throw new AssertionError("Unexpected!", e);
 		}
 	}
-
-	private static final String BOSK_NAME = "bosk name";
 }

--- a/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
@@ -8,6 +8,7 @@ import works.bosk.annotations.ReferencePath;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 
 /**
  * To get complete coverage of Bosk.java, include these:
@@ -40,7 +41,7 @@ public class BoskUpdateTest extends AbstractBoskTest {
 	@BeforeEach
 	void createBosk() throws InvalidTypeException {
 		bosk = new Bosk<TestRoot>(
-			BoskUpdateTest.class.getSimpleName(),
+			boskName(),
 			TestRoot.class,
 			AbstractBoskTest::initialRoot,
 			Bosk::simpleDriver

--- a/bosk-core/src/test/java/works/bosk/CatalogBenchmark.java
+++ b/bosk-core/src/test/java/works/bosk/CatalogBenchmark.java
@@ -14,6 +14,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.openjdk.jmh.annotations.Mode.Throughput;
+import static works.bosk.BoskTestUtils.boskName;
 
 @Fork(0)
 @Warmup(iterations = 5, time = 1)
@@ -29,7 +30,7 @@ public class CatalogBenchmark {
 		@Setup(Level.Trial)
 		public void setup() throws InvalidTypeException {
 			Bosk<AbstractBoskTest.TestRoot> bosk = new Bosk<AbstractBoskTest.TestRoot>(
-				"CatalogBenchmarkBosk",
+				boskName(),
 				AbstractBoskTest.TestRoot.class,
 				AbstractBoskTest::initialRoot,
 				Bosk::simpleDriver

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static works.bosk.BoskTestUtils.boskName;
 
 /*
  * TODO: This test is written in a mighty weird style. Change it to set up
@@ -54,7 +55,7 @@ class ListingTest {
 			return childrenStream
 					.map(children -> {
 						TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-						Bosk<TestEntity> bosk = new Bosk<>("Test Bosk", TestEntity.class, root, Bosk::simpleDriver);
+						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, root, Bosk::simpleDriver);
 						CatalogReference<TestEntity> catalog;
 						try {
 							catalog = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
@@ -73,7 +74,7 @@ class ListingTest {
 			TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 			List<TestEntity> children = singletonList(child);
 			TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-			Bosk<TestEntity> bosk = new Bosk<>("Test Bosk", TestEntity.class, root, Bosk::simpleDriver);
+			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, root, Bosk::simpleDriver);
 			CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 			return idStreams().map(list -> Arguments.of(list.map(Identifier::from).collect(toList()), childrenRef, bosk));
 		}
@@ -248,7 +249,7 @@ class ListingTest {
 		TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 		List<TestEntity> children = singletonList(child);
 		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-		Bosk<TestEntity> bosk = new Bosk<>("Test Bosk", TestEntity.class, root, Bosk::simpleDriver);
+		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, root, Bosk::simpleDriver);
 		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 
 		Listing<TestEntity> actual = Listing.empty(childrenRef);

--- a/bosk-core/src/test/java/works/bosk/MapValueTest.java
+++ b/bosk-core/src/test/java/works/bosk/MapValueTest.java
@@ -55,7 +55,7 @@ class MapValueTest extends AbstractBoskTest {
 	}
 
 	private static <V> Arguments fromMapCase(Map<String, V> map, V sampleValue) {
-		return mapValueCase(map, MapValue.fromOrderedMap(map), sampleValue);
+		return mapValueCase(map, MapValue.copyOf(map), sampleValue);
 	}
 
 	private static <V> Arguments fromFunctionCase(Iterable<String> keys, Function<String, V> function, V sampleValue) {
@@ -99,14 +99,14 @@ class MapValueTest extends AbstractBoskTest {
 	@ParameterizedTest
 	@MethodSource("mapArguments")
 	<V> void testEquals(Map<String,V> map, MapValue<V> mapValue, V sampleValue) {
-		assertEquals(MapValue.fromOrderedMap(map), mapValue);
+		assertEquals(MapValue.copyOf(map), mapValue);
 	}
 
 	@ParameterizedTest
 	@MethodSource("mapArguments")
 	<V> void testHashCode(Map<String,V> map, MapValue<V> mapValue, V sampleValue) {
 		try {
-			int expected = MapValue.fromOrderedMap(map).hashCode();
+			int expected = MapValue.copyOf(map).hashCode();
 			assertEquals(expected, mapValue.hashCode());
 		} catch (UnsupportedOperationException e) {
 			assertThrows(e.getClass(), mapValue::hashCode);
@@ -335,13 +335,13 @@ class MapValueTest extends AbstractBoskTest {
 	@Test
 	void testBad_nullKeyFromMap() {
 		Map<String, ?> map = singletonMap(null, "value");
-		assertThrows(NullPointerException.class, () -> MapValue.fromOrderedMap(map));
+		assertThrows(NullPointerException.class, () -> MapValue.copyOf(map));
 	}
 
 	@Test
 	void testBad_nullValueFromMap() {
 		Map<String, ?> map = singletonMap("key", null);
-		assertThrows(NullPointerException.class, () -> MapValue.fromOrderedMap(map));
+		assertThrows(NullPointerException.class, () -> MapValue.copyOf(map));
 	}
 
 	private void assertUnsupportedForAllKeys(Iterable<String> keys, Consumer<String> action) {

--- a/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
+++ b/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
@@ -17,13 +17,14 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static works.bosk.BoskTestUtils.boskName;
 
 class OptionalRefsTest extends AbstractRoundTripTest {
 	private static final Identifier ID = Identifier.from("dummy");
 
 	@Test
 	void testReferenceOptionalNotAllowed() {
-		Bosk<OptionalString> bosk = new Bosk<>("optionalNotAllowed", OptionalString.class, new OptionalString(ID, Optional.empty()), Bosk::simpleDriver);
+		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, new OptionalString(ID, Optional.empty()), Bosk::simpleDriver);
 		InvalidTypeException e = assertThrows(InvalidTypeException.class, () -> bosk.rootReference().then(Optional.class, Path.just("field")));
 		assertThat(e.getMessage(), containsString("not supported"));
 	}
@@ -117,7 +118,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 	}
 
 	private <E extends Entity, V> void doTest(E initialRoot, ValueFactory<E, V> valueFactory, DriverFactory<E> driverFactory) throws InvalidTypeException {
-		Bosk<E> bosk = new Bosk<>("bosk", initialRoot.getClass(), initialRoot, driverFactory);
+		Bosk<E> bosk = new Bosk<>(boskName(), initialRoot.getClass(), initialRoot, driverFactory);
 		V value = valueFactory.createFrom(bosk);
 		@SuppressWarnings("unchecked")
 		Reference<V> optionalRef = bosk.rootReference().then((Class<V>)value.getClass(), "field");

--- a/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static works.bosk.BoskTestUtils.boskName;
 
 public class ReferenceErrorTest {
 	Bosk<?> bosk;
@@ -17,7 +18,7 @@ public class ReferenceErrorTest {
 	@BeforeEach
 	void setupBosk() {
 		bosk = new Bosk<>(
-			"Test",
+			boskName(),
 			BadGetters.class,
 			new BadGetters(Identifier.from("test"), new NestedObject(Optional.of("stringValue"))),
 			Bosk::simpleDriver);

--- a/bosk-core/src/test/java/works/bosk/SideTableTest.java
+++ b/bosk-core/src/test/java/works/bosk/SideTableTest.java
@@ -2,6 +2,7 @@ package works.bosk;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -82,7 +83,7 @@ class SideTableTest extends AbstractBoskTest {
 		expected.put(id3, "value3");
 		expected.put(id4, "value4");
 
-		assertEqualsOrderedMap(expected, SideTable.fromOrderedMap(refs.entities(), expected));
+		assertEqualsOrderedMap(expected, SideTable.copyOf(refs.entities(), expected));
 		assertEqualsOrderedMap(expected, SideTable.fromFunction(refs.entities(), expected.keySet().stream(), expected::get));
 		assertEqualsOrderedMap(expected, SideTable.fromEntries(refs.entities(), expected.entrySet().stream()));
 	}
@@ -95,6 +96,18 @@ class SideTableTest extends AbstractBoskTest {
 		assertThrows(IllegalArgumentException.class, ()-> {
 			SideTable.fromEntries(refs.entities(), Stream.of("dup", "dup").map(v -> new SimpleEntry<>(Identifier.from(v), v)));
 		});
+	}
+
+	@Test
+	void nulls_disallowed() {
+		Map<Identifier, TestEntity> contents = new HashMap<>();
+
+		contents.put(null, firstEntity);
+		assertThrows(NullPointerException.class, ()-> SideTable.copyOf(refs.entities(), contents));
+
+		contents.clear();
+		contents.put(firstEntity.id(), null);
+		assertThrows(NullPointerException.class, ()-> SideTable.copyOf(refs.entities(), contents));
 	}
 
 	@Test

--- a/bosk-core/src/test/java/works/bosk/VariantTest.java
+++ b/bosk-core/src/test/java/works/bosk/VariantTest.java
@@ -1,0 +1,101 @@
+package works.bosk;
+
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import works.bosk.annotations.ReferencePath;
+import works.bosk.annotations.VariantCaseMap;
+import works.bosk.exceptions.InvalidTypeException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class VariantTest extends AbstractBoskTest {
+
+	public record BoskState(
+		TestVariant v
+	) implements StateTreeNode { }
+
+	public interface TestVariant extends VariantNode {
+		default String tag() {
+			if (this instanceof StringCase) {
+				return "string";
+			} else {
+				return "id";
+			}
+		}
+
+		@VariantCaseMap
+		MapValue<Class<? extends TestVariant>> TYPE_MAP = MapValue.copyOf(Map.of(
+			"string", StringCase.class,
+			"id", IDCase.class
+		));
+	}
+
+	public record StringCase(String value) implements TestVariant {}
+	public record IDCase(Identifier value) implements TestVariant {}
+
+	public interface Refs {
+		@ReferencePath("/v") Reference<TestVariant> v();
+		@ReferencePath("/v/id") Reference<IDCase> idCase();
+		@ReferencePath("/v/id/value") Reference<Identifier> idValue();
+		@ReferencePath("/v/string/value") Reference<String> stringValue();
+	}
+
+	@Test
+	void test() throws InvalidTypeException, IOException, InterruptedException {
+		String stringValue = "test";
+		var bosk = new Bosk<>(VariantTest.class.getSimpleName(), BoskState.class, new BoskState(new StringCase(stringValue)), Bosk::simpleDriver);
+		var refs = bosk.rootReference().buildReferences(Refs.class);
+		try (var __ = bosk.readContext()) {
+			assertEquals(stringValue, refs.stringValue().value());
+		}
+		IDCase idCase = new IDCase(Identifier.from("test2"));
+		bosk.driver().submitReplacement(refs.idCase(), idCase);
+		bosk.driver().flush();
+		try (var __ = bosk.readContext()) {
+			assertEquals(idCase, refs.v().value());
+			assertEquals(idCase, refs.idCase().value());
+			assertEquals(idCase.value(), refs.idValue().value());
+			assertNull(refs.stringValue().valueIfExists());
+		}
+	}
+
+	public interface WrongTagVariant extends VariantNode {
+		@VariantCaseMap
+		MapValue<Class<? extends WrongTagVariant>> CASE_MAP = MapValue.copyOf(Map.of(
+			"expectedTag", NonexistentTagCase.class
+		));
+	}
+
+	public record NonexistentTagCase() implements WrongTagVariant {
+		public NonexistentTagCase {
+			// The assertion recommended in the user's guide
+			assert CASE_MAP.get(tag()).isInstance(this);
+		}
+
+		@Override
+		public String tag() {
+			return "actualTag";
+		}
+	}
+
+	public record WrongTypeCase() implements WrongTagVariant {
+		public WrongTypeCase {
+			// The assertion recommended in the user's guide
+			assert CASE_MAP.get(tag()).isInstance(this);
+		}
+
+		@Override
+		public String tag() {
+			return "expectedTag";
+		}
+	}
+
+	@Test
+	void wrongTag_fails() {
+		assertThrows(NullPointerException.class, NonexistentTagCase::new);
+		assertThrows(AssertionError.class, WrongTypeCase::new);
+	}
+}

--- a/bosk-core/src/test/java/works/bosk/VariantTest.java
+++ b/bosk-core/src/test/java/works/bosk/VariantTest.java
@@ -10,6 +10,7 @@ import works.bosk.exceptions.InvalidTypeException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static works.bosk.BoskTestUtils.boskName;
 
 class VariantTest extends AbstractBoskTest {
 
@@ -46,7 +47,7 @@ class VariantTest extends AbstractBoskTest {
 	@Test
 	void test() throws InvalidTypeException, IOException, InterruptedException {
 		String stringValue = "test";
-		var bosk = new Bosk<>(VariantTest.class.getSimpleName(), BoskState.class, new BoskState(new StringCase(stringValue)), Bosk::simpleDriver);
+		var bosk = new Bosk<>(boskName(), BoskState.class, new BoskState(new StringCase(stringValue)), Bosk::simpleDriver);
 		var refs = bosk.rootReference().buildReferences(Refs.class);
 		try (var __ = bosk.readContext()) {
 			assertEquals(stringValue, refs.stringValue().value());

--- a/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
+++ b/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static works.bosk.BoskTestUtils.boskName;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 
 public class PathCompilerTest extends AbstractBoskTest {
@@ -268,7 +269,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 			.getConstructor(Identifier.class)
 			.newInstance(rootID);
 		Bosk<StateTreeNode> differentBosk = new Bosk<>(
-			"Different",
+			boskName("Different"),
 			differentRootClass,
 			initialRoot,
 			Bosk::simpleDriver

--- a/bosk-core/src/test/java/works/bosk/drivers/BsonRoundTripConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/BsonRoundTripConformanceTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 
 import static works.bosk.AbstractRoundTripTest.bsonRoundTripFactory;
 
+/**
+ * TODO: Move to bosk-mongo
+ */
 public class BsonRoundTripConformanceTest extends DriverConformanceTest {
 	@BeforeEach
 	void setupDriverFactory() {

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
@@ -6,6 +6,7 @@ import works.bosk.Bosk;
 import works.bosk.drivers.state.TestEntity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 
 class ReplicaSetConformanceTest extends DriverConformanceTest {
 	Bosk<TestEntity> replicaBosk;
@@ -14,7 +15,7 @@ class ReplicaSetConformanceTest extends DriverConformanceTest {
 	void setupDriverFactory() {
 		ReplicaSet<TestEntity> replicaSet = new ReplicaSet<>();
 		replicaBosk = new Bosk<TestEntity>(
-			"Replica bosk",
+			boskName("Replica"),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,
 			replicaSet.driverFactory());

--- a/bosk-jackson/build.gradle
+++ b/bosk-jackson/build.gradle
@@ -14,5 +14,6 @@ dependencies {
 	api 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
 	api project(":bosk-core")
 
+	testImplementation project(":bosk-testing")
 	testImplementation project(":lib-testing")
 }

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonCompiler.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonCompiler.java
@@ -61,6 +61,7 @@ final class JacksonCompiler {
 
 	/**
 	 * The main entry point to the compiler.
+	 * Only for ordinary {@link works.bosk.StateTreeNode}s that aren't variants.
 	 *
 	 * @return a newly compiled {@link CompiledSerDes} for values of the given <code>nodeType</code>.
 	 */

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPlugin.java
@@ -422,7 +422,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 					} else if (valuesById == null) {
 						throw new JsonParseException(p, "Missing 'valuesById' field");
 					} else {
-						return SideTable.fromOrderedMap(domain, valuesById);
+						return SideTable.copyOf(domain, valuesById);
 					}
 				}
 			};
@@ -470,7 +470,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 						}
 					}
 					expect(END_OBJECT, p);
-					return MapValue.fromOrderedMap(result1);
+					return MapValue.copyOf(result1);
 				}
 			};
 		}

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPlugin.java
@@ -1,5 +1,6 @@
 package works.bosk.jackson;
 
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -50,6 +51,7 @@ import works.bosk.ReflectiveEntity;
 import works.bosk.SerializationPlugin;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
+import works.bosk.VariantNode;
 import works.bosk.annotations.DerivedRecord;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.TunneledCheckedException;
@@ -209,8 +211,33 @@ public final class JacksonPlugin extends SerializationPlugin {
 		}
 
 		private JsonSerializer<StateTreeNode> stateTreeNodeSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
-			StateTreeNodeFieldModerator moderator = new StateTreeNodeFieldModerator(type);
-			return compiler.<StateTreeNode>compiled(type, boskInfo, moderator).serializer(config);
+			var variantCaseMap = getVariantCaseMapIfAny(type.getRawClass());
+			if (variantCaseMap == null) {
+				StateTreeNodeFieldModerator moderator = new StateTreeNodeFieldModerator(type);
+				return compiler.<StateTreeNode>compiled(type, boskInfo, moderator).serializer(config);
+			} else {
+				return new JsonSerializer<>() {
+					@Override
+					public void serialize(StateTreeNode stateTreeNode, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+						VariantNode value = (VariantNode) stateTreeNode;
+						String tag = value.tag();
+						Type caseType = variantCaseMap.get(tag);
+						if (caseType == null) {
+							throw new JsonParseException("Object has unexpected variant tag field; expected one of " + variantCaseMap.keySet());
+						}
+						Class<?> caseClass = rawClass(caseType);
+						if (!caseClass.isInstance(value)) {
+							throw new JsonParseException("Object type " + value.getClass().getSimpleName() + " doesn't match type for tag " + tag + " " + caseType);
+						}
+						JsonSerializer<Object> valueSerializer = serializers.findValueSerializer(caseClass);
+
+						gen.writeStartObject();
+						gen.writeFieldName(requireNonNull(tag));
+						valueSerializer.serialize(value, gen, serializers);
+						gen.writeEndObject();
+					}
+				};
+			}
 		}
 
 		private JsonSerializer<MapValue<Object>> mapValueSerializer(SerializationConfig config, BeanDescription beanDesc) {
@@ -428,9 +455,36 @@ public final class JacksonPlugin extends SerializationPlugin {
 			};
 		}
 
-		private JsonDeserializer<StateTreeNode> stateTreeNodeDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
-			StateTreeNodeFieldModerator moderator = new StateTreeNodeFieldModerator(type);
-			return compiler.<StateTreeNode>compiled(type, boskInfo, moderator).deserializer(config);
+		private JsonDeserializer<? extends StateTreeNode> stateTreeNodeDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {
+			var variantCaseMap = getVariantCaseMapIfAny(type.getRawClass());
+			if (variantCaseMap == null) {
+				StateTreeNodeFieldModerator moderator = new StateTreeNodeFieldModerator(type);
+				return compiler.<StateTreeNode>compiled(type, boskInfo, moderator).deserializer(config);
+			} else {
+				return variantNodeDeserializer(variantCaseMap);
+			}
+		}
+
+		private static JsonDeserializer<VariantNode> variantNodeDeserializer(Map<String, Type> variantCaseMap) {
+			return new JsonDeserializer<>() {
+				@Override
+				public VariantNode deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+					expect(START_OBJECT, p);
+					if (p.nextToken() == END_OBJECT) {
+						throw new JsonParseException(p, "Input is missing variant tag field; expected one of " + variantCaseMap.keySet());
+					}
+					p.nextValue();
+					String tag = p.currentName();
+					Type caseType = variantCaseMap.get(tag);
+					if (caseType == null) {
+						throw new JsonParseException(p, "Input has unexpected variant tag field; expected one of " + variantCaseMap.keySet());
+					}
+					JavaType type = TypeFactory.defaultInstance().constructType(caseType);
+					Object nested = ctxt.findContextualValueDeserializer(type, null).deserialize(p, ctxt);
+					expect(END_OBJECT, p);
+					return (VariantNode) type.getRawClass().cast(nested);
+				}
+			};
 		}
 
 		private JsonDeserializer<ListValue<Object>> listValueDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) {

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
@@ -70,8 +70,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	private Refs refs;
 
 	public interface Refs {
-		@ReferencePath("/entities")
-		CatalogReference<TestEntity> entities();
+		@ReferencePath("/entities") CatalogReference<TestEntity> entities();
 		@ReferencePath("/entities/-entity-") Reference<TestEntity> entity(Identifier entity);
 		@ReferencePath("/entities/-entity-/children") CatalogReference<TestChild> children(Identifier entity);
 		@ReferencePath("/entities/parent/implicitRefs") Reference<ImplicitRefs> parentImplicitRefs();
@@ -166,7 +165,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	@ParameterizedTest
 	@MethodSource("sideTableArguments")
 	void sideTable_works(List<String> keys, Map<String,String> valuesByString, Map<Identifier, String> valuesById) {
-		SideTable<TestEntity, String> sideTable = SideTable.fromOrderedMap(refs.entities(), valuesById);
+		SideTable<TestEntity, String> sideTable = SideTable.copyOf(refs.entities(), valuesById);
 
 		List<Map<String, Object>> expectedList = new ArrayList<>();
 		valuesByString.forEach((key, value) -> expectedList.add(singletonMap(key, value)));
@@ -299,7 +298,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	@ParameterizedTest
 	@MethodSource("mapValueArguments")
 	void mapValue_serializationWorks(Map<String,?> map, JavaType type) throws JsonProcessingException {
-		MapValue<?> mapValue = MapValue.fromOrderedMap(map);
+		MapValue<?> mapValue = MapValue.copyOf(map);
 		String expected = plainMapper.writeValueAsString(map);
 		assertEquals(expected, boskMapper.writeValueAsString(mapValue));
 	}
@@ -307,7 +306,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 	@ParameterizedTest
 	@MethodSource("mapValueArguments")
 	void mapValue_deserializationWorks(Map<String,?> map, JavaType type) throws JsonProcessingException {
-		MapValue<?> expected = MapValue.fromOrderedMap(map);
+		MapValue<?> expected = MapValue.copyOf(map);
 		String json = plainMapper.writeValueAsString(map);
 		Object actual = boskMapper.readerFor(type).readValue(json);
 		assertEquals(expected, actual);

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonRoundTripConformanceTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonRoundTripConformanceTest.java
@@ -1,0 +1,13 @@
+package works.bosk.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import works.bosk.drivers.DriverConformanceTest;
+
+import static works.bosk.AbstractRoundTripTest.jacksonRoundTripFactory;
+
+public class JacksonRoundTripConformanceTest extends DriverConformanceTest {
+	@BeforeEach
+	void setupDriverFactory() {
+		driverFactory = jacksonRoundTripFactory();
+	}
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/BsonPlugin.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/BsonPlugin.java
@@ -331,7 +331,7 @@ public final class BsonPlugin extends SerializationPlugin {
 					}
 				}
 				reader.readEndDocument();
-				return MapValue.fromOrderedMap(entries);
+				return MapValue.copyOf(entries);
 			}
 
 		};
@@ -542,7 +542,7 @@ public final class BsonPlugin extends SerializationPlugin {
 
 				reader.readEndDocument();
 
-				return SideTable.fromOrderedMap(domain, valuesById);
+				return SideTable.copyOf(domain, valuesById);
 			}
 
 			private MethodHandle sideTableWriterHandle(Type valueType, CodecRegistry codecRegistry) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/BsonPlugin.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/BsonPlugin.java
@@ -45,6 +45,7 @@ import works.bosk.Reference;
 import works.bosk.SerializationPlugin;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
+import works.bosk.VariantNode;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.UnexpectedPathException;
 
@@ -401,6 +402,15 @@ public final class BsonPlugin extends SerializationPlugin {
 	}
 
 	private <T extends StateTreeNode, R extends StateTreeNode> Codec<T> stateTreeNodeCodec(Class<T> nodeClass, CodecRegistry registry, BoskInfo<R> boskInfo) {
+		var variantCaseMap = getVariantCaseMapIfAny(nodeClass);
+		if (variantCaseMap == null) {
+			return ordinaryStateTreeNodeCodec(nodeClass, registry, boskInfo);
+		} else {
+			return variantNodeCodec(nodeClass, variantCaseMap, registry, boskInfo);
+		}
+	}
+
+	private <T extends StateTreeNode, R extends StateTreeNode> Codec<T> ordinaryStateTreeNodeCodec(Class<T> nodeClass, CodecRegistry registry, BoskInfo<R> boskInfo) {
 		// Pre-compute some reflection-based stuff
 		//
 		Constructor<?> constructor = theOnlyConstructorFor(nodeClass);
@@ -435,7 +445,51 @@ public final class BsonPlugin extends SerializationPlugin {
 				}
 			}
 
-			@Override public Class<T> getEncoderClass() { return nodeClass; }
+			@Override
+			public Class<T> getEncoderClass() {
+				return nodeClass;
+			}
+		};
+	}
+
+	private <T extends StateTreeNode, R extends StateTreeNode> Codec<T> variantNodeCodec(Class<T> nodeClass, Map<String, Type> variantCaseMap, CodecRegistry registry, BoskInfo<R> boskInfo) {
+		return new Codec<>() {
+			@Override
+			public void encode(BsonWriter writer, T stateTreeNode, EncoderContext encoderContext) {
+				VariantNode value = (VariantNode) stateTreeNode;
+				String tag = value.tag();
+				Type targetType = variantCaseMap.get(tag);
+				@SuppressWarnings("unchecked")
+				Codec<T> caseCodec = (Codec<T>) getCodec(targetType, rawClass(targetType), registry, boskInfo);
+				writer.writeStartDocument();
+				try {
+					writer.writeName(tag);
+					caseCodec.encode(writer, stateTreeNode, encoderContext);
+				} catch (Throwable e) {
+					throw new IllegalStateException("Error encoding " + nodeClass + ": " + e.getMessage(), e);
+				}
+				writer.writeEndDocument();
+			}
+
+			@Override
+			public T decode(BsonReader reader, DecoderContext decoderContext) {
+				reader.readStartDocument();
+				String tag = reader.readName();
+				Type caseType = variantCaseMap.get(tag);
+				if (caseType == null) {
+					throw new IllegalStateException("Unexpected tag \"" + tag + "\"");
+				}
+				@SuppressWarnings("unchecked")
+				Codec<T> caseCodec = (Codec<T>) getCodec(caseType, rawClass(caseType), registry, boskInfo);
+				T result = caseCodec.decode(reader, decoderContext);
+				reader.readEndDocument();
+				return result;
+			}
+
+			@Override
+			public Class<T> getEncoderClass() {
+				return nodeClass;
+			}
 		};
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonPluginTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonPluginTest.java
@@ -22,13 +22,14 @@ import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 
 class BsonPluginTest {
 
 	@Test
 	void sideTableOfSideTables() {
 		BsonPlugin bp = new BsonPlugin();
-		Bosk<Root> bosk = new Bosk<Root>("Test bosk", Root.class, this::defaultRoot, Bosk::simpleDriver);
+		Bosk<Root> bosk = new Bosk<Root>(boskName(), Root.class, this::defaultRoot, Bosk::simpleDriver);
 		CodecRegistry registry = CodecRegistries.fromProviders(bp.codecProviderFor(bosk), new ValueCodecProvider());
 		Codec<Root> codec = registry.get(Root.class);
 		try (var __ = bosk.readContext()) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
@@ -17,13 +17,14 @@ import works.bosk.drivers.state.TestEntity;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 
 class MongoDriverDottedFieldNameTest extends AbstractDriverTest {
 	private Bosk<TestEntity> bosk;
 
 	@BeforeEach
 	void setUpStuff() {
-		bosk = new Bosk<TestEntity>("Test bosk", TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
+		bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
 	}
 
 	private CatalogReference<TestEntity> rootCatalogRef(Bosk<TestEntity> bosk) throws InvalidTypeException {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverInitializationFailureTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverInitializationFailureTest.java
@@ -6,6 +6,7 @@ import works.bosk.drivers.state.TestEntity;
 
 import static ch.qos.logback.classic.Level.ERROR;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static works.bosk.BoskTestUtils.boskName;
 
 /**
  * Tests the functionality of {@link MongoDriverSettings.InitialDatabaseUnavailableMode#FAIL FAIL} mode.
@@ -27,7 +28,7 @@ public class MongoDriverInitializationFailureTest extends AbstractMongoDriverTes
 		mongoService.proxy().setConnectionCut(true);
 		tearDownActions.add(()->mongoService.proxy().setConnectionCut(false));
 		assertThrows(InitialRootFailureException.class, ()->{
-			new Bosk<TestEntity>("Fail", TestEntity.class, this::initialRoot, super.createDriverFactory(logController));
+			new Bosk<TestEntity>(boskName("Fail"), TestEntity.class, this::initialRoot, super.createDriverFactory(logController));
 		});
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
@@ -25,6 +25,7 @@ import works.bosk.junit.ParametersByName;
 import static ch.qos.logback.classic.Level.ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static works.bosk.BoskTestUtils.boskName;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 import static works.bosk.drivers.mongo.MainDriver.COLLECTION_NAME;
 
@@ -78,7 +79,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		tearDownActions.add(()->mongoService.proxy().setConnectionCut(false));
 
 		LOGGER.debug("Create a new bosk that can't connect");
-		Bosk<TestEntity> bosk = new Bosk<TestEntity>("Test " + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory);
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>(getClass().getSimpleName() + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory);
 
 		MongoDriverSpecialTest.Refs refs = bosk.buildReferences(MongoDriverSpecialTest.Refs.class);
 		BoskDriver<TestEntity> driver = bosk.driver();
@@ -208,7 +209,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		LOGGER.debug("Setup database to beforeState");
 		TestEntity beforeState = initializeDatabase("before deletion");
 
-		Bosk<TestEntity> bosk = new Bosk<TestEntity>("Test " + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory);
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(getClass().getSimpleName()), TestEntity.class, this::initialRoot, driverFactory);
 
 		try (var __ = bosk.readContext()) {
 			assertEquals(beforeState, bosk.rootReference().value());
@@ -252,7 +253,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 	private TestEntity initializeDatabase(String distinctiveString) {
 		try {
 			Bosk<TestEntity> prepBosk = new Bosk<TestEntity>(
-				"Prep " + boskCounter.incrementAndGet(),
+				boskName("Prep " + getClass().getSimpleName()),
 				TestEntity.class,
 				bosk -> initialRoot(bosk).withString(distinctiveString),
 				driverFactory);
@@ -270,7 +271,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		LOGGER.debug("Setup database to beforeState");
 		TestEntity beforeState = initializeDatabase("before disruption");
 
-		Bosk<TestEntity> bosk = new Bosk<TestEntity>("Test " + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory);
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(getClass().getSimpleName()), TestEntity.class, this::initialRoot, driverFactory);
 
 		try (var __ = bosk.readContext()) {
 			assertEquals(beforeState, bosk.rootReference().value());

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -17,6 +17,7 @@ import works.bosk.drivers.state.TestEntity;
 import works.bosk.junit.ParametersByName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 
 @UsesMongoService
 public class SchemaEvolutionTest {
@@ -176,10 +177,8 @@ public class SchemaEvolutionTest {
 	}
 
 	private static Bosk<TestEntity> newBosk(Helper helper) {
-		return new Bosk<TestEntity>("bosk" + boskCounter.incrementAndGet(), TestEntity.class, helper::initialRoot, helper.driverFactory);
+		return new Bosk<TestEntity>(boskName(helper.toString()), TestEntity.class, helper::initialRoot, helper.driverFactory);
 	}
-
-	private static final AtomicInteger boskCounter = new AtomicInteger(0);
 
 	record Configuration(
 		MongoDriverSettings.DatabaseFormat preferredFormat,

--- a/bosk-testing/src/main/java/works/bosk/BoskTestUtils.java
+++ b/bosk-testing/src/main/java/works/bosk/BoskTestUtils.java
@@ -1,0 +1,37 @@
+package works.bosk;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BoskTestUtils {
+	private static final AtomicInteger boskCounter = new AtomicInteger(0);
+
+	/**
+	 * @param framesToSkip number of topmost stack frames to ignore when determining caller information.
+	 *                     0 indicates the caller of this method should be used.
+	 *                     The intent is to specify the most informative possible frame for those investigating test failures.
+	 * @return an informative string suitable to be used as the name of a {@link Bosk}.
+	 * Helpful especially in parallel testing, to figure out which bosk emitted a log message.
+	 */
+	public static String boskName(int framesToSkip) {
+		var caller = StackWalker.getInstance().walk(s -> s.skip(1+framesToSkip).findFirst()).get();
+		return "bosk" + boskCounter.incrementAndGet() + "(" + caller.getFileName() + ":" + caller.getLineNumber() + ")";
+	}
+
+	public static String boskName() {
+		return boskName(1);
+	}
+
+	public static String boskName(String prefix) {
+		return prefix + " " + boskName(1);
+	}
+
+	/**
+	 * @param framesToSkip number of topmost stack frames to ignore when determining caller information.
+	 *                     0 indicates the caller of this method should be used.
+	 *                     The intent is to specify the most informative possible frame for those investigating test failures.
+	 */
+	public static String boskName(String prefix, int framesToSkip) {
+		return prefix + " " + boskName(1 + framesToSkip);
+	}
+
+}

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -20,6 +20,7 @@ import works.bosk.exceptions.InvalidTypeException;
 
 import static java.lang.Thread.currentThread;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 
 public abstract class AbstractDriverTest {
 	protected final Identifier child1ID = Identifier.from("child1");
@@ -48,10 +49,10 @@ public abstract class AbstractDriverTest {
 
 	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
 		// This is the bosk whose behaviour we'll consider to be correct by definition
-		canonicalBosk = new Bosk<TestEntity>(getClass().getSimpleName() + "-canonical", TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
+		canonicalBosk = new Bosk<TestEntity>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
 
 		// This is the bosk we're testing
-		bosk = new Bosk<TestEntity>(getClass().getSimpleName(), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
+		bosk = new Bosk<TestEntity>(boskName("Test", 1), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
 			MirroringDriver.targeting(canonicalBosk),
 			DriverStateVerifier.wrap(driverFactory, TestEntity.class, AbstractDriverTest::initialRoot)
 		));

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
@@ -23,6 +23,9 @@ import works.bosk.SideTable;
 import works.bosk.annotations.ReferencePath;
 import works.bosk.drivers.state.TestEntity;
 import works.bosk.drivers.state.TestValues;
+import works.bosk.drivers.state.TestValues.IdentifierCase;
+import works.bosk.drivers.state.TestValues.StringCase;
+import works.bosk.drivers.state.TestValues.Variant;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.junit.ParametersByName;
 
@@ -236,7 +239,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void replaceNonexistentField(Path enclosingCatalogPath) throws InvalidTypeException {
+	void replaceFieldOfNonexistentEntry(Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitReplacement(
 			ref.then(String.class, "nonexistent", "string"),
@@ -322,6 +325,30 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		assertThrows(NullPointerException.class, ()->driver.submitReplacement(enumRef, null));
 		assertCorrectBoskContents();
 		assertThrows(IllegalArgumentException.class, ()->driver.submitDeletion(enumRef));
+		assertCorrectBoskContents();
+	}
+
+	@ParametersByName
+	void variant() throws InvalidTypeException {
+		Reference<TestValues> ref = initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
+		assertCorrectBoskContents();
+
+		Reference<Variant> variantRef = ref.then(Variant.class, TestValues.Fields.variant);
+		driver.submitReplacement(variantRef, new StringCase("value1"));
+		assertCorrectBoskContents();
+		assertThrows(IllegalArgumentException.class, () -> driver.submitDeletion(variantRef));
+		assertCorrectBoskContents();
+
+		Reference<StringCase> stringCaseRef = variantRef.then(StringCase.class, "string");
+		driver.submitReplacement(stringCaseRef, new StringCase("value2"));
+		assertCorrectBoskContents();
+		assertThrows(IllegalArgumentException.class, () -> driver.submitDeletion(stringCaseRef));
+		assertCorrectBoskContents();
+
+		Reference<IdentifierCase> idCaseRef = variantRef.then(IdentifierCase.class, "identifier");
+		driver.submitReplacement(idCaseRef, new IdentifierCase(Identifier.from("value3")));
+		assertCorrectBoskContents();
+		assertThrows(IllegalArgumentException.class, () -> driver.submitDeletion(idCaseRef));
 		assertCorrectBoskContents();
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -22,6 +22,7 @@ import works.bosk.exceptions.NotYetImplementedException;
 
 import static java.lang.Thread.currentThread;
 import static lombok.AccessLevel.PRIVATE;
+import static works.bosk.BoskTestUtils.boskName;
 
 /**
  * Watches the updates entering and leaving a particular {@link BoskDriver} and ensures
@@ -51,7 +52,7 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject, Type rootType, Bosk.DefaultRootFunction<RR> defaultRootFunction) {
 		Bosk<RR> stateTrackingBosk = new Bosk<>(
-			DriverStateVerifier.class.getSimpleName(),
+			boskName(),
 			rootType, defaultRootFunction,
 			Bosk::simpleDriver
 		);

--- a/bosk-testing/src/main/java/works/bosk/drivers/HanoiTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/HanoiTest.java
@@ -2,7 +2,6 @@ package works.bosk.drivers;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -27,6 +26,7 @@ import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 
 /**
@@ -42,7 +42,6 @@ public abstract class HanoiTest {
 	Refs refs;
 	BlockingQueue<Integer> numSolved;
 	protected DriverFactory<HanoiState> driverFactory;
-	private static final AtomicInteger boskCounter = new AtomicInteger(0);
 
 	public interface Refs {
 		@ReferencePath("/puzzles")
@@ -58,7 +57,7 @@ public abstract class HanoiTest {
 	@BeforeEach
 	void setup() throws InvalidTypeException {
 		bosk = new Bosk<HanoiState>(
-			getClass().getSimpleName() + "_" + boskCounter.incrementAndGet(),
+			boskName(),
 			HanoiState.class,
 			this::defaultRoot,
 			driverFactory

--- a/bosk-testing/src/main/java/works/bosk/drivers/state/TestValues.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/state/TestValues.java
@@ -1,12 +1,17 @@
 package works.bosk.drivers.state;
 
+import java.lang.reflect.Type;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import lombok.Value;
 import lombok.With;
 import lombok.experimental.FieldNameConstants;
+import works.bosk.Identifier;
 import works.bosk.ListValue;
 import works.bosk.MapValue;
 import works.bosk.StateTreeNode;
+import works.bosk.VariantNode;
+import works.bosk.annotations.VariantCaseMap;
 
 import static java.time.temporal.ChronoUnit.FOREVER;
 
@@ -18,8 +23,28 @@ public class TestValues implements StateTreeNode {
 	ChronoUnit chronoUnit;
 	ListValue<String> list;
 	MapValue<String> map;
+	Variant variant;
+
+	public interface Variant extends VariantNode {
+		@Override
+		default String tag() {
+			if (this instanceof StringCase) {
+				return "string";
+			} else {
+				return "identifier";
+			}
+		}
+
+		@VariantCaseMap
+		MapValue<Type> VARIANT_CASE_MAP = MapValue.copyOf(Map.of(
+			"string", StringCase.class,
+			"identifier", IdentifierCase.class
+		));
+	}
+	public record StringCase(String value) implements Variant {}
+	public record IdentifierCase(Identifier value) implements Variant {}
 
 	public static TestValues blank() {
-		return new TestValues("", FOREVER, ListValue.empty(), MapValue.empty());
+		return new TestValues("", FOREVER, ListValue.empty(), MapValue.empty(), new StringCase(""));
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ spotless {
 		target '**/*.gradle', '**/*.md', '**/.gitignore'
 
 		trimTrailingWhitespace()
-		indentWithTabs()
+		//indentWithTabs() For markdown, we want to align some code examples very carefully, so we use spaces
 		replaceRegex 'class-level javadoc indentation fix', /^\*/, ' *'
 		replaceRegex 'method-level javadoc indentation fix', /\t\*/, '\t *'
 		endWithNewline()

--- a/lib-testing/build.gradle
+++ b/lib-testing/build.gradle
@@ -13,8 +13,9 @@ dependencies {
 	// which in turn can depend on the main code from other projects.
 	// It's a mild kind of circular dependency we can probably live with for now.
 	implementation project(":bosk-core")
-	implementation project(":bosk-jackson")
 	implementation project(":bosk-logback")
+	// These are for AbstractRoundTripTest. That logic ought to be moved to their respective sub-projects
+	implementation project(":bosk-jackson")
 	implementation project(":bosk-mongo")
 
 	// The bosk.development plugin brings these in as test dependencies,

--- a/lib-testing/build.gradle
+++ b/lib-testing/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	// It's a mild kind of circular dependency we can probably live with for now.
 	implementation project(":bosk-core")
 	implementation project(":bosk-logback")
+	implementation project(":bosk-testing")
 	// These are for AbstractRoundTripTest. That logic ought to be moved to their respective sub-projects
 	implementation project(":bosk-jackson")
 	implementation project(":bosk-mongo")

--- a/lib-testing/src/main/java/works/bosk/AbstractBoskTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractBoskTest.java
@@ -10,6 +10,7 @@ import works.bosk.annotations.Self;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static java.util.Arrays.asList;
+import static works.bosk.BoskTestUtils.boskName;
 
 public abstract class AbstractBoskTest {
 	@With
@@ -126,7 +127,7 @@ public abstract class AbstractBoskTest {
 	}
 
 	protected static Bosk<TestRoot> setUpBosk(DriverFactory<TestRoot> driverFactory) {
-		return new Bosk<TestRoot>("Test", TestRoot.class, AbstractRoundTripTest::initialRoot, driverFactory);
+		return new Bosk<TestRoot>(boskName(1), TestRoot.class, AbstractRoundTripTest::initialRoot, driverFactory);
 	}
 
 	protected static TestRoot initialRoot(Bosk<TestRoot> bosk) {

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
 	<logger name="works.bosk.drivers.mongo.UninitializedCollectionException" level="ERROR"/>
 
 	<!-- How to add more tracing during unit tests
+	<logger name="works.bosk" level="INFO"/>
 	<logger name="works.bosk.drivers.mongo" level="DEBUG"/>
 	<logger name="works.bosk.drivers.DriverConformanceTest" level="DEBUG"/>
 	<logger name="works.bosk.drivers.mongo.PandoFormatDriver" level="TRACE"/>


### PR DESCRIPTION
Supports polymorphism in the bosk state.

This is slightly cumbersome, with the `tag()` method and the `@VariantCaseMap`. Hopefully we can smooth out the rough edges over time.