### PR TITLE
Require state tree nodes to be records

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,40 +29,6 @@ all we do is send updates to MongoDB, and maintain the in-memory replica by foll
 
 ## Getting Started
 
-### Build settings
-
-First, be sure you're compiling Java with the `-parameters` argument.
-
-In Gradle:
-
-```
-dependencies {
-	compileJava {
-		options.compilerArgs << '-parameters'
-	}
-
-	compileTestJava {
-		options.compilerArgs << '-parameters'
-	}
-}
-```
-
-In Maven:
-
-```
-<plugin>
-		<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-compiler-plugin</artifactId>
-		<configuration>
-				<compilerArgs>
-						<arg>-parameters</arg>
-				</compilerArgs>
-		</configuration>
-</plugin>
-```
-
-### Standalone example
-
 The [bosk-core](bosk-core) library is enough to create a `Bosk` object and start writing your application.
 
 The library works particularly well with Java records.
@@ -76,17 +42,6 @@ public record ExampleState (
 	// Add fields here as you need them
 	String name
 ) implements StateTreeNode {}
-```
-
-You can also use classes, especially if you're using Lombok:
-
-```
-@Value
-@Accessors(fluent = true)
-public class ExampleState implements StateTreeNode {
-	// Add fields here as you need them
-	String name;
-}
 ```
 
 Now declare your singleton `Bosk` class to house and manage your application state:
@@ -198,7 +153,7 @@ To run this, you'll need a MongoDB replica set.
 You can run a single-node replica set using the following `Dockerfile`:
 
 ```
