### PR TITLE
Fix `ReplicaSet.initialRoot`

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -144,10 +144,6 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		RR apply(Bosk<RR> bosk) throws InvalidTypeException;
 	}
 
-	public Bosk(String name, Type rootType, R defaultRoot, DriverFactory<R> driverFactory) {
-		this(name, rootType, b->defaultRoot, driverFactory);
-	}
-
 	record UnderConstruction<RR extends StateTreeNode>(
 		String name,
 		Identifier instanceID,

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -12,6 +12,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import lombok.Getter;
@@ -116,13 +117,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			throw new IllegalArgumentException("Invalid root type " + rootType + ": " + e.getMessage(), e);
 		}
 
-		// Rather than pass `this` while it's still under construction,
-		// pass another object that contains the things that are available
-		// at this point.
-		//
 		UnderConstruction<R> boskInfo = new UnderConstruction<>(
-			name, instanceID, rootRef, this::registerHooks
-		);
+			name, instanceID, rootRef, this::registerHooks, new AtomicReference<>());
 
 		// We do this as late as possible because the driver factory is allowed
 		// to do such things as create References, so it needs the rest of the
@@ -138,6 +134,9 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 
 		// Type check
 		rawClass(rootType).cast(this.currentRoot);
+
+		// Ok, we're done initializing
+		boskInfo.boskRef().set(this);
 	}
 
 	public interface DefaultRootFunction<RR extends StateTreeNode> {
@@ -148,11 +147,22 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		String name,
 		Identifier instanceID,
 		RootReference<RR> rootReference,
-		RegisterHooksMethod m
+		RegisterHooksMethod m,
+		AtomicReference<Bosk<RR>> boskRef
 	) implements BoskInfo<RR> {
 		@Override
 		public void registerHooks(Object receiver) throws InvalidTypeException {
 			m.registerHooks(receiver);
+		}
+
+		@Override
+		public Bosk<RR> bosk() {
+			var result = boskRef.get();
+			if (result == null) {
+				throw new IllegalStateException("Bosk is not yet initialized");
+			} else {
+				return result;
+			}
 		}
 	}
 
