### PR TITLE
Jackson support for linked maps

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -106,6 +106,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 *
 	 * @see DriverStack
 	 */
+	@SuppressWarnings("this-escape")
 	public Bosk(String name, Type rootType, DefaultRootFunction<R> defaultRootFunction, DriverFactory<R> driverFactory) {
 		this.name = name;
 		this.localDriver = new LocalDriver(defaultRootFunction);
@@ -136,7 +137,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		rawClass(rootType).cast(this.currentRoot);
 
 		// Ok, we're done initializing
-		boskInfo.boskRef().set(this);
+		boskInfo.boskRef().set(this); // @SuppressWarnings("this-escape")
 	}
 
 	public interface DefaultRootFunction<RR extends StateTreeNode> {

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPluginConfiguration.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPluginConfiguration.java
@@ -1,0 +1,62 @@
+package works.bosk.jackson;
+
+public record JacksonPluginConfiguration(
+	MapShape mapShape
+) {
+	public static JacksonPluginConfiguration defaultConfiguration() {
+		return new JacksonPluginConfiguration(MapShape.ARRAY);
+	}
+
+	/**
+	 * How bosk's ordered maps should translate to JSON, where the order of object
+	 * fields is generally not preserved.
+	 */
+	public enum MapShape {
+		/**
+		 * A shape intended for brevity, human readability, and efficient serialization/deserialization.
+		 * <p>
+		 * An array of single-field objects, where the field name is the map entry's key
+		 * and the field value is the map entry's value.
+		 */
+		ARRAY,
+
+		/**
+		 * A shape intended for efficient incremental modification,
+		 * especially for values stored in a database that supports JSON
+		 * but does not preserve object field order (like Postgresql).
+		 * Inspired by {@link java.util.LinkedHashMap LinkedHashMap}.
+		 * <p>
+		 * An object containing the natural keys and values of the map being stored,
+		 * with a few changes:
+		 *
+		 * <ul>
+		 *     <li>
+		 *         The object also has fields "{@code -first}" and "{@code -last}" pointing
+		 *         at the first and last map entries, so they can be found efficiently.
+		 *         (These names have leading dashes to distinguish them from valid
+		 *         {@link works.bosk.Identifier Identifier} values.)
+		 *     </li>
+		 *     <li>
+		 *         The object's field values are themselves objects defined by
+		 *         {@link works.bosk.jackson.JacksonPlugin.LinkedMapEntry LinkedMapEntry}.
+		 *     </li>
+		 * </ul>
+		 *
+		 * The resulting structure supports the following operations in O(1) time:
+		 * <ul>
+		 *     <li>
+		 *         Lookup an entry given its ID
+		 *     </li>
+		 *     <li>
+		 *         Add a new entry at the end.
+		 *     </li>
+		 *     <li>
+		 *         Delete an entry.
+		 *     </li>
+		 * </ul>
+		 *
+		 * It also supports linear time walking of the entries in both forward and reverse order.
+		 */
+		LINKED_MAP,
+	}
+}

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
@@ -627,11 +627,6 @@ class JacksonPluginTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void catalogFromEmptyMap_throws() {
-		assertJsonException("{}", Catalog.class, TestEntity.class);
-	}
-
-	@Test
 	void catalogWithContentsArray_throws() {
 		assertJsonException("{ \"contents\": [] }", Catalog.class, TestEntity.class);
 	}
@@ -679,11 +674,6 @@ class JacksonPluginTest extends AbstractBoskTest {
 	@Test
 	void sideTableWithTwoDomains_throws() {
 		assertJsonException("{ \"domain\": \"/entities\", \"domain\": \"/entities\", \"valuesById\": [] }", SideTable.class, TestEntity.class, String.class);
-	}
-
-	@Test
-	void sideTableWithValuesMap_throws() {
-		assertJsonException("{ \"domain\": \"/entities\", \"valuesById\": {} }", SideTable.class, TestEntity.class, String.class);
 	}
 
 	@Test

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonRoundTripConformanceTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonRoundTripConformanceTest.java
@@ -1,13 +1,20 @@
 package works.bosk.jackson;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.util.stream.Stream;
 import works.bosk.drivers.DriverConformanceTest;
+import works.bosk.junit.ParametersByName;
 
 import static works.bosk.AbstractRoundTripTest.jacksonRoundTripFactory;
+import static works.bosk.jackson.JacksonPluginConfiguration.MapShape.LINKED_MAP;
 
 public class JacksonRoundTripConformanceTest extends DriverConformanceTest {
-	@BeforeEach
-	void setupDriverFactory() {
-		driverFactory = jacksonRoundTripFactory();
+	@ParametersByName
+	JacksonRoundTripConformanceTest(JacksonPluginConfiguration config) {
+		driverFactory = jacksonRoundTripFactory(config);
+	}
+
+	static Stream<JacksonPluginConfiguration> config() {
+		return Stream.of(JacksonPluginConfiguration.MapShape.values())
+			.map(shape -> new JacksonPluginConfiguration(shape));
 	}
 }

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
@@ -389,7 +389,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		MapValue<String> originalMapValue = MapValue.fromFunction(asList("key.with.dots.1", "key.with.dots.2"), k -> k + "_originalValue");
 		driver.submitReplacement(mapRef, originalMapValue);
 		assertCorrectBoskContents();
-		MapValue<String> newMapValue = originalMapValue.with("key.with.dots.1", "newValue");
+		MapValue<String> newMapValue = originalMapValue.with("key.with.dots.1", "_newValue");
 		driver.submitReplacement(mapRef, newMapValue);
 		assertCorrectBoskContents();
 
@@ -527,6 +527,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 			"id.with.dots",
 			"id/with/slashes",
 			"$id$with$dollars$",
+			"id:with:colons:",
 			AWKWARD_ID,
 			"idWithEmojis\uD83C\uDF33\uD83E\uDDCA"
 		).map(Identifier::from);
@@ -535,7 +536,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	/**
 	 * Contains all kinds of special characters
 	 */
-	public static final String AWKWARD_ID = "$id.with%everything/ +\uD83D\uDE09";
+	public static final String AWKWARD_ID = "$id.with%everything:/ +\uD83D\uDE09";
 
 	@SuppressWarnings("unused")
 	static Stream<String> testEntityField() {

--- a/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
@@ -31,10 +31,12 @@ import org.slf4j.LoggerFactory;
 import works.bosk.drivers.mongo.BsonPlugin;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.jackson.JacksonPlugin;
+import works.bosk.jackson.JacksonPluginConfiguration;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static java.lang.System.identityHashCode;
 import static java.util.Collections.newSetFromMap;
+import static works.bosk.jackson.JacksonPluginConfiguration.MapShape.LINKED_MAP;
 
 public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 
@@ -43,7 +45,8 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 				directFactory(),
 				factoryThatMakesAReference(),
 
-				jacksonRoundTripFactory(),
+				jacksonRoundTripFactory(JacksonPluginConfiguration.defaultConfiguration()),
+				jacksonRoundTripFactory(new JacksonPluginConfiguration(LINKED_MAP)),
 
 				bsonRoundTripFactory()
 		);
@@ -60,13 +63,18 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		};
 	}
 
