### PR TITLE
ValidatingDriver

### DIFF
--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -48,7 +48,7 @@ public class BoskConstructorTest {
 
 		// The driver object and root node should be exactly the same object passed in
 
-		assertSame(driver.get(), bosk.driver());
+		assertSame(driver.get(), bosk.getDriver(ForwardingDriver.class));
 
 		try (val __ = bosk.readContext()) {
 			assertSame(root, bosk.rootReference().value());

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -275,18 +274,6 @@ class BoskLocalReferenceTest {
 		}
 		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
 		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
-	}
-
-	@Test
-	void testDriver() {
-		// This doesn't test the operation of the driver; merely that the right driver is returned
-		AtomicReference<BoskDriver<Root>> driver = new AtomicReference<>();
-		Bosk<Root> myBosk = new Bosk<>(boskName(), Root.class, new Root(123, Catalog.empty()), (b,d) -> {
-			BoskDriver<Root> bd = new ProxyDriver(d);
-			driver.set(bd);
-			return bd;
-		});
-		assertSame(driver.get(), myBosk.driver());
 	}
 
 	@RequiredArgsConstructor

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
@@ -252,12 +252,17 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 
 	private TestEntity initializeDatabase(String distinctiveString) {
 		try {
+			AtomicReference<MongoDriver<TestEntity>> driverRef = new AtomicReference<>();
 			Bosk<TestEntity> prepBosk = new Bosk<TestEntity>(
 				boskName("Prep " + getClass().getSimpleName()),
 				TestEntity.class,
 				bosk -> initialRoot(bosk).withString(distinctiveString),
-				driverFactory);
-			MongoDriver<TestEntity> driver = (MongoDriver<TestEntity>) prepBosk.driver();
+				(b,d) -> {
+					var mongoDriver = (MongoDriver<TestEntity>) driverFactory.build(b, d);
+					driverRef.set(mongoDriver);
+					return mongoDriver;
+				});
+			var driver = driverRef.get();
 			waitFor(driver);
 			driver.close();
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -563,7 +563,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		assertEquals(Optional.empty(), before); // Not there yet
 
 		LOGGER.debug("Call refurbish");
-		((MongoDriver<?>)upgradeableBosk.driver()).refurbish();
+		upgradeableBosk.getDriver(MongoDriver.class).refurbish();
 		originalBosk.driver().flush(); // Not the bosk that did refurbish!
 
 		LOGGER.debug("Check state after");
@@ -621,7 +621,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		);
 
 		// (Close this so it doesn't crash when we delete the "path" field)
-		((MongoDriver<TestEntity>)initialBosk.driver()).close();
+		initialBosk.getDriver(MongoDriver.class).close();
 
 		// Delete some metadata fields
 		MongoCollection<Document> collection = mongoService.client()
@@ -655,7 +655,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		}
 
 		// Refurbish
-		((MongoDriver<?>)bosk.driver()).refurbish();
+		bosk.getDriver(MongoDriver.class).refurbish();
 
 		// Verify the fields are all now there
 		try (MongoCursor<Document> cursor = collection.find(filterDoc).cursor()) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -91,7 +91,8 @@ public class SchemaEvolutionTest {
 		}
 
 		LOGGER.debug("Refurbish");
-		((MongoDriver<?>)toBosk.driver()).refurbish();
+		MongoDriver<TestEntity> driver = toBosk.getDriver(MongoDriver.class);
+		driver.refurbish();
 
 		LOGGER.debug("Perform fromBosk read");
 		try (var __ = fromBosk.readContext()) {
@@ -117,7 +118,8 @@ public class SchemaEvolutionTest {
 		Refs toRefs = toBosk.buildReferences(Refs.class);
 
 		LOGGER.debug("Refurbish toBosk ({})", toBosk.name());
-		((MongoDriver<?>)toBosk.driver()).refurbish();
+		MongoDriver<TestEntity> driver = toBosk.getDriver(MongoDriver.class);
+		driver.refurbish();
 
 		flushIfLiveRefurbishIsNotSupported(fromBosk, fromHelper, toHelper);
 


### PR DESCRIPTION
A new driver layer automatically inserted on the top of the driver stack to enforce validity rules that were previously being enforced by `LocalDriver`. The effect is to cause the enforcement to occur at submission time (when a `submit` method is called) instead of application time (when the change is incorporated into the local in-memory state).

Made slightly awkward by the fact that some tests like to get `bosk.driver()` and downcast it; this won't work anymore because `driver()` returns the validating layer now. Added another method called `getDriver` but this needs more work.