-FROM mongo:4.4
+FROM mongo:7.0
 RUN echo "rs.initiate()" > /docker-entrypoint-initdb.d/rs-initiate.js
 CMD [ "mongod", "--replSet", "rsLonesome", "--port", "27017", "--bind_ip_all" ]
 ```
@@ -214,21 +169,6 @@ The repo is structured as a collection of subprojects because we publish several
 provide integrations with other technologies.
 
 The subprojects are listed in [settings.gradle](settings.gradle), and each has its own `README.md` describing what it is.
-
-### Compiler flags
-
-Ensure `javac` is supplied the `-parameters` flag.
-
-This is required because,
-for each class you use to describe your Bosk state, the "system of record" for its structure is its constructor.
-For example, you might define a class with a constructor like this:
-
-```
-public Member(Identifier id, String name) {...}
-```
-
-Based on this, Bosk now knows the names and types of all the "properties" of your object.
-For this to work smoothly, the parameter names must be present in the compiled bytecode.
 
 ### Gradle setup
 

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -741,7 +741,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			// TODO: This would be less cumbersome if we could apply a Reference to an arbitrary root object.
 			// For now, References only apply to the current ReadContext, so we need a new ReadContext every time
 			// we want to change roots.
-			try (@SuppressWarnings("unused") ReadContext priorContext = new ReadContext(priorRoot)) {
+			try (var __ = new ReadContext(priorRoot)) {
 				return containerRef.valueIfExists();
 			}
 		}

--- a/bosk-core/src/main/java/works/bosk/ReflectiveEntity.java
+++ b/bosk-core/src/main/java/works/bosk/ReflectiveEntity.java
@@ -6,24 +6,18 @@ package works.bosk;
  * <p>
  * Because the bosk system identifies an object by its location in the document
  * tree, this means instances of this class have enough information to determine
- * their identity, and so we provide {@link #equals(Object) equals} and {@link
- * #hashCode() hashCode} implementations.
+ * their identity, and so we provide some recommended {@link #equals(Object) equals}
+ * and {@link #hashCode() hashCode} implementations.
  *
  * <p>
  * <em>Performance note</em>: References aren't cheap to create.
  *
  * @author Patrick Doyle
  */
-public abstract class ReflectiveEntity<T extends ReflectiveEntity<T>> implements Entity {
-	public abstract Reference<T> reference();
+public interface ReflectiveEntity<T extends ReflectiveEntity<T>> extends Entity {
+	Reference<T> reference();
 
-	@Override
-	public int hashCode() {
-		return reference().hashCode();
-	}
-
-	@Override
-	public boolean equals(Object obj) {
+	default boolean reflectiveEntity_equals(Object obj) {
 		if (this == obj) {
 			return true;
 		} else if (obj instanceof ReflectiveEntity<?> r) {
@@ -33,8 +27,7 @@ public abstract class ReflectiveEntity<T extends ReflectiveEntity<T>> implements
 		}
 	}
 
-	@Override
-	public String toString() {
+	default String reflectiveEntity_toString() {
 		return getClass().getSimpleName() + "(" + reference() + ")";
 	}
 }

--- a/bosk-core/src/main/java/works/bosk/dereferencers/PathCompiler.java
+++ b/bosk-core/src/main/java/works/bosk/dereferencers/PathCompiler.java
@@ -32,6 +32,7 @@ import works.bosk.ListingEntry;
 import works.bosk.Path;
 import works.bosk.Phantom;
 import works.bosk.Reference;
+import works.bosk.ReferenceUtils;
 import works.bosk.SerializationPlugin;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
@@ -52,7 +53,6 @@ import static works.bosk.ReferenceUtils.getterMethod;
 import static works.bosk.ReferenceUtils.gettersForConstructorParameters;
 import static works.bosk.ReferenceUtils.parameterType;
 import static works.bosk.ReferenceUtils.rawClass;
-import static works.bosk.ReferenceUtils.theOnlyConstructorFor;
 import static works.bosk.bytecode.ClassBuilder.here;
 
 /**
@@ -248,7 +248,7 @@ public final class PathCompiler {
 				// InvalidTypeException here instead of adding the getter to the map. -pdoyle
 				getters.put(segment, getterMethod(currentClass, segment));
 
-				Step fieldStep = newFieldStep(segment, getters, theOnlyConstructorFor(currentClass));
+				Step fieldStep = newFieldStep(segment, getters, ReferenceUtils.getCanonicalConstructor(currentClass));
 				Class<?> fieldClass = rawClass(fieldStep.targetType());
 				Map<String, Type> typeMap = SerializationPlugin.getVariantCaseMapIfAny(fieldStep.targetClass());
 				if (typeMap != null) {

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import works.bosk.Bosk.DefaultRootFunction;
 import works.bosk.TypeValidationTest.BoxedPrimitives;
-import works.bosk.TypeValidationTest.MutableField;
 import works.bosk.TypeValidationTest.SimpleTypes;
 import works.bosk.drivers.ForwardingDriver;
 import works.bosk.drivers.NoOpDriver;
@@ -61,10 +60,10 @@ public class BoskConstructorTest {
 	@Test
 	void invalidRootType_throws() {
 		assertThrows(IllegalArgumentException.class, ()->
-			new Bosk<MutableField>(
+			new Bosk<TypeValidationTest.ArrayField>(
 				boskName("Invalid root type"),
-				MutableField.class,
-				bosk -> new MutableField(),
+				TypeValidationTest.ArrayField.class,
+				bosk -> new TypeValidationTest.ArrayField(Identifier.from("test"), new String[0]),
 				Bosk.simpleDriver()));
 	}
 

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -89,25 +89,25 @@ class BoskLocalReferenceTest {
 		root = bosk.currentRoot();
 	}
 
-	@Getter @With @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	@EqualsAndHashCode(callSuper = false) @ToString @FieldNameConstants
-	public static class Root implements StateTreeNode {
-		Integer version;
-		Catalog<TestEntity> entities;
-	}
+	@FieldNameConstants
+	@With
+	public record Root (
+		Integer version,
+		Catalog<TestEntity> entities
+	) implements StateTreeNode { }
 
-	@Getter @With @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	@EqualsAndHashCode(callSuper = false) @ToString @FieldNameConstants
-	public static class TestEntity implements Entity {
-		Identifier id;
-		Integer version;
-		Reference<TestEntity> refField;
-		Catalog<TestEntity> catalog;
-		Listing<TestEntity> listing;
-		SideTable<TestEntity, String> sideTable;
-		ListValue<String> listValue;
-		Optional<TestEntity> optional;
-	}
+	@With
+	@FieldNameConstants
+	public record TestEntity(
+		Identifier id,
+		Integer version,
+		Reference<TestEntity> refField,
+		Catalog<TestEntity> catalog,
+		Listing<TestEntity> listing,
+		SideTable<TestEntity, String> sideTable,
+		ListValue<String> listValue,
+		Optional<TestEntity> optional
+	) implements Entity { }
 
 	@Test
 	void testRootReference() throws Exception {
@@ -256,22 +256,6 @@ class BoskLocalReferenceTest {
 	@Test
 	void testName() {
 		assertEquals(boskName, bosk.name());
-	}
-
-	@Test
-	void testValidation() {
-		@EqualsAndHashCode(callSuper = true)
-		class InvalidRoot extends Root {
-			@SuppressWarnings("unused")
-			final String mutableString;
-
-			public InvalidRoot(Identifier id, Catalog<TestEntity> entities, String str) {
-				super(0xdead, entities);
-				this.mutableString = str;
-			}
-		}
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), InvalidRoot.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk.simpleDriver()));
-		assertThrows(IllegalArgumentException.class, () -> new Bosk<>(boskName(), String.class, _ -> new InvalidRoot(Identifier.unique("yucky"), Catalog.empty(), "hello"), Bosk.simpleDriver()));
 	}
 
 	private <T> void checkReferenceProperties(Reference<T> ref, Path expectedPath, T expectedValue) throws InvalidTypeException {

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -95,13 +95,11 @@ class ListingTest {
 		);
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
 	@FieldNameConstants
-	@EqualsAndHashCode(callSuper = false) // handy for testing
-	public static class TestEntity implements Entity {
-		Identifier id;
-		@EqualsAndHashCode.Exclude Catalog<TestEntity> children;
-	}
+	public record TestEntity(
+		Identifier id,
+		@EqualsAndHashCode.Exclude Catalog<TestEntity> children
+	) implements Entity { }
 
 	@ParameterizedTest
 	@ArgumentsSource(ListingArgumentProvider.class)

--- a/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
+++ b/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
@@ -34,12 +34,10 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 		doTest(new OptionalString(ID, Optional.empty()), b->"HERE I AM", driverFactory);
 	}
 
-	@EqualsAndHashCode(callSuper = false)
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static class OptionalString implements Entity {
-		Identifier id;
-		Optional<String> field;
-	}
+	public record OptionalString(
+		Identifier id,
+		Optional<String> field
+	) implements Entity { }
 
 	@ParameterizedTest
 	@MethodSource("driverFactories")
@@ -48,12 +46,10 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 		doTest(empty, b->empty, driverFactory);
 	}
 
-	@EqualsAndHashCode(callSuper = false)
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static class OptionalEntity implements Entity {
-		Identifier id;
-		Optional<OptionalEntity> field;
-	}
+	public record OptionalEntity(
+		Identifier id,
+		Optional<OptionalEntity> field
+	) implements Entity { }
 
 	//@ParameterizedTest // TODO: Reference<Reference<?>> is not yet supported
 	@MethodSource("driverFactories")
@@ -61,12 +57,10 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 		doTest(new OptionalReference(ID, Optional.empty()), Bosk::rootReference, driverFactory);
 	}
 
-	@EqualsAndHashCode(callSuper = false)
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static class OptionalReference implements Entity {
-		Identifier id;
-		Optional<Reference<OptionalReference>> field;
-	}
+	public record OptionalReference(
+		Identifier id,
+		Optional<Reference<OptionalReference>> field
+	) implements Entity { }
 
 	@ParameterizedTest
 	@MethodSource("driverFactories")
@@ -75,12 +69,10 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 		doTest(empty, b->Catalog.of(empty), driverFactory);
 	}
 
-	@EqualsAndHashCode(callSuper = false)
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static class OptionalCatalog implements Entity {
-		Identifier id;
-		Optional<Catalog<OptionalCatalog>> field;
-	}
+	public record OptionalCatalog(
+		Identifier id,
+		Optional<Catalog<OptionalCatalog>> field
+	) implements Entity { }
 
 	@ParameterizedTest
 	@MethodSource("driverFactories")
@@ -89,13 +81,11 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 		doTest(empty, b->Listing.of(b.rootReference().thenCatalog(OptionalListing.class, "catalog"), ID), driverFactory);
 	}
 
-	@EqualsAndHashCode(callSuper = false)
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static class OptionalListing implements Entity {
-		Identifier id;
-		Catalog<OptionalListing> catalog;
-		Optional<Listing<OptionalListing>> field;
-	}
+	public record OptionalListing(
+		Identifier id,
+		Catalog<OptionalListing> catalog,
+		Optional<Listing<OptionalListing>> field
+	) implements Entity { }
 
 	@ParameterizedTest
 	@MethodSource("driverFactories")
@@ -104,13 +94,11 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 		doTest(empty, b-> SideTable.of(b.rootReference().thenCatalog(OptionalSideTable.class, "catalog"), ID, "Howdy"), driverFactory);
 	}
 
-	@EqualsAndHashCode(callSuper = false)
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static class OptionalSideTable implements Entity {
-		Identifier id;
-		Catalog<OptionalSideTable> catalog;
-		Optional<SideTable<OptionalSideTable, String>> field;
-	}
+	public record OptionalSideTable(
+		Identifier id,
+		Catalog<OptionalSideTable> catalog,
+		Optional<SideTable<OptionalSideTable, String>> field
+	) implements Entity { }
 
 	private interface ValueFactory<R extends Entity, V> {
 		V createFrom(Bosk<R> bosk) throws InvalidTypeException;

--- a/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
@@ -41,12 +41,8 @@ public class ReferenceErrorTest {
 			bosk.driver().submitDeletion(stringRef));
 	}
 
-	@RequiredArgsConstructor
 	@FieldNameConstants
-	public static class BadGetters implements Entity {
-		final Identifier id;
-		final NestedObject nestedObject;
-
+	public record BadGetters(Identifier id, NestedObject nestedObject) implements Entity {
 		public Identifier id() {
 			throw new UnsupportedOperationException("Whoops");
 		}
@@ -56,9 +52,6 @@ public class ReferenceErrorTest {
 		}
 	}
 
-	@Value
 	@FieldNameConstants
-	public static class NestedObject implements StateTreeNode {
-		Optional<String> string;
-	}
+	public record NestedObject(Optional<String> string) implements StateTreeNode {}
 }

--- a/bosk-core/src/test/java/works/bosk/SerializationPluginTest.java
+++ b/bosk-core/src/test/java/works/bosk/SerializationPluginTest.java
@@ -8,28 +8,8 @@ import org.junit.jupiter.api.Test;
 import works.bosk.annotations.Self;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static works.bosk.ReferenceUtils.theOnlyConstructorFor;
 
 // TODO: This should aim for full coverage of SerializationPlugin
 class SerializationPluginTest {
 
-	@Test
-	void inheritedFieldAttribute_works() {
-		Constructor<Child> childConstructor = theOnlyConstructorFor(Child.class);
-		Parameter selfParameter = childConstructor.getParameters()[0];
-		assertTrue(SerializationPlugin.isSelfReference(Child.class, selfParameter));
-	}
-
-	@RequiredArgsConstructor
-	@Getter
-	static class Parent {
-		@Self final Parent self;
-	}
-
-	@Getter
-	static class Child extends Parent {
-		public Child(Parent self) {
-			super(self);
-		}
-	}
 }

--- a/bosk-core/src/test/java/works/bosk/TypeValidationTest.java
+++ b/bosk-core/src/test/java/works/bosk/TypeValidationTest.java
@@ -48,7 +48,6 @@ class TypeValidationTest {
 	@ParameterizedTest
 	@ValueSource(classes = {
 			String.class,
-			//MissingConstructorArgument.class, // TODO: Currently doesn't work because Bosk is constructor-driven. Figure out what's the system of record here
 			AmbiguousVariantCaseMap.class,
 			ArrayField.class,
 			BooleanPrimitive.class,
@@ -62,14 +61,8 @@ class TypeValidationTest {
 			EnclosingReferenceToCatalog.class,
 			EnclosingReferenceToOptional.class,
 			EnclosingReferenceToString.class,
-			ExtraConstructor.class,
-			ExtraConstructorArgument.class,
 			FieldNameWithDollarSign.class,
 			FloatPrimitive.class,
-			GetterHasParameter.class,
-			GetterReturnsSubtype.class,
-			GetterReturnsSupertype.class,
-			GetterReturnsWrongType.class,
 			HasDeserializationPath.class,
 			IntegerPrimitive.class,
 			ListingOfInvalidType.class,
@@ -87,12 +80,9 @@ class TypeValidationTest {
 			ReferenceToReference.class,
 			SelfNonReference.class,
 			SelfWrongType.class,
-			SelfSubtype.class,
 			ShortPrimitive.class,
 			SideTableWithInvalidKey.class,
 			SideTableWithInvalidValue.class,
-			MutableField.class,
-			MutableInheritedField.class,
 			NestedError.class,
 			OptionalOfInvalidType.class,
 			ReferenceToInvalidType.class,
@@ -187,35 +177,32 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class SimpleTypes implements Entity {
-		Identifier id;
-		String string;
-		MyEnum myEnum;
-
+	public record SimpleTypes(
+		Identifier id,
+		String string,
+		MyEnum myEnum
+	) implements Entity {
 		public enum MyEnum {
 			LEFT, RIGHT
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class BoskyTypes implements StateTreeNode {
-		Reference<SimpleTypes> ref;
-		Optional<SimpleTypes> optional;
-		Catalog<SimpleTypes> catalog;
-		Listing<SimpleTypes> listing;
-		SideTable<SimpleTypes, String> sideTableToString;
-		SideTable<SimpleTypes, SimpleTypes> sideTableToEntity;
-		ListValue<String> listValueOfStrings;
-		ListValue<ValueStruct> listValueOfStructs;
-		ListValueSubclass listValueSubclass;
-	}
+	public record BoskyTypes(
+		Reference<SimpleTypes> ref,
+		Optional<SimpleTypes> optional,
+		Catalog<SimpleTypes> catalog,
+		Listing<SimpleTypes> listing,
+		SideTable<SimpleTypes, String> sideTableToString,
+		SideTable<SimpleTypes, SimpleTypes> sideTableToEntity,
+		ListValue<String> listValueOfStrings,
+		ListValue<ValueStruct> listValueOfStructs,
+		ListValueSubclass listValueSubclass
+	) implements StateTreeNode { }
 
-	@Value
-	public static class ValueStruct implements StateTreeNode {
-		String string;
-		ListValue<String> innerList;
-	}
+	public record ValueStruct(
+		String string,
+		ListValue<String> innerList
+	) implements StateTreeNode { }
 
 	@EqualsAndHashCode(callSuper = true)
 	public static final class ListValueSubclass extends ListValue<String> {
@@ -227,20 +214,18 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class AllowedFieldNames implements StateTreeNode {
-		Integer justLetters;
-		Integer someNumbers4U2C;
-		Integer hereComesAnUnderscore_toldYouSo;
-	}
+	public record AllowedFieldNames(
+		Integer justLetters,
+		Integer someNumbers4U2C,
+		Integer hereComesAnUnderscore_toldYouSo
+	) implements StateTreeNode { }
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class ImplicitReferences_onConstructorParameters implements Entity {
-		Identifier id;
-		Reference<ImplicitReferences_onConstructorParameters> selfRef;
-		Reference<StateTreeNode> selfSupertype;
-		Reference<ImplicitReferences_onConstructorParameters> enclosingRef;
-
+	public record ImplicitReferences_onConstructorParameters(
+		Identifier id,
+		Reference<ImplicitReferences_onConstructorParameters> selfRef,
+		Reference<StateTreeNode> selfSupertype,
+		Reference<ImplicitReferences_onConstructorParameters> enclosingRef
+	) implements Entity {
 		public ImplicitReferences_onConstructorParameters(
 			Identifier id,
 			@Self Reference<ImplicitReferences_onConstructorParameters> selfRef,
@@ -254,14 +239,12 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ImplicitReferences_onFields implements Entity {
-		Identifier id;
-		@Self Reference<ImplicitReferences_onFields> selfRef;
-		@Self Reference<StateTreeNode> selfSupertype;
-		@Enclosing Reference<ImplicitReferences_onFields> enclosingRef;
-	}
+	public record ImplicitReferences_onFields(
+		Identifier id,
+		@Self Reference<ImplicitReferences_onFields> selfRef,
+		@Self Reference<StateTreeNode> selfSupertype,
+		@Enclosing Reference<ImplicitReferences_onFields> enclosingRef
+	) implements Entity { }
 
 	public interface ExtraStaticField extends VariantNode {
 		record Subtype() implements ExtraStaticField {}
@@ -277,199 +260,85 @@ class TypeValidationTest {
 		String EXTRA_FIELD = "ignore me";
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class MissingConstructorArgument implements Entity {
-		Identifier id;
-		String field = "fieldValue";
-	}
-
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class ExtraConstructor implements Entity {
-		Identifier id;
-
-		public ExtraConstructor(String extra) {
-			this.id = Identifier.from("dummy");
-		}
-
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("must have one constructor"));
-		}
-	}
-
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class ExtraConstructorArgument implements Entity {
-		Identifier id;
-
-		public ExtraConstructorArgument(Identifier id, String extra) {
-			this.id = id;
-		}
-
-		ExtraConstructorArgument withId(Identifier id) {
-			return new ExtraConstructorArgument(id, "dummy");
-		}
-
-		public static void testException(InvalidTypeException e) {
-			// Actually detected as a missing getter
-			assertThat(e.getMessage(), containsString("No method"));
-		}
-	}
-
-	@FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class GetterHasParameter implements Entity {
-		Identifier id;
-		String field;
-
-		@Override public Identifier id() { return id; }
-		public String field(int wonkyParameter) { return field; }
-
-		public static void testException(InvalidTypeException e) {
-			// Actually detected as a missing getter
-			assertThat(e.getMessage(), containsString("No method"));
-		}
-	}
-
-	@FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class GetterReturnsWrongType implements Entity {
-		Identifier id;
-		String field;
-
-		@Override public Identifier id() { return id; }
-		public int field() { return 123; }
-
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("Getter return type"));
-		}
-	}
-
-	@FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class GetterReturnsSupertype implements Entity {
-		Identifier id;
-		Integer field;
-
-		@Override public Identifier id() { return id; }
-		public Number field() { return field; }
-
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("Getter return type"));
-		}
-	}
-
-	@FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class GetterReturnsSubtype implements Entity {
-		Identifier id;
-		Number field;
-
-		@Override public Identifier id() { return id; }
-		public Integer field() { return 123; }
-
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("Getter return type"));
-		}
-	}
-
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE) @RequiredArgsConstructor
-	public static class MutableField implements Entity {
-		Identifier id;
-
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("not final"));
-		}
-	}
-
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE) @RequiredArgsConstructor
-	public static final class MutableInheritedField extends MutableField {
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("not final"));
-		}
-	}
-
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class NestedError implements Entity {
-		Identifier id;
-		GetterReturnsWrongType field;
-
+	public record NestedError(
+		Identifier id,
+		ReferenceToInvalidType field
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("NestedError.field"));
-			assertThat(e.getMessage(), containsString("GetterReturnsWrongType.field"));
+			assertThat(e.getMessage(), containsString("ReferenceToInvalidType.ref"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class ArrayField implements Entity {
-		Identifier id;
-		String[] strings;
-
+	public record ArrayField(
+		Identifier id,
+		String[] strings
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ArrayField.strings"));
 			assertThat(e.getMessage(), containsString("is not a"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class ReferenceToInvalidType implements Entity {
-		Identifier id;
-		Reference<ArrayField> ref;
-
+	public record ReferenceToInvalidType(
+		Identifier id,
+		Reference<ArrayField> ref
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ReferenceToInvalidType.ref"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class CatalogOfInvalidType implements Entity {
-		Identifier id;
-		Catalog<ArrayField> catalog;
+	public record CatalogOfInvalidType(
+		Identifier id,
+		Catalog<ArrayField> catalog
+	) implements Entity {
 
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("CatalogOfInvalidType.catalog"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class ListingOfInvalidType implements Entity {
-		Identifier id;
-		Listing<ArrayField> listing;
-
+	public record ListingOfInvalidType(
+		Identifier id,
+		Listing<ArrayField> listing
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListingOfInvalidType.listing"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class OptionalOfInvalidType implements Entity {
-		Identifier id;
-		Optional<ArrayField> optional;
-
+	public record OptionalOfInvalidType(
+		Identifier id,
+		Optional<ArrayField> optional
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("OptionalOfInvalidType.optional"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class SideTableWithInvalidKey implements Entity {
-		Identifier id;
-		SideTable<ArrayField,String> sideTable;
-
+	public record SideTableWithInvalidKey(
+		Identifier id,
+		SideTable<ArrayField,String> sideTable
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("SideTableWithInvalidKey.sideTable"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class SideTableWithInvalidValue implements Entity {
-		Identifier id;
-		SideTable<SimpleTypes,ArrayField> sideTable;
-
+	public record SideTableWithInvalidValue(
+		Identifier id,
+		SideTable<SimpleTypes,ArrayField> sideTable
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("SideTableWithInvalidValue.sideTable"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class FieldNameWithDollarSign implements Entity {
-		Identifier id;
-		int weird$name;
-
+	public record FieldNameWithDollarSign(
+		Identifier id,
+		int weird$name
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("FieldNameWithDollarSign.weird$name"));
 		}
@@ -479,190 +348,119 @@ class TypeValidationTest {
 	 * According to JLS 3.1, Java identifiers comprise only ASCII characters.
 	 * https://docs.oracle.com/javase/specs/jls/se14/html/jls-3.html#jls-3.1
 	 *
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true) @RequiredArgsConstructor
-	public static final class FieldNameWithNonAsciiLetters implements Entity {
-		Identifier id;
-		int trèsCassé;
-
+	public record FieldNameWithNonAsciiLetters(
+		Identifier id,
+		int trèsCassé
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("FieldNameWithNonAsciiLetters.trèsCassé"));
 		}
 	}
 	 */
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class EnclosingNonReference implements Entity {
-		Identifier id;
-		String enclosingString;
-
-		public EnclosingNonReference(Identifier id, @Enclosing String enclosingString) {
-			this.id = id;
-			this.enclosingString = enclosingString;
-		}
-
+	public record EnclosingNonReference(
+		Identifier id,
+		@Enclosing String enclosingString
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("EnclosingNonReference.enclosingString"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class EnclosingReferenceToString implements Entity {
-		Identifier id;
-		Reference<String> enclosingStringReference;
-
-		public EnclosingReferenceToString(Identifier id, @Enclosing Reference<String> enclosingStringReference) {
-			this.id = id;
-			this.enclosingStringReference = enclosingStringReference;
-		}
-
+	public record EnclosingReferenceToString(
+		Identifier id,
+		@Enclosing Reference<String> enclosingStringReference
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("EnclosingReferenceToString.enclosingStringReference"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class EnclosingReferenceToCatalog implements Entity {
-		Identifier id;
-		Reference<Catalog<SimpleTypes>> enclosingCatalogReference;
-
-		public EnclosingReferenceToCatalog(Identifier id, @Enclosing Reference<Catalog<SimpleTypes>> enclosingCatalogReference) {
-			this.id = id;
-			this.enclosingCatalogReference = enclosingCatalogReference;
-		}
-
+	public record EnclosingReferenceToCatalog(
+		Identifier id,
+		@Enclosing Reference<Catalog<SimpleTypes>> enclosingCatalogReference
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("EnclosingReferenceToCatalog.enclosingCatalogReference"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class EnclosingReferenceToOptional implements Entity {
-		Identifier id;
-		Reference<Optional<SimpleTypes>> enclosingOptionalReference;
-
-		public EnclosingReferenceToOptional(Identifier id, @Enclosing Reference<Optional<SimpleTypes>> enclosingOptionalReference) {
-			this.id = id;
-			this.enclosingOptionalReference = enclosingOptionalReference;
-		}
-
+	public record EnclosingReferenceToOptional(
+		Identifier id,
+		@Enclosing Reference<Optional<SimpleTypes>> enclosingOptionalReference
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("EnclosingReferenceToOptional.enclosingOptionalReference"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class SelfNonReference implements Entity {
-		Identifier id;
-		String str;
-
-		public SelfNonReference(Identifier id, @Enclosing String str) {
-			this.id = id;
-			this.str = str;
-		}
-
+	public record SelfNonReference(
+		Identifier id,
+		@Self String str
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("SelfNonReference.str"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static final class SelfWrongType implements Entity {
-		Identifier id;
-		Reference<SimpleTypes> ref;
-
-		public SelfWrongType(Identifier id, @Self Reference<SimpleTypes> ref) {
-			this.id = id;
-			this.ref = ref;
-		}
-
+	public record SelfWrongType(
+		Identifier id,
+		@Self Reference<SimpleTypes> ref
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("SelfWrongType.ref"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	public static class SelfSubtype implements Entity {
-		Identifier id;
-		Reference<TheSubtype> ref;
-
-		public SelfSubtype(Identifier id, @Self Reference<TheSubtype> ref) {
-			this.id = id;
-			this.ref = ref;
-		}
-
-		public static void testException(InvalidTypeException e) {
-			assertThat(e.getMessage(), containsString("SelfSubtype.ref"));
-		}
-
-		public static class TheSubtype extends SelfSubtype {
-			public TheSubtype(Identifier id, Reference<TheSubtype> ref) {
-				super(id, ref);
-			}
-		}
-	}
-
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class HasDeserializationPath implements Entity {
-		Identifier id;
-		@DeserializationPath("")
-		SimpleTypes badField;
-
+	public record HasDeserializationPath(
+		Identifier id,
+		@DeserializationPath("") SimpleTypes badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("HasDeserializationPath.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueOfIdentifier implements Entity {
-		Identifier id;
-		ListValue<Identifier> badField;
-
+	public record ListValueOfIdentifier(
+		Identifier id,
+		ListValue<Identifier> badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueOfIdentifier.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueOfReference implements Entity {
-		Identifier id;
-		ListValue<Reference<String>> badField;
-
+	public record ListValueOfReference(
+		Identifier id,
+		ListValue<Reference<String>> badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueOfReference.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueOfEntity implements Entity {
-		Identifier id;
-		ListValue<SimpleTypes> badField;
-
+	public record ListValueOfEntity(
+		Identifier id,
+		ListValue<SimpleTypes> badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueOfEntity.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueOfOptional implements Entity {
-		Identifier id;
-		ListValue<Optional<SimpleTypes>> badField;
-
+	public record ListValueOfOptional(
+		Identifier id,
+		ListValue<Optional<SimpleTypes>> badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueOfOptional.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueInvalidSubclass implements Entity {
-		Identifier id;
-		InvalidSubclass badField;
-
+	public record ListValueInvalidSubclass(
+		Identifier id,
+		InvalidSubclass badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueInvalidSubclass.badField"));
 		}
@@ -675,12 +473,10 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueMutableSubclass implements Entity {
-		Identifier id;
-		MutableSubclass badField;
-
+	public record ListValueMutableSubclass(
+		Identifier id,
+		MutableSubclass badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueMutableSubclass.badField"));
 			assertThat(e.getMessage(), containsString("MutableSubclass.mutableField"));
@@ -697,23 +493,19 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueOfInvalidType implements Entity {
-		Identifier id;
-		ListValue<ArrayList<Object>> badField;
-
+	public record ListValueOfInvalidType(
+		Identifier id,
+		ListValue<ArrayList<Object>> badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueOfInvalidType.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueSubclassWithMutableField implements Entity {
-		Identifier id;
-		Subclass badField;
-
+	public record ListValueSubclassWithMutableField(
+		Identifier id,
+		Subclass badField
+	) implements Entity {
 		@Getter @FieldDefaults(level=AccessLevel.PRIVATE)
 		@EqualsAndHashCode(callSuper = true)
 		public static final class Subclass extends ListValue<String> {
@@ -730,12 +522,10 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueSubclassWithTwoConstructors implements Entity {
-		Identifier id;
-		Subclass badField;
-
+	public record ListValueSubclassWithTwoConstructors(
+		Identifier id,
+		Subclass badField
+	) implements Entity {
 		@Getter @FieldDefaults(level=AccessLevel.PRIVATE)
 		@EqualsAndHashCode(callSuper = true)
 		public static final class Subclass extends ListValue<String> {
@@ -754,12 +544,10 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ListValueSubclassWithWrongConstructor implements Entity {
-		Identifier id;
-		Subclass badField;
-
+	public record ListValueSubclassWithWrongConstructor(
+		Identifier id,
+		Subclass badField
+	) implements Entity {
 		@Getter @FieldDefaults(level=AccessLevel.PRIVATE)
 		@EqualsAndHashCode(callSuper = true)
 		public static final class Subclass extends ListValue<String> {
@@ -775,35 +563,29 @@ class TypeValidationTest {
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
 	@DerivedRecord
-	public static final class DerivedRecordType implements Entity {
-		Identifier id;
-
+	public record DerivedRecordType(
+		Identifier id
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString(DerivedRecord.class.getSimpleName()));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class DerivedRecordField implements Entity {
-		Identifier id;
-		DerivedRecordType badField;
-
+	public record DerivedRecordField(
+		Identifier id,
+		DerivedRecordType badField
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString(DerivedRecord.class.getSimpleName()));
 			assertThat(e.getMessage(), containsString("DerivedRecordField.badField"));
 		}
 	}
 
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ReferenceToReference implements Entity {
-		Identifier id;
-		Reference<Reference<String>> ref;
-
+	public record ReferenceToReference(
+		Identifier id,
+		Reference<Reference<String>> ref
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ReferenceToReference.ref"));
 		}
@@ -815,13 +597,11 @@ class TypeValidationTest {
 	 *
 	 * @author Patrick Doyle
 	 */
-	@Getter @FieldDefaults(level=AccessLevel.PRIVATE, makeFinal=true)
-	@RequiredArgsConstructor
-	public static final class ValidThenInvalidOfTheSameClass implements Entity {
-		Identifier id;
-		ListValue<String> good;
-		ListValue<Identifier> bad;
-
+	public record ValidThenInvalidOfTheSameClass(
+		Identifier id,
+		ListValue<String> good,
+		ListValue<Identifier> bad
+	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ValidThenInvalidOfTheSameClass.bad"));
 		}

--- a/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
+++ b/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
@@ -354,10 +354,7 @@ public class PathCompilerTest extends AbstractBoskTest {
 		pathCompiler.compiled(p1); // just make sure this doesn't throw
 	}
 
-	@Value
-	public static class SimpleEntity implements Entity {
-		Identifier id;
-	}
+	public record SimpleEntity(Identifier id) implements Entity { }
 
 	private byte[] classBytes(Class<?> c) {
 		InputStream inputStream = c.getClassLoader().getResourceAsStream(

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonPluginTest.java
@@ -415,13 +415,13 @@ class JacksonPluginTest extends AbstractBoskTest {
 
 	@Test
 	void derivedRecord_list_works() throws JsonProcessingException {
-		ImplicitRefs reflectiveEntity;
+		ImplicitRefs implicitRefs;
 		try (var _ = bosk.readContext()) {
-			reflectiveEntity = refs.parentImplicitRefs().value();
+			implicitRefs = refs.parentImplicitRefs().value();
 		}
 
 		String expectedJSON = boskMapper.writeValueAsString(singletonList(refs.parentImplicitRefs().path().urlEncoded()));
-		String actualJSON = boskMapper.writeValueAsString(new ActualList(reflectiveEntity));
+		String actualJSON = boskMapper.writeValueAsString(new ActualList(implicitRefs));
 
 		assertEquals(expectedJSON, actualJSON);
 
@@ -430,14 +430,14 @@ class JacksonPluginTest extends AbstractBoskTest {
 			deserialized = boskMapper.readerFor(ActualList.class).readValue(expectedJSON);
 		}
 
-		ListValue<ReflectiveEntity<?>> expected = ListValue.of(reflectiveEntity);
+		ListValue<ImplicitRefs> expected = ListValue.of(implicitRefs);
 		assertEquals(expected, deserialized);
 	}
 
 	@Getter
 	@DerivedRecord
-	private static class ActualList extends ListValue<ReflectiveEntity<?>> {
-		protected ActualList(ReflectiveEntity<?>... entries) {
+	private static class ActualList extends ListValue<ImplicitRefs> {
+		protected ActualList(ImplicitRefs... entries) {
 			super(entries);
 		}
 	}

--- a/bosk-testing/src/main/java/works/bosk/drivers/state/TestEntity.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/state/TestEntity.java
@@ -16,17 +16,17 @@ import works.bosk.SideTable;
 import works.bosk.VariantNode;
 import works.bosk.annotations.VariantCaseMap;
 
-@Value
 @With
 @FieldNameConstants
-public class TestEntity implements Entity {
-	Identifier id;
-	String string;
-	Catalog<TestEntity> catalog;
-	Listing<TestEntity> listing;
-	SideTable<TestEntity, TestEntity> sideTable;
-	Variant variant;
-	Optional<TestValues> values;
+public record TestEntity(
+	Identifier id,
+	String string,
+	Catalog<TestEntity> catalog,
+	Listing<TestEntity> listing,
+	SideTable<TestEntity, TestEntity> sideTable,
+	Variant variant,
+	Optional<TestValues> values
+) implements Entity {
 
 	public interface Variant extends VariantNode {
 		@Override

--- a/bosk-testing/src/main/java/works/bosk/drivers/state/TestValues.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/state/TestValues.java
@@ -10,15 +10,14 @@ import works.bosk.StateTreeNode;
 
 import static java.time.temporal.ChronoUnit.FOREVER;
 
-@Value
 @With
 @FieldNameConstants
-public class TestValues implements StateTreeNode {
-	String string;
-	ChronoUnit chronoUnit;
-	ListValue<String> list;
-	MapValue<String> map;
-
+public record TestValues(
+	String string,
+	ChronoUnit chronoUnit,
+	ListValue<String> list,
+	MapValue<String> map
+) implements StateTreeNode {
 	public static TestValues blank() {
 		return new TestValues("", FOREVER, ListValue.empty(), MapValue.empty());
 	}

--- a/buildSrc/src/main/groovy/bosk.development.gradle
+++ b/buildSrc/src/main/groovy/bosk.development.gradle
@@ -35,7 +35,7 @@ allprojects {
 
 dependencies {
 	compileJava {
-		options.compilerArgs << '-parameters'
+		options.compilerArgs << '-parameters'        // @ParametersByName doesn't work without this; not sure why
 		options.compilerArgs << '-Xlint'
 		options.compilerArgs << '-Xlint:-serial'     // Don't care about Java serialization
 		options.compilerArgs << '-Xlint:-try'        // Really annoying bogus "auto-closeable never used" warnings
@@ -43,7 +43,7 @@ dependencies {
 	}
 
 	compileTestJava {
-		options.compilerArgs << '-parameters'
+		options.compilerArgs << '-parameters' // For @ParametersByName
 	}
 }
 

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -110,12 +110,7 @@ It has no functionality.
 `Entity` is a `StateTreeNode` that has a method `id()` returning an `Identifier`.
 This allows them to be stored in a `Catalog` (see below).
 
-A node's contents are defined by the names and types of its constructor's arguments.
-Each argument must have a corresponding getter method with the same name, taking no arguments, and returning the same type.
-(These conventions are compatible with `record` types, which are encouraged.)
-In the context of a bosk state tree, the constructor arguments and corresponding getters are referred to as "fields"
-regardless of whether they actually correspond to fields of the Java object (though they usually do).
-
+State tree node classes must be `record` types.
 A node is considered to _contain_ its fields, creating a whole/part parent/child relationship between them.
 Removing a node removes all its descendant nodes.
 Diamond relationships, where two nodes have the same child, are not _prevented_, but they are also not _preserved_:

--- a/lib-testing/src/main/java/works/bosk/AbstractBoskTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractBoskTest.java
@@ -109,17 +109,15 @@ public abstract class AbstractBoskTest {
 		}
 	}
 
-	@Value
-	@EqualsAndHashCode(callSuper=true)
 	@With
 	@FieldNameConstants
-	public static class ImplicitRefs extends ReflectiveEntity<ImplicitRefs> {
-		Identifier id;
-		Reference<ImplicitRefs> reference;
-		Reference<TestEntity> enclosingRef;
-		@Self Reference<ImplicitRefs> reference2;
-		@Enclosing Reference<TestEntity> enclosingRef2;
-
+	public record ImplicitRefs(
+		Identifier id,
+		Reference<ImplicitRefs> reference,
+		Reference<TestEntity> enclosingRef,
+		@Self Reference<ImplicitRefs> reference2,
+		@Enclosing Reference<TestEntity> enclosingRef2
+	) implements ReflectiveEntity<ImplicitRefs> {
 		public ImplicitRefs(Identifier id, @Self Reference<ImplicitRefs> reference, @Enclosing Reference<TestEntity> enclosingRef, Reference<ImplicitRefs> reference2, Reference<TestEntity> enclosingRef2) {
 			this.id = id;
 			this.reference = reference;


### PR DESCRIPTION
Supporting classes that aren't records is a hassle, because we need to use the java `-parameters` flag to get the names of the constructor arguments (to avoid heinous amounts of annotations), and check that the class has the required getters, and that all its fields are final, and so on.

Let's just mandate records.