### PR TITLE
Service endpoints test

### DIFF
--- a/bosk-spring-boot-3/build.gradle
+++ b/bosk-spring-boot-3/build.gradle
@@ -3,6 +3,10 @@ plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
 	id 'com.github.spotbugs' version '5.1.5'
+
+	// These are needed just for testing
+	id 'org.springframework.boot' version '3.3.2'
+	id 'io.spring.dependency-management' version '1.1.3'
 }
 
 java {
@@ -12,10 +16,11 @@ java {
 
 dependencies {
 	api project(":bosk-jackson")
-	implementation 'org.springframework.boot:spring-boot-starter-web:3.3.2'
-	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:3.3.2"
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	testImplementation project(":bosk-testing")
 	testImplementation project(":lib-testing")
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 repositories {

--- a/bosk-spring-boot-3/src/test/java/works/bosk/spring/boot/ServiceEndpointsTest.java
+++ b/bosk-spring-boot-3/src/test/java/works/bosk/spring/boot/ServiceEndpointsTest.java
@@ -1,0 +1,139 @@
+package works.bosk.spring.boot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import works.bosk.Bosk;
+import works.bosk.StateTreeNode;
+import works.bosk.drivers.BufferingDriver;
+import works.bosk.jackson.JacksonPlugin;
+import works.bosk.spring.boot.ServiceEndpointsTest.BoskState;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static works.bosk.spring.boot.ServiceEndpointsTest.GREETING_VALUE;
+import static works.bosk.spring.boot.TestBosk.INITIAL_STATE;
+
+/**
+ * Note: this is not an end-to-end test with a realistic Spring Boot environment.
+ * This can pass, yet {@link ServiceEndpoints} might still not work in a real Spring Boot project.
+ * This only tests some basic functionality.
+ */
+@SpringBootTest(classes={Config.class, ServiceEndpoints.class, ReadContextFilter.class})
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"bosk.web.service-path=/bosk"})
+public class ServiceEndpointsTest {
+	public record BoskState(Optional<String> greeting) implements StateTreeNode { }
+	public static final String GREETING_PATH = "/bosk/greeting";
+	public static final String GREETING_VALUE = "Hello, world!";
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private TestBosk bosk;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUpBosk() throws IOException, InterruptedException {
+		bosk.driver().submitReplacement(bosk.rootReference(), INITIAL_STATE);
+		bosk.driver().flush();
+	}
+
+	@Test
+	void get_works() throws Exception {
+		mvc.perform(get(GREETING_PATH))
+			.andExpect(status().isOk())
+			.andExpect(content().string(GREETING_VALUE));
+	}
+
+	@Test
+	void put_works() throws Exception {
+		mvc.perform(put(GREETING_PATH).content("\"New greeting\""))
+			.andExpect(status().isAccepted());
+		bosk.driver().flush();
+		mvc.perform(get(GREETING_PATH))
+			.andExpect(status().isOk())
+			.andExpect(content().string("New greeting"));
+	}
+
+	@Test
+	void delete_works() throws Exception {
+		mvc.perform(delete(GREETING_PATH))
+			.andExpect(status().isAccepted());
+		bosk.driver().flush();
+		mvc.perform(get(GREETING_PATH))
+			.andExpect(status().isNotFound());
+	}
+
+	@Disabled("Can't seem to get Jackson working. Without this, we can't test etags either.")
+	@Test
+	void root_works() throws Exception {
+		String expected = objectMapper.writeValueAsString(INITIAL_STATE);
+		mvc.perform(get("/bosk/"))
+			.andExpect(status().isOk())
+			.andExpect(content().json(expected));
+	}
+}
+
+class TestBosk extends Bosk<BoskState> {
+	public static final BoskState INITIAL_STATE = new BoskState(Optional.of(GREETING_VALUE));
+
+	public TestBosk() {
+		super(
+			"TestBosk",
+			BoskState.class,
+			INITIAL_STATE,
+			// Let's not cheat and skip the flushes here. In the future, our ReadContextFilter
+			// could support flush functionality, and we'll want to test that.
+			// Better to make the existing tests correct so that they work under those new conditions.
+			BufferingDriver.factory()
+		);
+	}
+}
+
+@Configuration
+class Config {
+	@Bean
+	public TestBosk bosk() {
+		return new TestBosk();
+	}
+
+	@Bean
+	public JacksonPlugin jacksonPlugin() {
+		return new JacksonPlugin();
+	}
+
+	@Bean
+	ObjectMapper objectMapper(TestBosk bosk, JacksonPlugin jacksonPlugin) {
+		return new ObjectMapper()
+			.registerModule(jacksonPlugin.moduleFor(bosk))
+			.enable(INDENT_OUTPUT);
+	}
+
+	@Bean
+	public FilterRegistrationBean<ReadContextFilter> filter(TestBosk bosk) {
+		FilterRegistrationBean<ReadContextFilter> registrationBean = new FilterRegistrationBean<>();
+		registrationBean.setFilter(new ReadContextFilter(bosk));
+		registrationBean.addUrlPatterns("/bosk*");
+		return registrationBean;
+	}
+
+}

--- a/example-hello/build.gradle
+++ b/example-hello/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.4'
+	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.3'
 }
 


### PR DESCRIPTION
From the commit message:

> Initial working `ServiceEndpointsTest`.
> 
> Sadly, this did not actually detect the error that motivated me to write the test. I saw this when I tried to use `ServiceEndpoints`:
> 
>     java.lang.IllegalStateException: getInputStream() has already been called for this request
>             at org.apache.catalina.connector.Request.getReader(Request.java:1134)
>             at org.apache.catalina.connector.RequestFacade.getReader(RequestFacade.java:392)
>             at works.bosk.spring.boot.ServiceEndpoints.putAny(ServiceEndpoints.java:68)
> 
> Apparently, the Spring Boot environment set up by `AutoConfigureMockMvc` isn't close enough to a real production usage to reproduce this problem.
> 
> Regardless, setting up these kinds of tests is tricky so it's nice to have this code committed.
> 
> Also, I think I've improved the `ServiceEndpoints` to make them a bit more idomatic, and also forgiving (eg. they can handle "`/bosk`" as well as "`/bosk/`").