@@ -599,6 +609,11 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	@Override
 	public void registerHooks(Object receiver) throws InvalidTypeException {
 		HookRegistrar.registerHooks(receiver, this);
+	}
+
+	@Override
+	public Bosk<R> bosk() {
+		return this;
 	}
 
 	public Collection<HookRegistration<?>> allRegisteredHooks() {

--- a/bosk-core/src/main/java/works/bosk/BoskInfo.java
+++ b/bosk-core/src/main/java/works/bosk/BoskInfo.java
@@ -3,12 +3,17 @@ package works.bosk;
 import works.bosk.exceptions.InvalidTypeException;
 
 /**
- * Provides access to a subset of bosk functionality that is available at the time
- * the {@link BoskDriver} is built, before the {@link Bosk} itself is fully initialized.
+ * Provides access to a subset of bosk functionality that is available while the
+ * {@link BoskDriver} is being constructed, before the {@link Bosk} itself is fully initialized.
  */
 public interface BoskInfo<R extends StateTreeNode> {
 	String name();
 	Identifier instanceID();
 	RootReference<R> rootReference();
 	void registerHooks(Object receiver) throws InvalidTypeException;
+
+	/**
+	 * @throws IllegalStateException if called before the {@link Bosk} constructor returns
+	 */
+	Bosk<R> bosk();
 }

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -113,7 +113,7 @@ public class BoskConstructorTest {
 	void defaultRoot_matches() {
 		SimpleTypes root = newEntity();
 		{
-			Bosk<StateTreeNode> valueBosk = new Bosk<>(boskName(), SimpleTypes.class, root, Bosk::simpleDriver);
+			Bosk<StateTreeNode> valueBosk = new Bosk<>(boskName(), SimpleTypes.class, _ -> root, Bosk::simpleDriver);
 			try (var _ = valueBosk.readContext()) {
 				assertSame(root, valueBosk.rootReference().value());
 			}
@@ -132,15 +132,21 @@ public class BoskConstructorTest {
 	//  Helpers
 	//
 
+	/**
+	 * The "initial root" is the one returned from the driver.
+	 */
 	private static void assertInitialRootThrows(Class<? extends Throwable> expectedType, InitialRootFunction initialRootFunction) {
 		assertThrows(expectedType, () -> new Bosk<>(
 			boskName(),
 			SimpleTypes.class,
-			newEntity(),
+			_ -> newEntity(),
 			initialRootDriver(initialRootFunction)
 		));
 	}
 
+	/**
+	 * The "default root" is the one passed to the bosk constructor.
+	 */
 	private static void assertDefaultRootThrows(Class<? extends Throwable> expectedType, DefaultRootFunction<StateTreeNode> defaultRootFunction) {
 		assertThrows(expectedType, () -> new Bosk<>(
 			boskName(),

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -68,7 +68,7 @@ class BoskLocalReferenceTest {
 	void initializeBosk() throws InvalidTypeException {
 		boskName = boskName();
 		Root initialRoot = new Root(1, Catalog.empty());
-		bosk = new Bosk<>(boskName, Root.class, initialRoot, Bosk::simpleDriver);
+		bosk = new Bosk<>(boskName, Root.class, _ -> initialRoot, Bosk::simpleDriver);
 		refs = bosk.rootReference().buildReferences(Refs.class);
 		Identifier ernieID = Identifier.from("ernie");
 		Identifier bertID = Identifier.from("bert");
@@ -271,8 +271,8 @@ class BoskLocalReferenceTest {
 				this.mutableString = str;
 			}
 		}
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
+		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
+		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
 	}
 
 	@RequiredArgsConstructor

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -54,7 +54,7 @@ class ListingTest {
 			return childrenStream
 					.map(children -> {
 						TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, root, Bosk::simpleDriver);
+						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk::simpleDriver);
 						CatalogReference<TestEntity> catalog;
 						try {
 							catalog = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
@@ -73,7 +73,7 @@ class ListingTest {
 			TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 			List<TestEntity> children = singletonList(child);
 			TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, root, Bosk::simpleDriver);
+			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk::simpleDriver);
 			CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 			return idStreams().map(list -> Arguments.of(list.map(Identifier::from).collect(toList()), childrenRef, bosk));
 		}
@@ -248,7 +248,7 @@ class ListingTest {
 		TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 		List<TestEntity> children = singletonList(child);
 		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, root, Bosk::simpleDriver);
+		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk::simpleDriver);
 		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 
 		Listing<TestEntity> actual = Listing.empty(childrenRef);

--- a/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
+++ b/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
@@ -23,7 +23,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 
 	@Test
 	void testReferenceOptionalNotAllowed() {
-		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, new OptionalString(ID, Optional.empty()), Bosk::simpleDriver);
+		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, _ -> new OptionalString(ID, Optional.empty()), Bosk::simpleDriver);
 		InvalidTypeException e = assertThrows(InvalidTypeException.class, () -> bosk.rootReference().then(Optional.class, Path.just("field")));
 		assertThat(e.getMessage(), containsString("not supported"));
 	}
@@ -117,7 +117,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 	}
 
 	private <E extends Entity, V> void doTest(E initialRoot, ValueFactory<E, V> valueFactory, DriverFactory<E> driverFactory) throws InvalidTypeException {
-		Bosk<E> bosk = new Bosk<>(boskName(), initialRoot.getClass(), initialRoot, driverFactory);
+		Bosk<E> bosk = new Bosk<>(boskName(), initialRoot.getClass(), _ -> initialRoot, driverFactory);
 		V value = valueFactory.createFrom(bosk);
 		@SuppressWarnings("unchecked")
 		Reference<V> optionalRef = bosk.rootReference().then((Class<V>)value.getClass(), "field");

--- a/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
@@ -19,7 +19,7 @@ public class ReferenceErrorTest {
 		bosk = new Bosk<>(
 			boskName(),
 			BadGetters.class,
-			new BadGetters(Identifier.from("test"), new NestedObject(Optional.of("stringValue"))),
+			_ -> new BadGetters(Identifier.from("test"), new NestedObject(Optional.of("stringValue"))),
 			Bosk::simpleDriver);
 	}
 

--- a/bosk-core/src/test/java/works/bosk/VariantTest.java
+++ b/bosk-core/src/test/java/works/bosk/VariantTest.java
@@ -47,7 +47,7 @@ class VariantTest extends AbstractBoskTest {
 	@Test
 	void test() throws InvalidTypeException, IOException, InterruptedException {
 		String stringValue = "test";
-		var bosk = new Bosk<>(boskName(), BoskState.class, new BoskState(new StringCase(stringValue)), Bosk::simpleDriver);
+		var bosk = new Bosk<>(boskName(), BoskState.class, _ -> new BoskState(new StringCase(stringValue)), Bosk::simpleDriver);
 		var refs = bosk.rootReference().buildReferences(Refs.class);
 		try (var _ = bosk.readContext()) {
 			assertEquals(stringValue, refs.stringValue().value());

--- a/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
+++ b/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
@@ -269,10 +269,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 			.getConstructor(Identifier.class)
 			.newInstance(rootID);
 		Bosk<StateTreeNode> differentBosk = new Bosk<>(
-			boskName("Different"),
-			differentRootClass,
-			initialRoot,
-			Bosk::simpleDriver
+			boskName("Different"), differentRootClass, _ -> initialRoot, Bosk::simpleDriver
 		);
 		Reference<Identifier> idRef = differentBosk.rootReference().then(Identifier.class, Path.parse(
 			"/id" ));

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
@@ -14,7 +14,7 @@ class ReplicaSetConformanceTest extends DriverConformanceTest {
 	@BeforeEach
 	void setupDriverFactory() {
 		ReplicaSet<TestEntity> replicaSet = new ReplicaSet<>();
-		replicaBosk = new Bosk<TestEntity>(
+		replicaBosk = new Bosk<>(
 			boskName("Replica"),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetTest.java
@@ -18,11 +18,28 @@ public class ReplicaSetTest extends AbstractDriverTest {
 	@Test
 	void joinAfterUpdate_correctInitialState() throws InvalidTypeException {
 		var replicaSet = new ReplicaSet<TestEntity>();
-		var bosk1 = new Bosk<TestEntity>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var bosk1 = new Bosk<>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
 		var refs1 = bosk1.rootReference().buildReferences(Refs.class);
 		bosk1.driver().submitReplacement(refs1.string(), "New value");
 
-		var bosk2 = new Bosk<TestEntity>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var bosk2 = new Bosk<>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var refs2 = bosk2.rootReference().buildReferences(Refs.class);
+		try (var _ = bosk2.readContext()) {
+			assertEquals("New value", refs2.string().value());
+		}
+	}
+
+	@Test
+	void secondaryConstructedInPrimaryReadContext_seesLatestState() throws InvalidTypeException {
+		var replicaSet = new ReplicaSet<TestEntity>();
+		var bosk1 = new Bosk<>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var refs1 = bosk1.rootReference().buildReferences(Refs.class);
+
+		Bosk<TestEntity> bosk2;
+		try (var _ = bosk1.readContext()) {
+			bosk1.driver().submitReplacement(refs1.string(), "New value");
+			bosk2 = new Bosk<>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		}
 		var refs2 = bosk2.rootReference().buildReferences(Refs.class);
 		try (var _ = bosk2.readContext()) {
 			assertEquals("New value", refs2.string().value());

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetTest.java
@@ -1,0 +1,31 @@
+package works.bosk.drivers;
+
+import org.junit.jupiter.api.Test;
+import works.bosk.Bosk;
+import works.bosk.Reference;
+import works.bosk.annotations.ReferencePath;
+import works.bosk.drivers.state.TestEntity;
+import works.bosk.exceptions.InvalidTypeException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.BoskTestUtils.boskName;
+
+public class ReplicaSetTest extends AbstractDriverTest {
+	public interface Refs {
+		@ReferencePath("/string") Reference<String> string();
+	}
+
+	@Test
+	void joinAfterUpdate_correctInitialState() throws InvalidTypeException {
+		var replicaSet = new ReplicaSet<TestEntity>();
+		var bosk1 = new Bosk<TestEntity>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var refs1 = bosk1.rootReference().buildReferences(Refs.class);
+		bosk1.driver().submitReplacement(refs1.string(), "New value");
+
+		var bosk2 = new Bosk<TestEntity>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var refs2 = bosk2.rootReference().buildReferences(Refs.class);
+		try (var _ = bosk2.readContext()) {
+			assertEquals("New value", refs2.string().value());
+		}
+	}
+}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/example/ExampleBosk.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/example/ExampleBosk.java
@@ -15,7 +15,7 @@ public class ExampleBosk extends Bosk<ExampleState> {
 		super(
 			"ExampleBosk",
 			ExampleState.class,
-			defaultRoot(),
+			_ -> defaultRoot(),
 			driverFactory());
 	}
 


### PR DESCRIPTION
Before, `ReplicaSet.initialRoot` delegated to one of the downstream drivers. This is wrong in several ways:

1. It is incorrect in general to call `initialRoot` twice on the same driver, according to its javadocs.
2. This would return the _original_ initial root even if the replica set has received some state updates in the mean time, leaving new replicas with the wrong state.

Nothing actually needed this yet, but I wanted to "get it right".