-	public static <R extends Entity> DriverFactory<R> jacksonRoundTripFactory() {
-		return new JacksonRoundTripDriverFactory<>();
+	public static <R extends Entity> DriverFactory<R> jacksonRoundTripFactory(JacksonPluginConfiguration config) {
+		return new JacksonRoundTripDriverFactory<>(config);
 	}
 
-	@RequiredArgsConstructor
 	private static class JacksonRoundTripDriverFactory<R extends Entity> implements DriverFactory<R> {
-		private final JacksonPlugin jp = new JacksonPlugin();
+		private final JacksonPluginConfiguration config;
+		private final JacksonPlugin jp;
+
+		private JacksonRoundTripDriverFactory(JacksonPluginConfiguration config) {
+			this.config = config;
+			this.jp = new JacksonPlugin(config);
+		}
 
 		@Override
 		public BoskDriver build(BoskInfo<R> boskInfo, BoskDriver driver) {


### PR DESCRIPTION
This offers an optional JSON notation for `Catalog` and `SideTable` inspired by `LinkedHashMap`.

The existing array-based notation is more concise, and more readable for humans. The new notation is intended for cases where the JSON is to be edited to implement `BoskDriver` operations; for example, if the JSON is to be stored in a database like Postgresql. With the new notation, the following operations are algorithmically efficient:

- Looking up an entry given its ID
- Adding a new entry at the end
- Deleting an entry