### PR TITLE
Remove generic parameter from BoskDriver

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -174,11 +174,11 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * You can use <code>Bosk::simpleDriver</code> as the
 	 * <code>driverFactory</code> if you don't want any additional driver functionality.
 	 */
-	public static <RR extends StateTreeNode> BoskDriver<RR> simpleDriver(@SuppressWarnings("unused") BoskInfo<RR> boskInfo, BoskDriver<RR> downstream) {
+	public static <RR extends StateTreeNode> BoskDriver simpleDriver(@SuppressWarnings("unused") BoskInfo<RR> boskInfo, BoskDriver downstream) {
 		return downstream;
 	}
 
-	public BoskDriver<R> driver() {
+	public BoskDriver driver() {
 		return driver;
 	}
 
@@ -192,7 +192,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * @throws IllegalArgumentException if there is no unique driver of the given type
 	 */
 	@SuppressWarnings("unchecked")
-	public <D extends BoskDriver<R>> D getDriver(Class<? super D> driverType) {
+	public <D extends BoskDriver> D getDriver(Class<? super D> driverType) {
 		var userSuppliedDriver = driver.downstream;
 		if (driverType.isInstance(userSuppliedDriver)) {
 			return (D)driverType.cast(userSuppliedDriver);
@@ -206,8 +206,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * requirements of the {@link BoskDriver} are enforced.
 	 */
 	@RequiredArgsConstructor
-	final class ValidatingDriver implements BoskDriver<R> {
-		final BoskDriver<R> downstream;
+	final class ValidatingDriver implements BoskDriver {
+		final BoskDriver downstream;
 
 		@Override
 		public <T> void submitReplacement(Reference<T> target, T newValue) {
@@ -295,7 +295,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * @author pdoyle
 	 */
 	@RequiredArgsConstructor
-	private final class LocalDriver implements BoskDriver<R> {
+	private final class LocalDriver implements BoskDriver {
 		final DefaultRootFunction<R> initialRootFunction;
 		final Deque<Runnable> hookExecutionQueue = new ConcurrentLinkedDeque<>();
 		final Semaphore hookExecutionPermit = new Semaphore(1);

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -127,7 +127,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		this.driver = new ValidatingDriver(driverFactory.build(boskInfo, this.localDriver));
 
 		try {
-			this.currentRoot = requireNonNull(driver.initialRoot(rootType));
+			this.currentRoot = rootRef.targetClass().cast(requireNonNull(driver.initialRoot(rootType)));
 		} catch (InvalidTypeException | IOException | InterruptedException e) {
 			throw new IllegalArgumentException("Error computing initial root: " + e.getMessage(), e);
 		}
@@ -246,8 +246,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		@Override
-		public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
-			return downstream.initialRoot(rootType);
+		public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+			return rootRef.targetClass().cast(downstream.initialRoot(rootType));
 		}
 
 		@Override
@@ -301,7 +301,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		final Semaphore hookExecutionPermit = new Semaphore(1);
 
 		@Override
-		public R initialRoot(Type rootType) throws InvalidTypeException {
+		public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException {
 			R initialRoot = requireNonNull(initialRootFunction.apply(Bosk.this));
 			rawClass(rootType).cast(initialRoot);
 			return initialRoot;

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -38,6 +38,7 @@ public interface BoskDriver {
 	 * that creates {@link Reference References} (which is very common) so that implementations
 	 * do not need to catch that exception and wrap it or otherwise deal with it:
 	 * the caller of this method is expected to know how to deal with that exception.
+	 * @return an instance of {@code rootType}
 	 * @throws UnsupportedOperationException if this driver is unable to provide
 	 * an initial root. Such a driver cannot be used on its own to initialize a Bosk,
 	 * but it can be used downstream of a {@link ForwardingDriver} provided there is

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -12,7 +12,7 @@ import works.bosk.exceptions.InvalidTypeException;
  *
  * @author pdoyle
  */
-public interface BoskDriver<R extends StateTreeNode> {
+public interface BoskDriver {
 	/**
 	 * Returns the root object the {@link Bosk} should use as its initial state upon
 	 * returning from its constructor.
@@ -45,7 +45,7 @@ public interface BoskDriver<R extends StateTreeNode> {
 	 *
 	 * @see InitializationFailureException
 	 */
-	R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException;
+	StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException;
 
 	/**
 	 * Requests that the object referenced by <code>target</code> be changed to <code>newValue</code>.

--- a/bosk-core/src/main/java/works/bosk/DriverFactory.java
+++ b/bosk-core/src/main/java/works/bosk/DriverFactory.java
@@ -1,5 +1,9 @@
 package works.bosk;
 
+/**
+ * @param <R> permits us to ensure at compile time that the driver factories
+ *           for a given bosk are all prepared to use the same root type.
+ */
 public interface DriverFactory<R extends StateTreeNode> {
 	BoskDriver build(BoskInfo<R> boskInfo, BoskDriver downstream);
 }

--- a/bosk-core/src/main/java/works/bosk/DriverFactory.java
+++ b/bosk-core/src/main/java/works/bosk/DriverFactory.java
@@ -1,5 +1,5 @@
 package works.bosk;
 
 public interface DriverFactory<R extends StateTreeNode> {
-	BoskDriver<R> build(BoskInfo<R> boskInfo, BoskDriver<R> downstream);
+	BoskDriver build(BoskInfo<R> boskInfo, BoskDriver downstream);
 }

--- a/bosk-core/src/main/java/works/bosk/DriverStack.java
+++ b/bosk-core/src/main/java/works/bosk/DriverStack.java
@@ -28,8 +28,8 @@ public interface DriverStack<R extends StateTreeNode> extends DriverFactory<R> {
 	static <RR extends StateTreeNode> DriverStack<RR> of(List<DriverFactory<RR>> factories) {
 		return new DriverStack<>() {
 			@Override
-			public BoskDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver<RR> downstream) {
-				BoskDriver<RR> result = downstream;
+			public BoskDriver build(BoskInfo<RR> boskInfo, BoskDriver downstream) {
+				BoskDriver result = downstream;
 				for (int i = factories.size() - 1; i >= 0; i--) {
 					result = factories.get(i).build(boskInfo, result);
 				}

--- a/bosk-core/src/main/java/works/bosk/SerializationPlugin.java
+++ b/bosk-core/src/main/java/works/bosk/SerializationPlugin.java
@@ -273,7 +273,7 @@ public abstract class SerializationPlugin {
 		}
 	}
 
-	public <R extends StateTreeNode> void initializeEnclosingPolyfills(Reference<?> target, BoskDriver<R> driver) {
+	public <R extends StateTreeNode> void initializeEnclosingPolyfills(Reference<?> target, BoskDriver driver) {
 		if (!ANY_POLYFILLS.get()) {
 			return;
 		}
@@ -296,7 +296,7 @@ public abstract class SerializationPlugin {
 		}
 	}
 
-	private <R extends StateTreeNode, T> void initializePolyfills(Reference<T> ref, BoskDriver<R> driver) {
+	private <R extends StateTreeNode, T> void initializePolyfills(Reference<T> ref, BoskDriver driver) {
 		initializeEnclosingPolyfills(ref, driver);
 		if (!ref.path().isEmpty()) {
 			Class<?> enclosing;

--- a/bosk-core/src/main/java/works/bosk/drivers/BufferingDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/BufferingDriver.java
@@ -32,20 +32,20 @@ import static lombok.AccessLevel.PROTECTED;
  * @author pdoyle
  */
 @RequiredArgsConstructor(access = PROTECTED)
-public class BufferingDriver<R extends StateTreeNode> implements BoskDriver {
+public class BufferingDriver implements BoskDriver {
 	private final BoskDriver downstream;
 	private final Deque<Consumer<BoskDriver>> updateQueue = new ConcurrentLinkedDeque<>();
 
-	public static <RR extends StateTreeNode> BufferingDriver<RR> writingTo(BoskDriver downstream) {
-		return new BufferingDriver<>(downstream);
+	public static BufferingDriver writingTo(BoskDriver downstream) {
+		return new BufferingDriver(downstream);
 	}
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory() {
-		return (b,d) -> new BufferingDriver<>(d);
+		return (b,d) -> new BufferingDriver(d);
 	}
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		return downstream.initialRoot(rootType);
 	}
 

--- a/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
@@ -20,17 +20,17 @@ import static lombok.AccessLevel.PRIVATE;
  * Allows diagnostic context to be supplied automatically to every operation.
  */
 @RequiredArgsConstructor(access = PRIVATE)
-public class DiagnosticScopeDriver<R extends StateTreeNode> implements BoskDriver {
+public class DiagnosticScopeDriver implements BoskDriver {
 	final BoskDriver downstream;
 	final BoskDiagnosticContext diagnosticContext;
 	final Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier) {
-		return (b,d) -> new DiagnosticScopeDriver<>(d, b.rootReference().diagnosticContext(), scopeSupplier);
+		return (b,d) -> new DiagnosticScopeDriver(d, b.rootReference().diagnosticContext(), scopeSupplier);
 	}
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		try (var __ = scopeSupplier.apply(diagnosticContext)) {
 			return downstream.initialRoot(rootType);
 		}

--- a/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
@@ -20,8 +20,8 @@ import static lombok.AccessLevel.PRIVATE;
  * Allows diagnostic context to be supplied automatically to every operation.
  */
 @RequiredArgsConstructor(access = PRIVATE)
-public class DiagnosticScopeDriver<R extends StateTreeNode> implements BoskDriver<R> {
-	final BoskDriver<R> downstream;
+public class DiagnosticScopeDriver<R extends StateTreeNode> implements BoskDriver {
+	final BoskDriver downstream;
 	final BoskDiagnosticContext diagnosticContext;
 	final Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier;
 

--- a/bosk-core/src/main/java/works/bosk/drivers/ForwardingDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ForwardingDriver.java
@@ -18,11 +18,11 @@ import works.bosk.exceptions.InvalidTypeException;
  * point to the right bosk. The references must already be from the downstream bosk.
  */
 @RequiredArgsConstructor
-public class ForwardingDriver<R extends StateTreeNode> implements BoskDriver {
+public class ForwardingDriver implements BoskDriver {
 	protected final BoskDriver downstream;
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		return downstream.initialRoot(rootType);
 	}
 

--- a/bosk-core/src/main/java/works/bosk/drivers/ForwardingDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ForwardingDriver.java
@@ -18,8 +18,8 @@ import works.bosk.exceptions.InvalidTypeException;
  * point to the right bosk. The references must already be from the downstream bosk.
  */
 @RequiredArgsConstructor
-public class ForwardingDriver<R extends StateTreeNode> implements BoskDriver<R> {
-	protected final BoskDriver<R> downstream;
+public class ForwardingDriver<R extends StateTreeNode> implements BoskDriver {
+	protected final BoskDriver downstream;
 
 	@Override
 	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {

--- a/bosk-core/src/main/java/works/bosk/drivers/NoOpDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/NoOpDriver.java
@@ -9,13 +9,13 @@ import works.bosk.Reference;
 import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
-public class NoOpDriver<R extends StateTreeNode> implements BoskDriver {
+public class NoOpDriver implements BoskDriver {
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory() {
-		return (b,d) -> new NoOpDriver<>();
+		return (b,d) -> new NoOpDriver();
 	}
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/bosk-core/src/main/java/works/bosk/drivers/NoOpDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/NoOpDriver.java
@@ -9,7 +9,7 @@ import works.bosk.Reference;
 import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
-public class NoOpDriver<R extends StateTreeNode> implements BoskDriver<R> {
+public class NoOpDriver<R extends StateTreeNode> implements BoskDriver {
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory() {
 		return (b,d) -> new NoOpDriver<>();
 	}

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -123,7 +123,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 		 * as obtained by {@link Bosk#supersedingReadContext()}.
 		 */
 		@Override
-		public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+		public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 			assert !replicas.isEmpty(): "Replicas must be added during by the driver factory before the drivers are used";
 			var primary = requireNonNull(ReplicaSet.this.primary.get());
 			if (isInitialized.getAndSet(true)) {

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -97,7 +97,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 	public static <RR extends StateTreeNode> DriverFactory<RR> mirroringTo(Bosk<RR>... mirrors) {
 		var replicaSet = new ReplicaSet<RR>();
 		for (var m: mirrors) {
-			BoskDriver<RR> downstream = m.driver();
+			BoskDriver downstream = m.driver();
 			replicaSet.replicas.add(new Replica<>(m, downstream));
 		}
 		return replicaSet.driverFactory();
@@ -108,7 +108,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 	 * The resulting driver can accept references to a different bosk
 	 * with the same root type.
 	 */
-	public static <RR extends StateTreeNode> BoskDriver<RR> redirectingTo(Bosk<RR> other) {
+	public static <RR extends StateTreeNode> BoskDriver redirectingTo(Bosk<RR> other) {
 		// A ReplicaSet with only the one replica
 		return new ReplicaSet<RR>()
 			.driverFactory().build(
@@ -117,7 +117,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 			);
 	}
 
-	final class BroadcastDriver implements BoskDriver<R> {
+	final class BroadcastDriver implements BoskDriver {
 		/**
 		 * @return the <em>current state</em> of the replica set, which is the state of its primary
 		 * as obtained by {@link Bosk#supersedingReadContext()}.
@@ -208,7 +208,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 	 */
 	record Replica<R extends StateTreeNode>(
 		BoskInfo<R> boskInfo,
-		BoskDriver<R> driver
+		BoskDriver driver
 	) {
 		public RootReference<R> rootReference() {
 			return boskInfo.rootReference();

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -68,6 +68,13 @@ public class ReplicaSet<R extends StateTreeNode> {
 			replicas.add(replica);
 			return broadcastDriver;
 		};
+
+		/*
+		 * Note: there's a subtle and interesting thing going on here.
+		 * Most driver factories can accept a bosk and a driver of any matching root type,
+		 * but this one requires a root type of R specifically. This enforces the rule that
+		 * all the bosks in a replica set must have the same root type.
+		 */
 	}
 
 	/**

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -31,7 +31,7 @@ public class BoskConstructorTest {
 		Type rootType = SimpleTypes.class;
 		StateTreeNode root = newEntity();
 
-		AtomicReference<BoskDriver<StateTreeNode>> driver = new AtomicReference<>();
+		AtomicReference<BoskDriver> driver = new AtomicReference<>();
 		Bosk<StateTreeNode> bosk = new Bosk<StateTreeNode>(
 			name,
 			rootType,

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -37,7 +37,7 @@ public class BoskConstructorTest {
 			rootType,
 			_ -> root,
 			(_, d)-> {
-				driver.set(new ForwardingDriver<>(d));
+				driver.set(new ForwardingDriver(d));
 				return driver.get();
 			});
 
@@ -158,7 +158,7 @@ public class BoskConstructorTest {
 
 	@NotNull
 	private static DriverFactory<StateTreeNode> initialRootDriver(InitialRootFunction initialRootFunction) {
-		return (_, _) -> new NoOpDriver<>() {
+		return (_, _) -> new NoOpDriver() {
 			@Override
 			public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 				return initialRootFunction.get();

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -15,7 +15,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.With;
-import lombok.experimental.Delegate;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.FieldNameConstants;
 import org.junit.jupiter.api.BeforeEach;
@@ -273,11 +272,6 @@ class BoskLocalReferenceTest {
 		}
 		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
 		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
-	}
-
-	@RequiredArgsConstructor
-	private static final class ProxyDriver implements BoskDriver {
-		@Delegate final BoskDriver delegate;
 	}
 
 	private <T> void checkReferenceProperties(Reference<T> ref, Path expectedPath, T expectedValue) throws InvalidTypeException {

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -276,8 +276,8 @@ class BoskLocalReferenceTest {
 	}
 
 	@RequiredArgsConstructor
-	private static final class ProxyDriver implements BoskDriver<Root> {
-		@Delegate final BoskDriver<Root> delegate;
+	private static final class ProxyDriver implements BoskDriver {
+		@Delegate final BoskDriver delegate;
 	}
 
 	private <T> void checkReferenceProperties(Reference<T> ref, Path expectedPath, T expectedValue) throws InvalidTypeException {

--- a/bosk-core/src/test/java/works/bosk/DriverStackTest.java
+++ b/bosk-core/src/test/java/works/bosk/DriverStackTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class DriverStackTest {
-	final BoskDriver baseDriver = new NoOpDriver<>();
+	final BoskDriver baseDriver = new NoOpDriver();
 
 	@Test
 	void emptyStack_returnsDownstream() {
@@ -32,7 +32,7 @@ class DriverStackTest {
 		assertSame(baseDriver, thirdDriver);
 	}
 
-	static class TestDriver<R extends Entity> extends ForwardingDriver<R> {
+	static class TestDriver<R extends Entity> extends ForwardingDriver {
 		final String name;
 
 		public TestDriver(String name, BoskDriver downstream) {

--- a/bosk-core/src/test/java/works/bosk/DriverStackTest.java
+++ b/bosk-core/src/test/java/works/bosk/DriverStackTest.java
@@ -8,11 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class DriverStackTest {
-	final BoskDriver<AbstractBoskTest.TestEntity> baseDriver = new NoOpDriver<>();
+	final BoskDriver baseDriver = new NoOpDriver<>();
 
 	@Test
 	void emptyStack_returnsDownstream() {
-		BoskDriver<AbstractBoskTest.TestEntity> actual = DriverStack.<AbstractBoskTest.TestEntity>of().build(null, baseDriver);
+		BoskDriver actual = DriverStack.<AbstractBoskTest.TestEntity>of().build(null, baseDriver);
 		assertSame(baseDriver, actual);
 	}
 
@@ -25,7 +25,7 @@ class DriverStackTest {
 
 		TestDriver<AbstractBoskTest.TestEntity> firstDriver = (TestDriver<AbstractBoskTest.TestEntity>) stack.build(null, baseDriver);
 		TestDriver<AbstractBoskTest.TestEntity> secondDriver = (TestDriver<AbstractBoskTest.TestEntity>) firstDriver.downstream();
-		BoskDriver<AbstractBoskTest.TestEntity> thirdDriver = secondDriver.downstream();
+		BoskDriver thirdDriver = secondDriver.downstream();
 
 		assertEquals("first", firstDriver.name);
 		assertEquals("second", secondDriver.name);
@@ -35,12 +35,12 @@ class DriverStackTest {
 	static class TestDriver<R extends Entity> extends ForwardingDriver<R> {
 		final String name;
 
-		public TestDriver(String name, BoskDriver<R> downstream) {
+		public TestDriver(String name, BoskDriver downstream) {
 			super(downstream);
 			this.name = name;
 		}
 
-		BoskDriver<R> downstream() {
+		BoskDriver downstream() {
 			return downstream;
 		}
 

--- a/bosk-core/src/test/java/works/bosk/drivers/ForwardingDriverConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ForwardingDriverConformanceTest.java
@@ -6,7 +6,7 @@ public class ForwardingDriverConformanceTest extends DriverConformanceTest {
 
 	@BeforeEach
 	void setupDriverFactory() {
-		driverFactory = (_, d)-> new ForwardingDriver<>(d);
+		driverFactory = (_, d)-> new ForwardingDriver(d);
 	}
 
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/FormatDriver.java
@@ -35,7 +35,7 @@ import works.bosk.exceptions.InitializationFailureException;
  * </li></ol>
  */
 sealed interface FormatDriver<R extends StateTreeNode>
-	extends MongoDriver<R>
+	extends MongoDriver
 	permits AbstractFormatDriver, DisconnectedDriver {
 	void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException;
 
@@ -68,7 +68,7 @@ sealed interface FormatDriver<R extends StateTreeNode>
 	void initializeCollection(StateAndMetadata<R> priorContents) throws InitializationFailureException;
 
 	@Override
-	default R initialRoot(Type rootType) {
+	default StateTreeNode initialRoot(Type rootType) {
 		throw new UnsupportedOperationException(
 			"FormatDriver doesn't need to implement initialRoot: MainDriver derives it from loadAllState");
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
@@ -59,7 +59,7 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 	private final ChangeReceiver receiver;
 	private final MongoDriverSettings driverSettings;
 	private final BsonPlugin bsonPlugin;
-	private final BoskDriver<R> downstream;
+	private final BoskDriver downstream;
 	private final TransactionalCollection<BsonDocument> collection;
 	private final Listener listener;
 	final Formatter formatter;
@@ -83,7 +83,7 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver<R> {
 		MongoClientSettings clientSettings,
 		MongoDriverSettings driverSettings,
 		BsonPlugin bsonPlugin,
-		BoskDriver<R> downstream
+		BoskDriver downstream
 	) {
 		try (MDCScope __ = setupMDC(boskInfo.name(), boskInfo.instanceID())) {
 			this.boskInfo = boskInfo;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriver.java
@@ -21,7 +21,7 @@ import works.bosk.drivers.mongo.status.MongoStatus;
  * {@link BoskDriver#initialRoot} on the downstream driver.
  */
 public sealed interface MongoDriver<R extends StateTreeNode>
-	extends BoskDriver<R>
+	extends BoskDriver
 	permits MainDriver, FormatDriver {
 
 	/**
@@ -74,6 +74,6 @@ public sealed interface MongoDriver<R extends StateTreeNode>
 	}
 
 	interface MongoDriverFactory<RR extends StateTreeNode> extends DriverFactory<RR> {
-		@Override MongoDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver<RR> downstream);
+		@Override MongoDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver downstream);
 	}
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriver.java
@@ -20,7 +20,7 @@ import works.bosk.drivers.mongo.status.MongoStatus;
  * this driver will create it and populate it with the state returned by calling
  * {@link BoskDriver#initialRoot} on the downstream driver.
  */
-public sealed interface MongoDriver<R extends StateTreeNode>
+public sealed interface MongoDriver
 	extends BoskDriver
 	permits MainDriver, FormatDriver {
 
@@ -74,6 +74,6 @@ public sealed interface MongoDriver<R extends StateTreeNode>
 	}
 
 	interface MongoDriverFactory<RR extends StateTreeNode> extends DriverFactory<RR> {
-		@Override MongoDriver<RR> build(BoskInfo<RR> boskInfo, BoskDriver downstream);
+		@Override MongoDriver build(BoskInfo<RR> boskInfo, BoskDriver downstream);
 	}
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormatDriver.java
@@ -67,7 +67,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	private final PandoFormat format;
 	private final MongoDriverSettings settings;
 	private final TransactionalCollection<BsonDocument> collection;
-	private final BoskDriver<R> downstream;
+	private final BoskDriver downstream;
 	private final FlushLock flushLock;
 	private final BsonSurgeon bsonSurgeon;
 	private final Demultiplexer demultiplexer = new Demultiplexer();
@@ -82,7 +82,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		MongoDriverSettings driverSettings,
 		PandoFormat format, BsonPlugin bsonPlugin,
 		FlushLock flushLock,
-		BoskDriver<R> downstream
+		BoskDriver downstream
 	) {
 		super(boskInfo.rootReference(), new Formatter(boskInfo, bsonPlugin));
 		this.description = getClass().getSimpleName() + ": " + driverSettings;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -54,7 +54,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	private final String description;
 	private final MongoDriverSettings settings;
 	private final MongoCollection<BsonDocument> collection;
-	private final BoskDriver<R> downstream;
+	private final BoskDriver downstream;
 	private final FlushLock flushLock;
 
 	private volatile BsonInt64 revisionToSkip = null;
@@ -67,7 +67,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 		MongoDriverSettings driverSettings,
 		BsonPlugin bsonPlugin,
 		FlushLock flushLock,
-		BoskDriver<R> downstream
+		BoskDriver downstream
 	) {
 		super(boskInfo.rootReference(), new Formatter(boskInfo, bsonPlugin));
 		this.description = getClass().getSimpleName() + ": " + driverSettings;

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/AbstractMongoDriverTest.java
@@ -128,7 +128,7 @@ abstract class AbstractMongoDriverTest {
 
 	protected <E extends Entity> DriverFactory<E> createDriverFactory(BoskLogFilter.LogController logController) {
 		DriverFactory<E> mongoDriverFactory = (boskInfo, downstream) -> {
-			MongoDriver<E> driver = MongoDriver.<E>factory(
+			MongoDriver driver = MongoDriver.<E>factory(
 				MongoClientSettings.builder(mongoService.clientSettings())
 					.applyToClusterSettings(builder -> {
 						builder.serverSelectionTimeout(5, SECONDS);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverConformanceTest.java
@@ -57,7 +57,7 @@ class MongoDriverConformanceTest extends DriverConformanceTest {
 
 	private <R extends StateTreeNode> DriverFactory<R> createDriverFactory() {
 		return (boskInfo, downstream) -> {
-			MongoDriver<R> driver = MongoDriver.<R>factory(
+			MongoDriver driver = MongoDriver.<R>factory(
 				mongoService.clientSettings(), driverSettings, new BsonPlugin()
 			).build(boskInfo, downstream);
 			tearDownActions.addFirst(()->{

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverHanoiTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverHanoiTest.java
@@ -22,7 +22,7 @@ public class MongoDriverHanoiTest extends HanoiTest {
 	public MongoDriverHanoiTest(TestParameters.ParameterSet parameters) {
 		MongoDriverSettings settings = parameters.driverSettingsBuilder().build();
 		this.driverFactory = DriverStack.of(
-			(b,d) -> { shutdownOperations.add(((MongoDriver<?>)d)::close); return d;},
+			(_,d) -> { shutdownOperations.add(((MongoDriver)d)::close); return d;},
 			MongoDriver.factory(
 				mongoService.clientSettings(),
 				settings,

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
@@ -252,13 +252,13 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 
 	private TestEntity initializeDatabase(String distinctiveString) {
 		try {
-			AtomicReference<MongoDriver<TestEntity>> driverRef = new AtomicReference<>();
-			Bosk<TestEntity> prepBosk = new Bosk<TestEntity>(
+			AtomicReference<MongoDriver> driverRef = new AtomicReference<>();
+			Bosk<TestEntity> prepBosk = new Bosk<>(
 				boskName("Prep " + getClass().getSimpleName()),
 				TestEntity.class,
 				bosk -> initialRoot(bosk).withString(distinctiveString),
-				(b,d) -> {
-					var mongoDriver = (MongoDriver<TestEntity>) driverFactory.build(b, d);
+				(b, d) -> {
+					var mongoDriver = (MongoDriver) driverFactory.build(b, d);
 					driverRef.set(mongoDriver);
 					return mongoDriver;
 				});

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
@@ -82,7 +82,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(getClass().getSimpleName() + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory);
 
 		MongoDriverSpecialTest.Refs refs = bosk.buildReferences(MongoDriverSpecialTest.Refs.class);
-		BoskDriver<TestEntity> driver = bosk.driver();
+		BoskDriver driver = bosk.driver();
 		TestEntity defaultState = initialRoot(bosk);
 
 		try (var _ = bosk.readContext()) {
@@ -119,7 +119,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		}
 	}
 
-	private void waitFor(BoskDriver<TestEntity> driver) throws IOException, InterruptedException {
+	private void waitFor(BoskDriver driver) throws IOException, InterruptedException {
 		switch (flushOrWait) {
 			case FLUSH:
 				driver.flush();

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -100,7 +100,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		// have tight control over all the comings and goings from MongoDriver.
 		BlockingQueue<Reference<?>> replacementsSeen = new LinkedBlockingDeque<>();
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, this::initialRoot,
-			(b,d) -> driverFactory.build(b, new BufferingDriver<>(d) {
+			(b,d) -> driverFactory.build(b, new BufferingDriver(d) {
 				@Override
 				public <T> void submitReplacement(Reference<T> target, T newValue) {
 					super.submitReplacement(target, newValue);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -152,7 +152,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	@UsesMongoService
 	void listing_stateMatches() throws InvalidTypeException, InterruptedException, IOException {
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, this::initialRoot, driverFactory);
-		BoskDriver<TestEntity> driver = bosk.driver();
+		BoskDriver driver = bosk.driver();
 		CatalogReference<TestEntity> catalogRef = bosk.rootReference().thenCatalog(TestEntity.class,
 			TestEntity.Fields.catalog);
 		ListingReference<TestEntity> listingRef = bosk.rootReference().thenListing(TestEntity.class,
@@ -193,7 +193,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName("Main"), TestEntity.class, this::initialRoot, driverFactory);
 		Refs refs = bosk.buildReferences(Refs.class);
-		BoskDriver<TestEntity> driver = bosk.driver();
+		BoskDriver driver = bosk.driver();
 
 		LOGGER.debug("Wait till MongoDB is up and running");
 		driver.flush();
@@ -239,7 +239,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, this::initialRoot, driverFactory);
 		Refs refs = bosk.buildReferences(Refs.class);
-		BoskDriver<TestEntity> driver = bosk.driver();
+		BoskDriver driver = bosk.driver();
 		CountDownLatch listingEntry124Exists = new CountDownLatch(1);
 
 		bosk.registerHook("notice 124", refs.listingEntry(entity124), ref -> {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -91,7 +91,7 @@ public class SchemaEvolutionTest {
 		}
 
 		LOGGER.debug("Refurbish");
-		MongoDriver<TestEntity> driver = toBosk.getDriver(MongoDriver.class);
+		MongoDriver driver = toBosk.getDriver(MongoDriver.class);
 		driver.refurbish();
 
 		LOGGER.debug("Perform fromBosk read");
@@ -118,7 +118,7 @@ public class SchemaEvolutionTest {
 		Refs toRefs = toBosk.buildReferences(Refs.class);
 
 		LOGGER.debug("Refurbish toBosk ({})", toBosk.name());
-		MongoDriver<TestEntity> driver = toBosk.getDriver(MongoDriver.class);
+		MongoDriver driver = toBosk.getDriver(MongoDriver.class);
 		driver.refurbish();
 
 		flushIfLiveRefurbishIsNotSupported(fromBosk, fromHelper, toHelper);

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -27,7 +27,7 @@ public abstract class AbstractDriverTest {
 	protected final Identifier child2ID = Identifier.from("child2");
 	protected Bosk<TestEntity> canonicalBosk;
 	protected Bosk<TestEntity> bosk;
-	protected BoskDriver<TestEntity> driver;
+	protected BoskDriver driver;
 
 	@BeforeEach
 	void logStart(TestInfo testInfo) {

--- a/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
@@ -19,8 +19,8 @@ import works.bosk.exceptions.InvalidTypeException;
 import static lombok.AccessLevel.PRIVATE;
 
 @RequiredArgsConstructor(access = PRIVATE)
-public class AsyncDriver<R extends StateTreeNode> implements BoskDriver {
-	private final BoskInfo<R> bosk;
+public class AsyncDriver implements BoskDriver {
+	private final BoskInfo<?> bosk;
 	private final BoskDriver downstream;
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -29,7 +29,7 @@ public class AsyncDriver<R extends StateTreeNode> implements BoskDriver {
 	}
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		return downstream.initialRoot(rootType);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
@@ -19,9 +19,9 @@ import works.bosk.exceptions.InvalidTypeException;
 import static lombok.AccessLevel.PRIVATE;
 
 @RequiredArgsConstructor(access = PRIVATE)
-public class AsyncDriver<R extends StateTreeNode> implements BoskDriver<R> {
+public class AsyncDriver<R extends StateTreeNode> implements BoskDriver {
 	private final BoskInfo<R> bosk;
-	private final BoskDriver<R> downstream;
+	private final BoskDriver downstream;
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory() {

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -45,7 +45,7 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 	 * Unlike {@link #stateTrackingBosk}.{@link Bosk#driver() driver()},
 	 * this driver can accept updates with references pointing to a different bosk with the same root type.
 	 */
-	final BoskDriver<R> stateTrackingDriver;
+	final BoskDriver stateTrackingDriver;
 
 	final Map<String, Deque<UpdateOperation>> pendingOperationsByThreadName = new ConcurrentHashMap<>();
 	static final String THREAD_NAME = "thread.name";

--- a/bosk-testing/src/main/java/works/bosk/drivers/JitterDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/JitterDriver.java
@@ -13,15 +13,15 @@ import works.bosk.Reference;
 import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
-public final class JitterDriver<R extends StateTreeNode> implements BoskDriver<R> {
-	private final BoskDriver<R> downstream;
+public final class JitterDriver<R extends StateTreeNode> implements BoskDriver {
+	private final BoskDriver downstream;
 	private final DoubleSupplier jitter;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(double meanMillis, double limitMillis, long seed) {
 		return (b,d) -> new JitterDriver<>(d, meanMillis, limitMillis, seed);
 	}
 
-	private JitterDriver(BoskDriver<R> downstream, double meanMillis, double limitMillis, long seed) {
+	private JitterDriver(BoskDriver downstream, double meanMillis, double limitMillis, long seed) {
 		this.downstream = downstream;
 		Random random = new Random(seed);
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/JitterDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/JitterDriver.java
@@ -13,12 +13,12 @@ import works.bosk.Reference;
 import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
-public final class JitterDriver<R extends StateTreeNode> implements BoskDriver {
+public final class JitterDriver implements BoskDriver {
 	private final BoskDriver downstream;
 	private final DoubleSupplier jitter;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(double meanMillis, double limitMillis, long seed) {
-		return (b,d) -> new JitterDriver<>(d, meanMillis, limitMillis, seed);
+		return (b,d) -> new JitterDriver(d, meanMillis, limitMillis, seed);
 	}
 
 	private JitterDriver(BoskDriver downstream, double meanMillis, double limitMillis, long seed) {
@@ -45,7 +45,7 @@ public final class JitterDriver<R extends StateTreeNode> implements BoskDriver {
 	}
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		sleep();
 		return downstream.initialRoot(rootType);
 	}

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -26,8 +26,8 @@ import works.bosk.exceptions.InvalidTypeException;
  * so that the ordinary {@link DriverConformanceTest} suite also tests all the {@link UpdateOperation} objects.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class ReportingDriver<R extends StateTreeNode> implements BoskDriver<R> {
-	final BoskDriver<R> downstream;
+public class ReportingDriver<R extends StateTreeNode> implements BoskDriver {
+	final BoskDriver downstream;
 	final BoskDiagnosticContext diagnosticContext;
 	final Consumer<UpdateOperation> updateListener;
 	final Runnable flushListener;

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -26,18 +26,18 @@ import works.bosk.exceptions.InvalidTypeException;
  * so that the ordinary {@link DriverConformanceTest} suite also tests all the {@link UpdateOperation} objects.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class ReportingDriver<R extends StateTreeNode> implements BoskDriver {
+public class ReportingDriver implements BoskDriver {
 	final BoskDriver downstream;
 	final BoskDiagnosticContext diagnosticContext;
 	final Consumer<UpdateOperation> updateListener;
 	final Runnable flushListener;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<UpdateOperation> listener, Runnable flushListener) {
-		return (b,d) -> new ReportingDriver<>(d, b.rootReference().diagnosticContext(), listener, flushListener);
+		return (b,d) -> new ReportingDriver(d, b.rootReference().diagnosticContext(), listener, flushListener);
 	}
 
 	@Override
-	public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+	public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 		return downstream.initialRoot(rootType);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalDeletion.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalDeletion.java
@@ -24,7 +24,7 @@ public record SubmitConditionalDeletion<T>(
 	}
 
 	@Override
-	public void submitTo(BoskDriver<?> driver) {
+	public void submitTo(BoskDriver driver) {
 		driver.submitConditionalDeletion(target, precondition, requiredValue);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalReplacement.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalReplacement.java
@@ -25,7 +25,7 @@ public record SubmitConditionalReplacement<T>(
 	}
 
 	@Override
-	public void submitTo(BoskDriver<?> driver) {
+	public void submitTo(BoskDriver driver) {
 		driver.submitConditionalReplacement(target, newValue, precondition, requiredValue);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitDeletion.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitDeletion.java
@@ -16,7 +16,7 @@ public record SubmitDeletion<T>(
 	}
 
 	@Override
-	public void submitTo(BoskDriver<?> driver) {
+	public void submitTo(BoskDriver driver) {
 		driver.submitDeletion(target);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitInitialization.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitInitialization.java
@@ -17,7 +17,7 @@ public record SubmitInitialization<T>(
 	}
 
 	@Override
-	public void submitTo(BoskDriver<?> driver) {
+	public void submitTo(BoskDriver driver) {
 		driver.submitInitialization(target, newValue);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitReplacement.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitReplacement.java
@@ -17,7 +17,7 @@ public record SubmitReplacement<T>(
 	}
 
 	@Override
-	public void submitTo(BoskDriver<?> driver) {
+	public void submitTo(BoskDriver driver) {
 		driver.submitReplacement(target, newValue);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/UpdateOperation.java
@@ -25,5 +25,5 @@ public sealed interface UpdateOperation permits
 	 * Any {@link BoskDiagnosticContext diagnostic context} is <em>not</em> propagated;
 	 * if that behaviour is desired, the caller must do it.
 	 */
-	void submitTo(BoskDriver<?> driver);
+	void submitTo(BoskDriver driver);
 }

--- a/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 
 		@Override
 		public BoskDriver build(BoskInfo<R> boskInfo, BoskDriver driver) {
-			return new PreprocessingDriver<>(driver) {
+			return new PreprocessingDriver(driver) {
 				final Module module = jp.moduleFor(boskInfo);
 				final ObjectMapper objectMapper = new ObjectMapper()
 					.registerModule(module)
@@ -110,7 +110,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		@Override
 		public BoskDriver build(BoskInfo<R> boskInfo, BoskDriver driver) {
 			final BsonPlugin bp = new BsonPlugin();
-			return new PreprocessingDriver<>(driver) {
+			return new PreprocessingDriver(driver) {
 				final CodecRegistry codecRegistry = CodecRegistries.fromProviders(bp.codecProviderFor(boskInfo));
 
 				/**
@@ -204,7 +204,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		}
 	}
 
-	private static abstract class PreprocessingDriver<R extends StateTreeNode> implements BoskDriver {
+	private static abstract class PreprocessingDriver implements BoskDriver {
 		private final BoskDriver downstream;
 
 		private PreprocessingDriver(BoskDriver downstream) {
@@ -234,7 +234,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		abstract <T> T preprocess(Reference<T> reference, T newValue);
 
 		@Override
-		public R initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+		public StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
 			return downstream.initialRoot(rootType);
 		}
 

--- a/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		private final JacksonPlugin jp = new JacksonPlugin();
 
 		@Override
-		public BoskDriver<R> build(BoskInfo<R> boskInfo, BoskDriver<R> driver) {
+		public BoskDriver build(BoskInfo<R> boskInfo, BoskDriver driver) {
 			return new PreprocessingDriver<>(driver) {
 				final Module module = jp.moduleFor(boskInfo);
 				final ObjectMapper objectMapper = new ObjectMapper()
@@ -108,7 +108,7 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 	@RequiredArgsConstructor
 	private static class BsonRoundTripDriverFactory<R extends Entity> implements DriverFactory<R> {
 		@Override
-		public BoskDriver<R> build(BoskInfo<R> boskInfo, BoskDriver<R> driver) {
+		public BoskDriver build(BoskInfo<R> boskInfo, BoskDriver driver) {
 			final BsonPlugin bp = new BsonPlugin();
 			return new PreprocessingDriver<>(driver) {
 				final CodecRegistry codecRegistry = CodecRegistries.fromProviders(bp.codecProviderFor(boskInfo));
@@ -204,10 +204,10 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		}
 	}
 
-	private static abstract class PreprocessingDriver<R extends StateTreeNode> implements BoskDriver<R> {
-		private final BoskDriver<R> downstream;
+	private static abstract class PreprocessingDriver<R extends StateTreeNode> implements BoskDriver {
+		private final BoskDriver downstream;
 
-		private PreprocessingDriver(BoskDriver<R> downstream) {
+		private PreprocessingDriver(BoskDriver downstream) {
 			this.downstream = downstream;
 		}
 


### PR DESCRIPTION
That generic parameter was used only to constrain the return type of `initialRoot`, and was not carrying its weight. Very little is lost if we verify the object returned by `initialRoot` at runtime, and in exchange, we simplify `BoskDriver` (a critically important type in this library).

When trying to add additional rigour around driver creation, it turned out there were cases where we had a generic root type `R` and driver class `D` and wanted to describe the driver as `D<R>`, but Java's generic type system is not up to this task. By dropping the generic parameter on the driver, we can now describe this type precisely as just `D`.

Some implementations of `BoskDriver` choose to be parameterized anyway, if it helps the implementation ensure type safety.

We've left `DriverFactory` parameterized because it turns out to be useful to ensure that certain kinds of related driver factories will accept the same root type; for example, in `ReplicaSet`.