### PR TITLE
Read context filter only for safe HTTP methods

### DIFF
--- a/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/ReadContextFilter.java
+++ b/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/ReadContextFilter.java
@@ -1,24 +1,54 @@
 package works.bosk.spring.boot;
 
-import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.filter.OncePerRequestFilter;
 import works.bosk.Bosk;
+import works.bosk.exceptions.NoReadContextException;
 
 @Component
+@ControllerAdvice
 @RequiredArgsConstructor
-public class ReadContextFilter implements Filter {
+public class ReadContextFilter extends OncePerRequestFilter {
 	private final Bosk<?> bosk;
 
 	@Override
-	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-		try (var __ = bosk.readContext()) {
-			chain.doFilter(request, response);
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+		if (automaticallyOpenReadContext(request)) {
+			try (var __ = bosk.readContext()) {
+				filterChain.doFilter(request, response);
+			}
+		} else {
+			filterChain.doFilter(request, response);
 		}
 	}
+
+	/**
+	 * The "safe" HTTP methods won't change server state, so there's no reason not to
+	 * open a
+	 */
+	private boolean automaticallyOpenReadContext(HttpServletRequest request) {
+		return switch (request.getMethod()) {
+			case "GET", "HEAD", "OPTIONS" -> true;
+			default -> false;
+		};
+	}
+
+	@ExceptionHandler(NoReadContextException.class)
+	void handleException(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		LOGGER.error("Bosk read context was not opened automatically; the request handler method should open one by calling Bosk.readContext(). " +
+			"Request: {} {}", request.getMethod(), request.getRequestURI());
+		response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReadContextFilter.class);
 }

--- a/example-hello/build.gradle
+++ b/example-hello/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation project(':bosk-logback')
 
 	// A real project would pull this like any other library
 	implementation project(':bosk-spring-boot-3')

--- a/example-hello/src/main/java/works/bosk/hello/APIEndpoints.java
+++ b/example-hello/src/main/java/works/bosk/hello/APIEndpoints.java
@@ -1,6 +1,7 @@
 package works.bosk.hello;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +21,13 @@ public record APIEndpoints (
 	@GetMapping("/targets")
 	Object getTargets() {
 		return bosk.refs.targets().value();
+	}
+
+	/**
+	 * This should throw a 500. Useful for testing.
+	 */
+	@PostMapping("/noReadContext")
+	void noReadContext() {
+		bosk.rootReference().value();
 	}
 }

--- a/example-hello/src/main/java/works/bosk/hello/HelloApplication.java
+++ b/example-hello/src/main/java/works/bosk/hello/HelloApplication.java
@@ -2,6 +2,8 @@ package works.bosk.hello;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import works.bosk.logback.BoskLogFilter;
 
 @SpringBootApplication
 public class HelloApplication {
@@ -10,4 +12,9 @@ public class HelloApplication {
 		SpringApplication.run(HelloApplication.class, args);
 	}
 
+
+	@Bean
+	BoskLogFilter.LogController logController() {
+		return new BoskLogFilter.LogController();
+	}
 }

--- a/example-hello/src/main/java/works/bosk/hello/HelloBosk.java
+++ b/example-hello/src/main/java/works/bosk/hello/HelloBosk.java
@@ -9,11 +9,13 @@ import works.bosk.annotations.ReferencePath;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.hello.state.BoskState;
 import works.bosk.hello.state.Target;
+import works.bosk.logback.BoskLogFilter;
+import works.bosk.logback.BoskLogFilter.LogController;
 
 @Component
 public class HelloBosk extends Bosk<BoskState> {
-	public HelloBosk() throws InvalidTypeException {
-		super("Hello", BoskState.class, HelloBosk::defaultRoot, Bosk::simpleDriver);
+	public HelloBosk(LogController logController) throws InvalidTypeException {
+		super("Hello", BoskState.class, HelloBosk::defaultRoot, BoskLogFilter.withController(logController));
 	}
 
 	public final Refs refs = buildReferences(Refs.class);

--- a/example-hello/src/main/resources/application.properties
+++ b/example-hello/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 server.port=1111
 bosk.web.service-path=/bosk
+
+# Now that we use this in unit tests, quiet down the logging
+spring.main.banner-mode=off

--- a/example-hello/src/main/resources/logback.xml
+++ b/example-hello/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<filter class="works.bosk.logback.BoskLogFilter"/>
+		<encoder>
+			<pattern>%d %-5level [%thread] [%X{bosk.name}]%X{bosk.MongoDriver.transaction}%X{bosk.MongoDriver.event} %logger{25}: %msg%n</pattern>
+		</encoder>
+		<immediateFlush>true</immediateFlush>
+	</appender>
+	<root level="WARN">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+	<!-- How to add more tracing during unit tests
+	<logger name="works.bosk" level="INFO"/>
+	 -->
+
+</configuration>

--- a/example-hello/src/test/java/works/bosk/hello/HelloServiceEndpointsTest.java
+++ b/example-hello/src/test/java/works/bosk/hello/HelloServiceEndpointsTest.java
@@ -28,6 +28,7 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -174,6 +175,13 @@ public class HelloServiceEndpointsTest {
 		mvc.perform(get("/bosk/targets/" + INITIAL_TARGET.id()))
 			.andExpect(status().isNotFound());
 		assertHello();
+	}
+
+	@Test
+	void postWithoutReadContext_reportsError() throws Exception {
+		logController.setLogging(OFF, ReadContextFilter.class);
+		mvc.perform(post("/api/noReadContext"))
+			.andExpect(status().isInternalServerError());
 	}
 
 	private void assertGetReturns(Object object, String uri) throws Exception {


### PR DESCRIPTION
The "safe" methods (`GET`, `HEAD`, `OPTIONS`) can't change the bosk state anyway, so the only sensible policy for them is to open a read context by default to allow reads.

For all other methods, writes are expected, and so we leave it up to the application programmer to open read contexts as required. In particular, `PUT` and `DELETE` should not really be using read contexts anyway, except in exceptional circumstances.

The one exception to this is `POST` endpoints used "safely" in place of `GET` because the latter does not support a body. In that case, sadly, the application programmer will need to open their own read context.