### PR TITLE
JsonNode utilities in bosk-jackson

### DIFF
--- a/bosk-annotations/build.gradle
+++ b/bosk-annotations/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
 	id 'bosk.maven-publish'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {

--- a/bosk-core/build.gradle
+++ b/bosk-core/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
 	id 'info.solidsoft.pitest' version '1.7.4'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {

--- a/bosk-core/src/main/java/works/bosk/Phantom.java
+++ b/bosk-core/src/main/java/works/bosk/Phantom.java
@@ -18,6 +18,8 @@ package works.bosk;
  * and reference that as your domain.
  */
 public final class Phantom<T> {
+	private Phantom() {}
+
 	public static <T> Phantom<T> empty() {
 		@SuppressWarnings("unchecked")
 		Phantom<T> instance = (Phantom<T>) INSTANCE;

--- a/bosk-core/src/main/java/works/bosk/Reference.java
+++ b/bosk-core/src/main/java/works/bosk/Reference.java
@@ -144,6 +144,10 @@ public sealed interface Reference<T> permits
 		return path().parametersFrom(definitePath);
 	}
 
+	default boolean isRoot() {
+		return path().isEmpty();
+	}
+
 	/**
 	 * @return The equivalent of {@link Bosk#rootReference()} on the <code>bosk</code> to which this Reference applies,
 	 * but without static type checking; the intent is that you'd call {@link #then} on the resulting reference,

--- a/bosk-jackson/build.gradle
+++ b/bosk-jackson/build.gradle
@@ -2,7 +2,7 @@
 plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPlugin.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonPlugin.java
@@ -782,7 +782,7 @@ public final class JacksonPlugin extends SerializationPlugin {
 		// use getCanonicalConstructor, we rule out using things that currently work as derived
 		// records, such as subclasses of ListValue, which can't be records. I'm not going to sweat
 		// this too much right now because I think derived records are likely to go away soon enough anyway.
-		Constructor<L> constructor = (Constructor<L>) (Constructor) ReferenceUtils.theOnlyConstructorFor(objClass);
+		Constructor<L> constructor = (Constructor<L>) ReferenceUtils.theOnlyConstructorFor(objClass);
 		Class<?>[] parameters = constructor.getParameterTypes();
 		if (parameters.length == 1 && parameters[0].getComponentType().equals(entryClass)) {
 			JavaType referenceType = TypeFactory.defaultInstance().constructParametricType(Reference.class, entryClass);

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
@@ -1,0 +1,122 @@
+package works.bosk.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import works.bosk.BoskDriver;
+import works.bosk.BoskInfo;
+import works.bosk.DriverFactory;
+import works.bosk.Identifier;
+import works.bosk.Reference;
+import works.bosk.StateTreeNode;
+import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.jackson.JsonNodeSurgeon.NodeInfo;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.Root;
+
+/**
+ * Maintains an in-memory representation of the bosk state
+ * in the form of a tree of {@link JsonNode} objects.
+ */
+public class JsonNodeDriver implements BoskDriver {
+	final BoskDriver downstream;
+	final ObjectMapper mapper;
+	final JsonNodeSurgeon surgeon;
+	protected JsonNode currentRoot;
+	int updateNumber = 0;
+
+	public static <R extends StateTreeNode> DriverFactory<R> factory(JacksonPlugin jacksonPlugin) {
+		return (b,d) -> new JsonNodeDriver(b, d, jacksonPlugin);
+	}
+
+	protected JsonNodeDriver(BoskInfo<?> bosk, BoskDriver downstream, JacksonPlugin jacksonPlugin) {
+		this.downstream = downstream;
+		this.mapper = new ObjectMapper();
+		this.surgeon = new JsonNodeSurgeon();
+		mapper.registerModule(jacksonPlugin.moduleFor(bosk));
+	}
+
+	@Override
+	public synchronized StateTreeNode initialRoot(Type rootType) throws InvalidTypeException, IOException, InterruptedException {
+		StateTreeNode result = downstream.initialRoot(rootType);
+		currentRoot = mapper.convertValue(result, JsonNode.class);
+		traceCurrentState("After initialRoot");
+		return result;
+	}
+
+	@Override
+	public synchronized <T> void submitReplacement(Reference<T> target, T newValue) {
+		traceCurrentState("Before submitReplacement");
+		doReplacement(surgeon.nodeInfo(currentRoot, target), target.path().lastSegment(), newValue);
+		downstream.submitReplacement(target, newValue);
+		traceCurrentState("After submitReplacement");
+	}
+
+	@Override
+	public synchronized <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		traceCurrentState("Before submitConditionalReplacement");
+		if (requiredValue.toString().equals(surgeon.valueNode(currentRoot, precondition).textValue())) {
+			doReplacement(surgeon.nodeInfo(currentRoot, target), target.path().lastSegment(), newValue);
+		}
+		downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+		traceCurrentState("After submitConditionalReplacement");
+	}
+
+	@Override
+	public synchronized <T> void submitInitialization(Reference<T> target, T newValue) {
+		traceCurrentState("Before submitInitialization");
+		if (surgeon.valueNode(currentRoot, target) == null) {
+			doReplacement(surgeon.nodeInfo(currentRoot, target), target.path().lastSegment(), newValue);
+		}
+		downstream.submitInitialization(target, newValue);
+		traceCurrentState("After submitInitialization");
+	}
+
+	@Override
+	public synchronized <T> void submitDeletion(Reference<T> target) {
+		traceCurrentState("Before submitDeletion");
+		surgeon.deleteNode(surgeon.nodeInfo(currentRoot, target));
+		downstream.submitDeletion(target);
+		traceCurrentState("After submitDeletion");
+	}
+
+	@Override
+	public synchronized <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		traceCurrentState("Before submitConditionalDeletion");
+		if (requiredValue.toString().equals(surgeon.valueNode(currentRoot, precondition).textValue())) {
+			surgeon.deleteNode(surgeon.nodeInfo(currentRoot, target));
+		}
+		downstream.submitConditionalDeletion(target, precondition, requiredValue);
+		traceCurrentState("After submitConditionalDeletion");
+	}
+
+	@Override
+	public synchronized void flush() throws IOException, InterruptedException {
+		traceCurrentState("Before flush");
+		downstream.flush();
+	}
+
+	private <T> void doReplacement(NodeInfo nodeInfo, String lastSegment, T newValue) {
+		JsonNode replacement = surgeon.replacementNode(nodeInfo, lastSegment, () -> mapper.convertValue(newValue, JsonNode.class));
+		if (nodeInfo.replacementLocation() instanceof Root) {
+			currentRoot = replacement;
+		} else {
+			surgeon.replaceNode(nodeInfo, replacement);
+		}
+	}
+
+	void traceCurrentState(String description) {
+		if (LOGGER.isTraceEnabled()) {
+			try {
+				LOGGER.trace("State {} {}:\n{}", ++updateNumber, description, mapper.writerWithDefaultPrettyPrinter().writeValueAsString(currentRoot));
+			} catch (JsonProcessingException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JsonNodeDriver.class);
+}

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeSurgeon.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeSurgeon.java
@@ -1,0 +1,314 @@
+package works.bosk.jackson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.Map;
+import java.util.function.Supplier;
+import works.bosk.Catalog;
+import works.bosk.Listing;
+import works.bosk.Path;
+import works.bosk.Reference;
+import works.bosk.SideTable;
+import works.bosk.exceptions.NotYetImplementedException;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.ArrayElement;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.NonexistentParent;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.ObjectMember;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.Root;
+
+import static java.util.Objects.requireNonNull;
+import static works.bosk.jackson.JsonNodeSurgeon.ReplacementStyle.ID_ONLY;
+import static works.bosk.jackson.JsonNodeSurgeon.ReplacementStyle.PLAIN;
+import static works.bosk.jackson.JsonNodeSurgeon.ReplacementStyle.WRAPPED_ENTITY;
+
+/**
+ * Utilities to find and modify the {@link JsonNode} corresponding to
+ * a given bosk {@link Reference}.
+ *
+ * <p>
+ * Note: currently only works with {@link works.bosk.jackson.JacksonPluginConfiguration.MapShape#ARRAY MapShape.ARRAY}.
+ */
+public class JsonNodeSurgeon {
+	/**
+	 * Describes how to access a particular {@link JsonNode} from its parent node.
+	 */
+	public sealed interface NodeLocation {
+		public record Root() implements NodeLocation {}
+		public record ObjectMember(ObjectNode parent, String memberName) implements NodeLocation {
+			public ObjectMember {
+				requireNonNull(parent);
+				requireNonNull(memberName);
+			}
+		}
+		public record ArrayElement(ArrayNode parent, int elementIndex) implements NodeLocation {
+			public ArrayElement {
+				requireNonNull(parent);
+				// Note that elementIndex == parent.size() is valid for nonexistent array elements
+				if (elementIndex < 0 || elementIndex > parent.size()) {
+					throw new IllegalArgumentException("Invalid index: " + elementIndex);
+				}
+			}
+		}
+
+		/**
+		 * The parent {@link JsonNode} does not exist, so there's no way to describe
+		 * the desired node's location.
+		 *
+		 * <p>
+		 * (Note that the parent {@link JsonNode} is not always the node corresponding
+		 * to the {@link Reference#enclosingReference enclosing reference}.
+		 * They're two related but different concepts. See {@link ReplacementStyle#WRAPPED_ENTITY WRAPPED_ENTITY}.)
+		 */
+		public record NonexistentParent() implements NodeLocation {}
+	}
+
+	/**
+	 * Describes what should be placed at a {@link NodeLocation} in order to
+	 * {@link works.bosk.BoskDriver#submitReplacement replace} a bosk node.
+	 */
+	public enum ReplacementStyle {
+		/**
+		 * Use the serialized form of the resired value
+		 */
+		PLAIN,
+
+		/**
+		 * Use the {@link works.bosk.Entity#id id} of the desired entity
+		 */
+		ID_ONLY,
+
+		/**
+		 * Use an {@link ObjectNode} having a single member whose name is the desired
+		 * entity's {@link works.bosk.Entity#id id} and whose value is the serialized
+		 * form of the desired entity.
+		 *
+		 * <p>
+		 * Note that this is the style that causes the {@link NodeInfo#valueLocation value location}
+		 * to differ from the {@link NodeInfo#replacementLocation replacement location},
+		 * because the value is placed inside another object.
+		 * In particular, for nonexistent entities,
+		 * the <i>value location</i> will be {@link NonexistentParent NonexistentParent}
+		 * because the parent JSON node (the wrapper object) doesn't yet exist,
+		 * since it is created at the same time as the JSON node for the entity;
+		 * however, the <i>replacement location</i> will exist (that is, it will be
+		 * something other than {@link NonexistentParent NonexistentParent}
+		 * and will indicate where the wrapper object should be.
+		 */
+		WRAPPED_ENTITY,
+	};
+
+	/**
+	 * Information about which {@link JsonNode} corresponds to a particular {@link Reference}.
+	 * This can be used to find the node, and to replace or delete it.
+	 *
+	 * <p>
+	 * The indicated {@link JsonNode} need not actually exist in the tree: so long as the
+	 * parent node exists, we can describe where the node <em>would</em> be if it existed,
+	 * which is useful for adding new nodes to the tree as well as modifying existing ones.
+	 *
+	 * <p>
+	 * However, if the parent node does not exist, the location will be described using {@link NonexistentParent NonexistentParent}.
+	 *
+	 * @param valueLocation the JsonNode containing the referenced value
+	 * @param replacementLocation the JsonNode to be replaced when the reference value is modified
+	 * @param replacementStyle the means by which {@code replacementLocation} should be modified
+	 */
+	public record NodeInfo(
+		NodeLocation valueLocation,
+		NodeLocation replacementLocation,
+		ReplacementStyle replacementStyle
+	) {
+		static NodeInfo plain(NodeLocation theLocation) {
+			return new NodeInfo(theLocation, theLocation, PLAIN);
+		}
+
+		static NodeInfo idOnly(NodeLocation theLocation) {
+			return new NodeInfo(theLocation, theLocation, ID_ONLY);
+		}
+
+		static NodeInfo wrappedEntity(NodeLocation valueLocation, NodeLocation replacementLocation) {
+			return new NodeInfo(valueLocation, replacementLocation, WRAPPED_ENTITY);
+		}
+	}
+
+	/**
+	 * @return null if {@code doc} has no node corresponding to {@code ref}
+	 */
+	public JsonNode valueNode(JsonNode doc, Reference<?> ref) {
+		return getNode(nodeInfo(doc, ref).valueLocation, doc);
+	}
+
+	/**
+	 * @param rootDocument is needed only if {@code location} is a {@link Root},
+	 *                     in which case it is returned. It can even be null.
+	 * @return null if the node does not exist
+	 */
+	public JsonNode node(NodeLocation location, JsonNode rootDocument) {
+		return getNode(location, rootDocument);
+	}
+
+	/**
+	 * @return the JSON node that must be modified to replace or delete {@code ref}.
+	 */
+	public NodeInfo nodeInfo(JsonNode doc, Reference<?> ref) {
+		if (ref.isRoot()) {
+			return NodeInfo.plain(new Root());
+		}
+
+		// For some kinds of enclosing nodes, the JSON structure differs from the bosk structure.
+		// Peel off those cases.
+		Reference<?> enclosingRef = ref.enclosingReference(Object.class);
+		NodeLocation parentLocation = nodeInfo(doc, enclosingRef).valueLocation;
+		var parent = getNode(parentLocation, doc);
+		if (Listing.class.isAssignableFrom(enclosingRef.targetClass())) {
+			if (parent == null) {
+				return NodeInfo.idOnly(new NonexistentParent());
+			}
+			var ids = (ArrayNode)parent.get("ids");
+			var id = ref.path().lastSegment();
+			for (int i = 0; i < ids.size(); i++) {
+				if (id.equals(((TextNode)ids.get(i)).textValue())) {
+					return NodeInfo.idOnly(new ArrayElement(ids, i));
+				}
+			}
+			// New entries go at the end
+			return NodeInfo.idOnly(new ArrayElement(ids, ids.size()));
+		} else if (Catalog.class.isAssignableFrom(enclosingRef.targetClass())) {
+			if (parent == null) {
+				return NodeInfo.wrappedEntity(new NonexistentParent(), new NonexistentParent());
+			} else {
+				String entryID = ref.path().lastSegment();
+				NodeLocation element = findArrayElementWithId(parent, entryID);
+				JsonNode elementNode = getNode(element, doc);
+				if (elementNode == null) {
+					// Doesn't exist yet
+					return NodeInfo.wrappedEntity (new NonexistentParent(), element);
+				} else {
+					return NodeInfo.wrappedEntity (getMapEntryValueLocation(elementNode, entryID), element);
+				}
+			}
+		} else if (SideTable.class.isAssignableFrom(enclosingRef.targetClass())) {
+			if (parent == null) {
+				return NodeInfo.wrappedEntity(new NonexistentParent(), new NonexistentParent());
+			} else {
+				String entryID = ref.path().lastSegment();
+				NodeLocation element = findArrayElementWithId(parent.get("valuesById"), entryID);
+				JsonNode elementNode = getNode(element, doc);
+				if (elementNode == null) {
+					// Doesn't exist yet
+					return NodeInfo.wrappedEntity(new NonexistentParent(), element);
+				} else {
+					return NodeInfo.wrappedEntity(getMapEntryValueLocation(elementNode, entryID), element);
+				}
+			}
+		}
+		
+		// For every other type, this is an object member contained in the parent
+		NodeLocation valueLocation = parent == null
+			? new NonexistentParent()
+			: new ObjectMember((ObjectNode) parent, ref.path().lastSegment());
+		return NodeInfo.plain(valueLocation);
+	}
+
+	private static ObjectMember getMapEntryValueLocation(JsonNode element, String entryID) {
+		return new ObjectMember((ObjectNode) element, entryID);
+	}
+
+	private static NodeLocation findArrayElementWithId(JsonNode entries, String id) {
+		ArrayNode entriesArray = (ArrayNode) entries;
+		for (int i = 0; i < entriesArray.size(); i++) {
+			ObjectNode entryObject = (ObjectNode) entries.get(i);
+			var properties = entryObject.properties();
+			if (properties.size() != 1) {
+				throw new NotYetImplementedException(properties.toString());
+			}
+			Map.Entry<String, JsonNode> entry = properties.iterator().next();
+			if (id.equals(entry.getKey())) {
+				return new ArrayElement(entriesArray, i);
+			}
+		}
+		return new ArrayElement(entriesArray, entries.size());
+	}
+
+	private static JsonNode getNode(NodeLocation nodeLocation, JsonNode rootDocument) {
+		return switch (nodeLocation) {
+			case ArrayElement a -> {
+				yield a.parent().get(a.elementIndex());
+			}
+			case ObjectMember o -> {
+				yield o.parent().get(o.memberName());
+			}
+			case Root() -> {
+				yield rootDocument;
+			}
+			case NonexistentParent() -> {
+				yield null;
+			}
+		};
+	}
+
+	/**
+	 * @throws IllegalArgumentException if {@link NodeInfo#replacementLocation() nodeInfo.replacementLocation} is {@link Root Root} or {@link NonexistentParent NonexistentParent}.
+	 *                                  Callers must handle these cases.
+	 */
+	public void replaceNode(NodeInfo nodeInfo, JsonNode replacement) {
+		var location = nodeInfo.replacementLocation();
+		if (location instanceof NonexistentParent) {
+			// Nothing to do
+			return;
+		}
+		switch (location) {
+			case Root() -> {
+				throw new IllegalArgumentException("Cannot replace root node");
+			}
+			case JsonNodeSurgeon.NodeLocation.ArrayElement(var parent, int i) -> {
+				if (parent.size() == i) {
+					parent.add(replacement);
+				} else {
+					parent.set(i, replacement);
+				}
+			}
+			case JsonNodeSurgeon.NodeLocation.ObjectMember(var parent, String member) -> {
+				parent.set(member, replacement);
+			}
+			case NonexistentParent() -> {
+				throw new IllegalArgumentException("This should already have been handled");
+			}
+		}
+	}
+
+	/**
+	 * @param lastSegment the {@link Path#lastSegment() lastSegment} of the {@link Reference} pointing at the node to be replaced.
+	 */
+	public JsonNode replacementNode(NodeInfo nodeInfo, String lastSegment, Supplier<JsonNode> newValue) {
+		return switch (nodeInfo.replacementStyle()) {
+			case PLAIN -> newValue.get();
+			case ID_ONLY -> new TextNode(lastSegment);
+			case WRAPPED_ENTITY -> {
+				JsonNode entityNode = newValue.get();
+				String id = entityNode.get("id").textValue();
+				yield new ObjectNode(JsonNodeFactory.instance, Map.of(id, entityNode));
+			}
+		};
+	}
+
+	public void deleteNode(NodeInfo nodeInfo) {
+		switch (nodeInfo.replacementLocation()) {
+			case Root() -> {
+				throw new IllegalArgumentException("Cannot delete root");
+			}
+			case JsonNodeSurgeon.NodeLocation.ArrayElement(var parent, int i) -> {
+				parent.remove(i);
+			}
+			case JsonNodeSurgeon.NodeLocation.ObjectMember(var parent, String member) -> {
+				parent.remove(member);
+			}
+			case NonexistentParent() -> {
+				// Nothing to do
+			}
+		}
+	}
+
+}

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeDriverConformanceTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeDriverConformanceTest.java
@@ -1,0 +1,15 @@
+package works.bosk.jackson;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.LoggerFactory;
+import works.bosk.drivers.DriverConformanceTest;
+
+// TODO: This currently doesn't test much beyond the driver's ability to pass updates downstream
+class JsonNodeDriverConformanceTest extends DriverConformanceTest {
+	@BeforeEach
+	void setUp() {
+		driverFactory = JsonNodeDriver.factory(new JacksonPlugin());
+	}
+}

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeSurgeonTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeSurgeonTest.java
@@ -1,0 +1,219 @@
+package works.bosk.jackson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import works.bosk.Bosk;
+import works.bosk.Catalog;
+import works.bosk.CatalogReference;
+import works.bosk.Entity;
+import works.bosk.Identifier;
+import works.bosk.Listing;
+import works.bosk.ListingEntry;
+import works.bosk.ListingReference;
+import works.bosk.Reference;
+import works.bosk.SideTable;
+import works.bosk.SideTableReference;
+import works.bosk.StateTreeNode;
+import works.bosk.annotations.ReferencePath;
+import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.jackson.JsonNodeSurgeon.NodeInfo;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.ArrayElement;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.NonexistentParent;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.ObjectMember;
+import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.Root;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static works.bosk.BoskTestUtils.boskName;
+import static works.bosk.ListingEntry.LISTING_ENTRY;
+import static works.bosk.jackson.JacksonPluginConfiguration.MapShape.ARRAY;
+
+// TODO: Test mutation methods too
+public class JsonNodeSurgeonTest {
+	Bosk<JsonRoot> bosk;
+	Refs refs;
+	JacksonPlugin jacksonPlugin;
+	ObjectMapper mapper;
+	JsonNodeSurgeon surgeon;
+
+	@BeforeEach
+	void setUp() throws InvalidTypeException {
+		bosk = new Bosk<JsonRoot>(
+			boskName(),
+			JsonRoot.class,
+			b->JsonRoot.empty(b.buildReferences(Refs.class)),
+			Bosk.simpleDriver());
+		refs = bosk.buildReferences(Refs.class);
+		jacksonPlugin = new JacksonPlugin(new JacksonPluginConfiguration(ARRAY));
+		mapper = new ObjectMapper();
+		mapper.registerModule(jacksonPlugin.moduleFor(bosk));
+		surgeon = new JsonNodeSurgeon();
+	}
+
+	public record JsonRoot(
+		Identifier id,
+		String string,
+		Catalog<JsonEntity> catalog,
+		Listing<JsonEntity> listing,
+		SideTable<JsonEntity, JsonEntity> sideTable
+	) implements StateTreeNode {
+		public static final JsonRoot empty(Refs refs) {
+			return new JsonRoot(
+				Identifier.from("testID"),
+				"testString",
+				Catalog.empty(),
+				Listing.empty(refs.catalog()),
+				SideTable.empty(refs.catalog()));
+		}
+	}
+
+	public record JsonEntity(
+		Identifier id
+	) implements Entity {}
+
+	public interface Refs {
+		@ReferencePath("/id") Reference<Identifier> id();
+		@ReferencePath("/string") Reference<String> string();
+		@ReferencePath("/catalog") CatalogReference<JsonEntity> catalog();
+		@ReferencePath("/catalog/-jsonEntity-") Reference<JsonEntity> catalogEntry(Identifier jsonEntity);
+		@ReferencePath("/catalog/-jsonEntity-/id") Reference<Identifier> catalogEntryID(Identifier jsonEntity);
+		@ReferencePath("/listing") ListingReference<JsonEntity> listing();
+		@ReferencePath("/listing/-jsonEntity-") Reference<ListingEntry> listingEntry(Identifier jsonEntity);
+		@ReferencePath("/sideTable") SideTableReference<JsonEntity, JsonEntity> sideTable();
+		@ReferencePath("/sideTable/-jsonEntity-") Reference<JsonEntity> sideTableEntry(Identifier jsonEntity);
+		@ReferencePath("/sideTable/-jsonEntity-/id") Reference<Identifier> sideTableEntryID(Identifier jsonEntity);
+	}
+
+	@Test
+	void root() throws IOException, InterruptedException {
+		JsonNode doc = boskContents();
+		NodeInfo expected = NodeInfo.plain(new Root());
+		NodeInfo actual = surgeon.nodeInfo(doc, bosk.rootReference());
+		assertEquals(expected, actual);
+		assertEquals(doc, surgeon.valueNode(doc, bosk.rootReference()));
+	}
+
+	@Test
+	void id() throws IOException, InterruptedException {
+		JsonNode doc = boskContents();
+		NodeInfo expected = NodeInfo.plain(new ObjectMember((ObjectNode) doc, "id"));
+		NodeInfo actual = surgeon.nodeInfo(doc, refs.id());
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void string() throws IOException, InterruptedException {
+		JsonNode doc = boskContents();
+		NodeInfo expected = NodeInfo.plain(new ObjectMember((ObjectNode) doc, "string"));
+		NodeInfo actual = surgeon.nodeInfo(doc, refs.string());
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void catalog() throws IOException, InterruptedException {
+		JsonNode doc = boskContents();
+		NodeInfo expected = NodeInfo.plain(new ObjectMember((ObjectNode) doc, "catalog"));
+		NodeInfo actual = surgeon.nodeInfo(doc, refs.catalog());
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void catalogEntry() throws IOException, InterruptedException {
+		Identifier id = Identifier.from("testEntry");
+		bosk.driver().submitReplacement(refs.catalogEntry(id), new JsonEntity(id));
+		JsonNode doc = boskContents();
+		JsonNode catalogArray = doc.get("catalog");
+		JsonNode catalogEntry = catalogArray.get(0);
+		{
+			NodeInfo expected = NodeInfo.wrappedEntity(
+				new ObjectMember((ObjectNode) catalogEntry, "testEntry"),
+				new ArrayElement((ArrayNode) catalogArray, 0));
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.catalogEntry(id));
+			assertEquals(expected, actual);
+		}
+		{
+			NodeInfo expected = NodeInfo.wrappedEntity(
+				new NonexistentParent(),
+				new ArrayElement((ArrayNode) catalogArray, 1));
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.catalogEntry(Identifier.from("NONEXISTENT")));
+			assertEquals(expected, actual);
+		}
+		{
+			NodeInfo expected = NodeInfo.plain(new NonexistentParent());
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.catalogEntryID(Identifier.from("NONEXISTENT")));
+			assertEquals(expected, actual);
+		}
+	}
+
+	@Test void listing() throws IOException, InterruptedException {
+		JsonNode doc = boskContents();
+		NodeInfo expected = NodeInfo.plain(new ObjectMember((ObjectNode) doc, "listing"));
+		NodeInfo actual = surgeon.nodeInfo(doc, refs.listing());
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void listingEntry() throws IOException, InterruptedException {
+		Identifier id = Identifier.from("testEntry");
+		bosk.driver().submitReplacement(refs.listingEntry(id), LISTING_ENTRY);
+		JsonNode doc = boskContents();
+		JsonNode idsArray = doc.get("listing").get("ids");
+		{
+			NodeInfo expected = NodeInfo.idOnly(new ArrayElement((ArrayNode) idsArray, 0));
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.listingEntry(id));
+			assertEquals(expected, actual);
+		}
+		{
+			NodeInfo expected = NodeInfo.idOnly(new ArrayElement((ArrayNode) idsArray, 1));
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.listingEntry(Identifier.from("NONEXISTENT")));
+			assertEquals(expected, actual);
+		}
+	}
+
+	@Test void sideTable() throws IOException, InterruptedException {
+		JsonNode doc = boskContents();
+		NodeInfo expected = NodeInfo.plain(new ObjectMember((ObjectNode) doc, "sideTable"));
+		NodeInfo actual = surgeon.nodeInfo(doc, refs.sideTable());
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void sideTableEntry() throws IOException, InterruptedException {
+		Identifier id = Identifier.from("testKey");
+		bosk.driver().submitReplacement(refs.sideTableEntry(id), new JsonEntity(Identifier.from("testValue")));
+		JsonNode doc = boskContents();
+		JsonNode valuesById = doc.get("sideTable").get("valuesById");
+		JsonNode entry = valuesById.get(0);
+		{
+			NodeInfo expected = NodeInfo.wrappedEntity(
+				new ObjectMember((ObjectNode) entry, "testKey"),
+				new ArrayElement((ArrayNode) valuesById, 0));
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.sideTableEntry(id));
+			assertEquals(expected, actual);
+		}
+		{
+			NodeInfo expected = NodeInfo.wrappedEntity(
+				new NonexistentParent(),
+				new ArrayElement((ArrayNode) valuesById, 1));
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.sideTableEntry(Identifier.from("NONEXISTENT")));
+			assertEquals(expected, actual);
+		}
+		{
+			NodeInfo expected = NodeInfo.plain(new NonexistentParent());
+			NodeInfo actual = surgeon.nodeInfo(doc, refs.sideTableEntryID(Identifier.from("NONEXISTENT")));
+			assertEquals(expected, actual);
+		}
+	}
+
+	JsonNode boskContents() throws IOException, InterruptedException {
+		bosk.driver().flush();
+		try (var __ = bosk.readContext()) {
+			return mapper.convertValue(bosk.rootReference().value(), JsonNode.class);
+		}
+	}
+}

--- a/bosk-logback/build.gradle
+++ b/bosk-logback/build.gradle
@@ -2,7 +2,7 @@
 plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {

--- a/bosk-mongo/build.gradle
+++ b/bosk-mongo/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
 	id 'info.solidsoft.pitest' version '1.15.0'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 base {

--- a/bosk-spring-boot-3/build.gradle
+++ b/bosk-spring-boot-3/build.gradle
@@ -2,7 +2,7 @@
 plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {

--- a/bosk-testing/build.gradle
+++ b/bosk-testing/build.gradle
@@ -2,7 +2,7 @@
 plugins {
 	id 'bosk.development'
 	id 'bosk.maven-publish'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.Bosk;
+import works.bosk.BoskDiagnosticContext;
 import works.bosk.BoskDriver;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
@@ -459,7 +460,9 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		bosk.registerHook("contextPropagatesToHook", bosk.rootReference(), ref -> {
 			// Note that this will run as soon as it's registered
 			if (diagnosticsAreReady.get()) {
-				assertEquals("attributeValue", bosk.diagnosticContext().getAttribute("attributeName"));
+				BoskDiagnosticContext boskDiagnosticContext = bosk.diagnosticContext();
+				LOGGER.debug("Received diagnostic attributes: {}", boskDiagnosticContext.getAttributes());
+				assertEquals("attributeValue", boskDiagnosticContext.getAttribute("attributeName"));
 				diagnosticsVerified.release();
 			}
 		});

--- a/lib-testing/build.gradle
+++ b/lib-testing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'bosk.development'
-	id 'com.github.spotbugs' version '5.1.5'
+	id 'com.github.spotbugs' version '6.1.2'
 }
 
 java {


### PR DESCRIPTION
Much like `BsonSurgeon` gives us a nice ability to edit MongoDB documents in bosk-mongo, this adds a more general JSON-based way to edit JSON documents for any purpose.

Spoiler: I want to use this for a very simple SQL driver that simply stores the bosk state as a JSON document.