### PR TITLE
Encapsulate simpleDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ public class ExampleBosk extends Bosk<ExampleState> {
 
 	// Start off simple
 	private static DriverFactory<ExampleState> driverFactory() {
-		return Bosk::simpleDriver;
+		return Bosk.simpleDriver();
 	}
 }
 ```
@@ -164,7 +164,7 @@ Use the same version number for all packages.
 
 When you're ready to turn your standalone app into a replica set,
 add [bosk-mongo](bosk-mongo) as a dependency
-and change your Bosk `driverFactory` method to substitute `MongoDriver` in place of `Bosk::simpleDriver`:
+and change your Bosk `driverFactory` method to substitute `MongoDriver` in place of `Bosk.simpleDriver()`:
 
 ```
 import com.mongodb.MongoClientSettings;

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -171,11 +171,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	}
 
 	/**
-	 * You can use <code>Bosk::simpleDriver</code> as the
-	 * <code>driverFactory</code> if you don't want any additional driver functionality.
+	 * @return a {@link DriverFactory} with only the basic functionality.
 	 */
-	public static <RR extends StateTreeNode> BoskDriver simpleDriver(@SuppressWarnings("unused") BoskInfo<RR> boskInfo, BoskDriver downstream) {
-		return downstream;
+	public static <RR extends StateTreeNode> DriverFactory<RR> simpleDriver() {
+		return (b,d) -> d;
 	}
 
 	public BoskDriver driver() {

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -65,7 +65,7 @@ public class BoskConstructorTest {
 				boskName("Invalid root type"),
 				MutableField.class,
 				bosk -> new MutableField(),
-				Bosk::simpleDriver));
+				Bosk.simpleDriver()));
 	}
 
 	@Test
@@ -91,7 +91,7 @@ public class BoskConstructorTest {
 				boskName("Mismatched root"),
 				BoxedPrimitives.class, // Valid but wrong
 				bosk -> newEntity(),
-				Bosk::simpleDriver
+				Bosk.simpleDriver()
 			)
 		);
 	}
