### PR TITLE
Upgrade to SLF4J v2

### DIFF
--- a/bosk-logback/build.gradle
+++ b/bosk-logback/build.gradle
@@ -16,5 +16,5 @@ repositories {
 
 dependencies {
 	api project(":bosk-core")
-	implementation "ch.qos.logback:logback-classic:1.4.14"
+	implementation "ch.qos.logback:logback-classic:1.5.6"
 }

--- a/buildSrc/src/main/groovy/bosk.development.gradle
+++ b/buildSrc/src/main/groovy/bosk.development.gradle
@@ -65,8 +65,8 @@ dependencies {
 	testImplementation "org.hamcrest:hamcrest:2.2"
 	testImplementation "org.hamcrest:hamcrest-library:2.2"
 
-	implementation "org.slf4j:slf4j-api:1.7.36"
-	testImplementation "ch.qos.logback:logback-classic:1.4.14"
+	implementation "org.slf4j:slf4j-api:2.0.13"
+	testImplementation "ch.qos.logback:logback-classic:1.5.6"
 
 	testImplementation 'org.openjdk.jmh:jmh-core:1.37'
 	testAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.37'


### PR DESCRIPTION
I think this may break compatibility with apps using SLF4J v1, but since basically nobody uses bosk yet, that's A-OK.