@@ -113,14 +113,14 @@ public class BoskConstructorTest {
 	void defaultRoot_matches() {
 		SimpleTypes root = newEntity();
 		{
-			Bosk<StateTreeNode> valueBosk = new Bosk<>(boskName(), SimpleTypes.class, _ -> root, Bosk::simpleDriver);
+			Bosk<StateTreeNode> valueBosk = new Bosk<>(boskName(), SimpleTypes.class, _ -> root, Bosk.simpleDriver());
 			try (var _ = valueBosk.readContext()) {
 				assertSame(root, valueBosk.rootReference().value());
 			}
 		}
 
 		{
-			Bosk<StateTreeNode> functionBosk = new Bosk<StateTreeNode>(boskName(), SimpleTypes.class, _ -> root, Bosk::simpleDriver);
+			Bosk<StateTreeNode> functionBosk = new Bosk<StateTreeNode>(boskName(), SimpleTypes.class, _ -> root, Bosk.simpleDriver());
 			try (var _ = functionBosk.readContext()) {
 				assertSame(root, functionBosk.rootReference().value());
 			}
@@ -152,7 +152,7 @@ public class BoskConstructorTest {
 			boskName(),
 			SimpleTypes.class,
 			defaultRootFunction,
-			Bosk::simpleDriver
+			Bosk.simpleDriver()
 		));
 	}
 

--- a/bosk-core/src/test/java/works/bosk/BoskDiagnosticContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskDiagnosticContextTest.java
@@ -31,7 +31,7 @@ class BoskDiagnosticContextTest extends AbstractDriverTest {
 			boskName(),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,
-			Bosk::simpleDriver
+			Bosk.simpleDriver()
 		);
 		refs = bosk.buildReferences(Refs.class);
 	}

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -67,7 +67,7 @@ class BoskLocalReferenceTest {
 	void initializeBosk() throws InvalidTypeException {
 		boskName = boskName();
 		Root initialRoot = new Root(1, Catalog.empty());
-		bosk = new Bosk<>(boskName, Root.class, _ -> initialRoot, Bosk::simpleDriver);
+		bosk = new Bosk<>(boskName, Root.class, _ -> initialRoot, Bosk.simpleDriver());
 		refs = bosk.rootReference().buildReferences(Refs.class);
 		Identifier ernieID = Identifier.from("ernie");
 		Identifier bertID = Identifier.from("bert");
@@ -270,8 +270,8 @@ class BoskLocalReferenceTest {
 				this.mutableString = str;
 			}
 		}
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk::simpleDriver));
+		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk.simpleDriver()));
+		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk.simpleDriver()));
 	}
 
 	private <T> void checkReferenceProperties(Reference<T> ref, Path expectedPath, T expectedValue) throws InvalidTypeException {

--- a/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
@@ -43,7 +43,7 @@ public class BoskUpdateTest extends AbstractBoskTest {
 			boskName(),
 			TestRoot.class,
 			AbstractBoskTest::initialRoot,
-			Bosk::simpleDriver
+			Bosk.simpleDriver()
 		);
 		refs = bosk.buildReferences(Refs.class);
 		try (var _ = bosk.readContext()) {

--- a/bosk-core/src/test/java/works/bosk/BuildReferencesErrorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BuildReferencesErrorTest.java
@@ -13,7 +13,7 @@ public class BuildReferencesErrorTest extends AbstractBoskTest {
 
 	@BeforeAll
 	static void setup() throws InvalidTypeException {
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		teb = new TestEntityBuilder(bosk);
 	}
 

--- a/bosk-core/src/test/java/works/bosk/BuildReferencesTest.java
+++ b/bosk-core/src/test/java/works/bosk/BuildReferencesTest.java
@@ -17,7 +17,7 @@ public class BuildReferencesTest extends AbstractBoskTest {
 
 	@BeforeAll
 	static void setup() throws InvalidTypeException {
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		refs = bosk.buildReferences(Refs.class);
 
 		teb = new TestEntityBuilder(bosk);

--- a/bosk-core/src/test/java/works/bosk/CatalogBenchmark.java
+++ b/bosk-core/src/test/java/works/bosk/CatalogBenchmark.java
@@ -33,7 +33,7 @@ public class CatalogBenchmark {
 				boskName(),
 				AbstractBoskTest.TestRoot.class,
 				AbstractBoskTest::initialRoot,
-				Bosk::simpleDriver
+				Bosk.simpleDriver()
 			);
 			TestEntityBuilder teb = new TestEntityBuilder(bosk);
 			int initialSize = 100_000;

--- a/bosk-core/src/test/java/works/bosk/HooksTest.java
+++ b/bosk-core/src/test/java/works/bosk/HooksTest.java
@@ -46,7 +46,7 @@ public class HooksTest extends AbstractBoskTest {
 
 	@BeforeEach
 	void setupBosk() throws InvalidTypeException {
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		refs = bosk.rootReference().buildReferences(Refs.class);
 		try (var _ = bosk.readContext()) {
 			originalRoot = bosk.rootReference().value();

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -54,7 +54,7 @@ class ListingTest {
 			return childrenStream
 					.map(children -> {
 						TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk::simpleDriver);
+						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver());
 						CatalogReference<TestEntity> catalog;
 						try {
 							catalog = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
@@ -73,7 +73,7 @@ class ListingTest {
 			TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 			List<TestEntity> children = singletonList(child);
 			TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk::simpleDriver);
+			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver());
 			CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 			return idStreams().map(list -> Arguments.of(list.map(Identifier::from).collect(toList()), childrenRef, bosk));
 		}
@@ -248,7 +248,7 @@ class ListingTest {
 		TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 		List<TestEntity> children = singletonList(child);
 		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk::simpleDriver);
+		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver());
 		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 
 		Listing<TestEntity> actual = Listing.empty(childrenRef);

--- a/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
+++ b/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
@@ -23,7 +23,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 
 	@Test
 	void testReferenceOptionalNotAllowed() {
-		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, _ -> new OptionalString(ID, Optional.empty()), Bosk::simpleDriver);
+		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, _ -> new OptionalString(ID, Optional.empty()), Bosk.simpleDriver());
 		InvalidTypeException e = assertThrows(InvalidTypeException.class, () -> bosk.rootReference().then(Optional.class, Path.just("field")));
 		assertThat(e.getMessage(), containsString("not supported"));
 	}

--- a/bosk-core/src/test/java/works/bosk/ReferenceBenchmark.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceBenchmark.java
@@ -36,7 +36,7 @@ public class ReferenceBenchmark extends AbstractBoskTest {
 
 		@Setup(Level.Trial)
 		public void setup() throws InvalidTypeException {
-			this.bosk = setUpBosk(Bosk::simpleDriver);
+			this.bosk = setUpBosk(Bosk.simpleDriver());
 			context = bosk.readContext();
 			rootRef = bosk.rootReference();
 			TestRoot localRoot = root = rootRef.value();

--- a/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
@@ -20,7 +20,7 @@ public class ReferenceErrorTest {
 			boskName(),
 			BadGetters.class,
 			_ -> new BadGetters(Identifier.from("test"), new NestedObject(Optional.of("stringValue"))),
-			Bosk::simpleDriver);
+			Bosk.simpleDriver());
 	}
 
 	@Test

--- a/bosk-core/src/test/java/works/bosk/ReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceTest.java
@@ -33,7 +33,7 @@ class ReferenceTest extends AbstractBoskTest {
 
 	@BeforeEach
 	void setup() throws InvalidTypeException {
-		this.bosk = setUpBosk(Bosk::simpleDriver);
+		this.bosk = setUpBosk(Bosk.simpleDriver());
 		context = bosk.readContext();
 		this.root = bosk.rootReference().value();
 		this.refs = bosk.buildReferences(Refs.class);

--- a/bosk-core/src/test/java/works/bosk/SideTableTest.java
+++ b/bosk-core/src/test/java/works/bosk/SideTableTest.java
@@ -37,7 +37,7 @@ class SideTableTest extends AbstractBoskTest {
 
 	@BeforeEach
 	void setup() throws InvalidTypeException {
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		refs = bosk.buildReferences(Refs.class);
 
 		readContext = bosk.readContext();

--- a/bosk-core/src/test/java/works/bosk/VariantTest.java
+++ b/bosk-core/src/test/java/works/bosk/VariantTest.java
@@ -47,7 +47,7 @@ class VariantTest extends AbstractBoskTest {
 	@Test
 	void test() throws InvalidTypeException, IOException, InterruptedException {
 		String stringValue = "test";
-		var bosk = new Bosk<>(boskName(), BoskState.class, _ -> new BoskState(new StringCase(stringValue)), Bosk::simpleDriver);
+		var bosk = new Bosk<>(boskName(), BoskState.class, _ -> new BoskState(new StringCase(stringValue)), Bosk.simpleDriver());
 		var refs = bosk.rootReference().buildReferences(Refs.class);
 		try (var _ = bosk.readContext()) {
 			assertEquals(stringValue, refs.stringValue().value());

--- a/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
+++ b/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
@@ -54,7 +54,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 	@BeforeEach
 	void setup() throws InvalidTypeException, InterruptedException, IOException {
 		pathCompiler = PathCompiler.withSourceType(TestRoot.class);
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		teb = new TestEntityBuilder(bosk);
 		root = initialRoot(bosk);
 		bosk.driver().submitReplacement(bosk.rootReference(), root);
@@ -269,7 +269,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 			.getConstructor(Identifier.class)
 			.newInstance(rootID);
 		Bosk<StateTreeNode> differentBosk = new Bosk<>(
-			boskName("Different"), differentRootClass, _ -> initialRoot, Bosk::simpleDriver
+			boskName("Different"), differentRootClass, _ -> initialRoot, Bosk.simpleDriver()
 		);
 		Reference<Identifier> idRef = differentBosk.rootReference().then(Identifier.class, Path.parse(
 			"/id" ));

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
@@ -84,7 +84,7 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	@BeforeEach
 	void setUpJackson() throws Exception {
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		teb = new TestEntityBuilder(bosk);
 		refs = bosk.buildReferences(Refs.class);
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonPluginTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonPluginTest.java
@@ -29,7 +29,7 @@ class BsonPluginTest {
 	@Test
 	void sideTableOfSideTables() {
 		BsonPlugin bp = new BsonPlugin();
-		Bosk<Root> bosk = new Bosk<Root>(boskName(), Root.class, this::defaultRoot, Bosk::simpleDriver);
+		Bosk<Root> bosk = new Bosk<Root>(boskName(), Root.class, this::defaultRoot, Bosk.simpleDriver());
 		CodecRegistry registry = CodecRegistries.fromProviders(bp.codecProviderFor(bosk), new ValueCodecProvider());
 		Codec<Root> codec = registry.get(Root.class);
 		try (var _ = bosk.readContext()) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonSurgeonTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonSurgeonTest.java
@@ -52,7 +52,7 @@ public class BsonSurgeonTest extends AbstractDriverTest {
 
 	@BeforeEach
 	void setup() throws InvalidTypeException, IOException, InterruptedException {
-		setupBosksAndReferences(Bosk::simpleDriver);
+		setupBosksAndReferences(Bosk.simpleDriver());
 		bsonPlugin = new BsonPlugin();
 		formatter = new Formatter(bosk, bsonPlugin);
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/FormatterTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/FormatterTest.java
@@ -34,7 +34,7 @@ class FormatterTest extends AbstractBoskTest {
 
 	@BeforeEach
 	void setupFormatter() throws InvalidTypeException, IOException, InterruptedException {
-		bosk = setUpBosk(Bosk::simpleDriver);
+		bosk = setUpBosk(Bosk.simpleDriver());
 		TestEntityBuilder builder = new TestEntityBuilder(bosk);
 		entitiesRef = builder.entitiesRef();
 		weirdRef = builder.entityRef(Identifier.from(WEIRD_ID));

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverDottedFieldNameTest.java
@@ -24,7 +24,7 @@ class MongoDriverDottedFieldNameTest extends AbstractDriverTest {
 
 	@BeforeEach
 	void setUpStuff() {
-		bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
+		bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver());
 	}
 
 	private CatalogReference<TestEntity> rootCatalogRef(Bosk<TestEntity> bosk) throws InvalidTypeException {

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractDriverTest {
 
 	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
 		// This is the bosk whose behaviour we'll consider to be correct by definition
-		canonicalBosk = new Bosk<TestEntity>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk::simpleDriver);
+		canonicalBosk = new Bosk<TestEntity>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver());
 
 		// This is the bosk we're testing
 		bosk = new Bosk<TestEntity>(boskName("Test", 1), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -54,7 +54,7 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 		Bosk<RR> stateTrackingBosk = new Bosk<>(
 			boskName(),
 			rootType, defaultRootFunction,
-			Bosk::simpleDriver
+			Bosk.simpleDriver()
 		);
 		DriverStateVerifier<RR> verifier = new DriverStateVerifier<>(
 			stateTrackingBosk,

--- a/bosk-testing/src/test/java/works/bosk/drivers/ConformanceMetaTest.java
+++ b/bosk-testing/src/test/java/works/bosk/drivers/ConformanceMetaTest.java
@@ -11,7 +11,7 @@ public class ConformanceMetaTest extends DriverConformanceTest {
 
 	@BeforeEach
 	void setupDriverFactory() {
-		driverFactory = Bosk::simpleDriver;
+		driverFactory = Bosk.simpleDriver();
 	}
 
 }

--- a/bosk-testing/src/test/java/works/bosk/drivers/HanoiMetaTest.java
+++ b/bosk-testing/src/test/java/works/bosk/drivers/HanoiMetaTest.java
@@ -4,6 +4,6 @@ import works.bosk.Bosk;
 
 public class HanoiMetaTest extends HanoiTest {
 	public HanoiMetaTest() {
-		driverFactory = Bosk::simpleDriver;
+		driverFactory = Bosk.simpleDriver();
 	}
 }

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -549,7 +549,7 @@ and briefly describes the drivers that are built into the bosk library.
 #### Local driver
 
 Every bosk has a _local driver_, which applies changes directly to the in-memory state tree.
-If you use `Bosk::simpleDriver` as your driver factory when you initialize your `Bosk` object,
+If you use `Bosk.simpleDriver()` as your driver factory when you initialize your `Bosk` object,
 then the driver is _just_ the local driver.
 
 The local driver performs the grafting operations that create a new state tree containing specified changes applied to the existing tree.
@@ -563,7 +563,7 @@ The calling thread is used to trigger hooks, and even to run them (unless a hook
 `BoskDriver` itself is designed to permit stackable layers (the _Decorator_ design pattern),
 making drivers modular and composable.
 
-The simplest `DriverFactory` is `Bosk::simpleDriver`, which adds no driver layers at all, and simply returns the bosk's own local driver, which directly updates the Bosk's in-memory state tree.
+The simplest `DriverFactory` is `Bosk.simpleDriver()`, which adds no driver layers at all, and simply returns the bosk's own local driver, which directly updates the Bosk's in-memory state tree.
 More sophisticated driver layers can provide their own factories, which typically create an instance of the driver layer object configured to forward update requests to the downstream driver, forming a forwarding chain that ultimately ends with the bosk's local driver.
 
 For example, an application could create a `LoggingDriver` class to perform logging of update requests before forwarding them to a downstream driver that actually applies them to the bosk state.
@@ -968,7 +968,7 @@ public class ExampleBosk extends Bosk<ExampleState> {
 
 	// Start off simple
 	private static DriverFactory<ExampleState> driverFactory() {
-		return Bosk::simpleDriver;
+		return Bosk.simpleDriver();
 	}
 }
 ```

--- a/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
@@ -50,13 +50,13 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 	}
 
 	public static <R extends Entity> DriverFactory<R> directFactory() {
-		return Bosk::simpleDriver;
+		return Bosk.simpleDriver();
 	}
 
 	public static <R extends Entity> DriverFactory<R> factoryThatMakesAReference() {
 		return (boskInfo, downstream) -> {
 			boskInfo.rootReference();
-			return Bosk.simpleDriver(boskInfo, downstream);
+			return Bosk.<R>simpleDriver().build(boskInfo, downstream);
 		};
 	}
 


### PR DESCRIPTION
### Note for users

This change will require you to switch existing uses of `Bosk::simpleDriver` to `Bosk.simpleDriver()`. Besides that, it's a drop-in replacement.

### Rationale

Exposing `simpleDriver` in a way that encourages users to use method reference syntax (`Bosk::simpleDriver`) limits our ability to change the implementation over time. Driver stacks are an area we definitely expect to change, so it's important to encapsulate this syntactically as a method call so that users don't need to change their code as driver stacks evolve.

