### PR TITLE
Remove USE_IF_EXISTS support and other cleanup

### DIFF
--- a/bosk-core/src/main/java/works/bosk/bytecode/ClassBuilder.java
+++ b/bosk-core/src/main/java/works/bosk/bytecode/ClassBuilder.java
@@ -196,8 +196,6 @@ public final class ClassBuilder<T> {
 	 */
 	public void pushObject(String name, Object object, Class<?> type) {
 		type.cast(object);
-
-		// TODO: Use ConstantDynamic instead
 		invokeDynamic(name, new ConstantCallSite(MethodHandles.constant(type, object)));
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
@@ -264,7 +264,11 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			collection.deleteMany(deletionFilter);
 
 			newFormatDriver.initializeCollection(result);
+
+			// We must rudely commit the transaction here, since correctness requires that
+			// the database updates commit before we publish newFormatDriver.
 			collection.commitTransaction();
+
 			publishFormatDriver(newFormatDriver);
 		} catch (UninitializedCollectionException e) {
 			throw new IOException("Unable to refurbish uninitialized database collection", e);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
@@ -46,7 +46,6 @@ import static works.bosk.drivers.mongo.Formatter.REVISION_ONE;
 import static works.bosk.drivers.mongo.Formatter.REVISION_ZERO;
 import static works.bosk.drivers.mongo.MappedDiagnosticContext.setupMDC;
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
-import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestMode.USE_IF_EXISTS;
 
 /**
  * This is the driver returned to the user by {@link MongoDriver#factory}.
@@ -256,24 +255,11 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			StateAndMetadata<R> result = formatDriver.loadAllState();
 			FormatDriver<R> newFormatDriver = newPreferredFormatDriver();
 
-			BsonDocument deletionFilter;
-			if (driverSettings.experimental().manifestMode() == USE_IF_EXISTS) {
-				// In this weirdo mode, the format driver won't create a manifest
-				// document. We'd better delete the one that's there to avoid
-				// ending up with an incorrect manifest document that doesn't
-				// match the database contents.
-				//
-				// TODO: The sooner we get rid of this mode, the better.
-
-				deletionFilter = new BsonDocument();
-				LOGGER.debug("Deleting manifest due to experimental USE_IF_EXISTS manifest mode");
-			} else {
-				// initializeCollection is required to replace the manifest anyway,
-				// so deleting it has no value; and if we do delete it, then every
-				// FormatDriver must cope with deletions of the manifest document,
-				// which is a burden. Let's just not.
-				deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
-			}
+			// initializeCollection is required to replace the manifest anyway,
+			// so deleting it has no value; and if we do delete it, then every
+			// FormatDriver must cope with deletions of the manifest document,
+			// which is a burden. Let's just not.
+			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
 			LOGGER.trace("Deleting state documents: {}", deletionFilter);
 			collection.deleteMany(deletionFilter);
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/Manifest.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/Manifest.java
@@ -3,6 +3,7 @@ package works.bosk.drivers.mongo;
 import java.util.Optional;
 import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
+import works.bosk.drivers.mongo.MongoDriverSettings.SequoiaFormat;
 
 /**
  * Defines the format of the manifest document, which is stored in the database
@@ -35,11 +36,9 @@ public record Manifest(
 	}
 
 	public static Manifest forFormat(DatabaseFormat format) {
-		// TODO: Use a type switch in newer Java versions
-		if (format instanceof PandoFormat p) {
-			return forPando(p);
-		} else {
-			return forSequoia();
-		}
+		return switch (format) {
+			case PandoFormat p -> forPando(p);
+			case SequoiaFormat __ -> forSequoia();
+		};
 	}
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -6,7 +6,6 @@ import lombok.Value;
 import works.bosk.BoskDriver;
 
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
-import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestMode.USE_IF_EXISTS;
 import static works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode.EARNEST;
 
 @Value
@@ -33,7 +32,6 @@ public class MongoDriverSettings {
 	@Builder
 	public static class Experimental {
 		@Default long changeStreamInitialWaitMS = 20;
-		@Default ManifestMode manifestMode = ManifestMode.CREATE_IF_ABSENT;
 		@Default OrphanDocumentMode orphanDocumentMode = OrphanDocumentMode.HASTY;
 	}
 
@@ -94,11 +92,6 @@ public class MongoDriverSettings {
 
 	public enum ManifestMode {
 		/**
-		 * If a manifest document doesn't exist, we'll assume certain defaults.
-		 */
-		USE_IF_EXISTS,
-
-		/**
 		 * If a manifest document doesn't exist, we'll create one.
 		 */
 		CREATE_IF_ABSENT,
@@ -118,9 +111,6 @@ public class MongoDriverSettings {
 
 	public void validate() {
 		if (preferredDatabaseFormat() instanceof PandoFormat) {
-			if (experimental.manifestMode() == USE_IF_EXISTS) {
-				throw new IllegalArgumentException("Pando format requires a manifest. Databases with no manifest are interpreted as Sequoia.");
-			}
 			if (experimental.orphanDocumentMode() == EARNEST) {
 				throw new IllegalArgumentException("Pando format does not support earnest orphan document cleanup");
 			}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormatDriver.java
@@ -231,9 +231,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		LOGGER.trace("| Options: {}", options);
 		UpdateResult result = collection.updateOne(filter, update, options);
 		LOGGER.debug("| Result: {}", result);
-		if (settings.experimental().manifestMode() == MongoDriverSettings.ManifestMode.CREATE_IF_ABSENT) {
-			writeManifest();
-		}
+		writeManifest();
 	}
 
 	private void writeManifest() {
@@ -889,6 +887,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			}
 		} else {
 			// TODO!
+			assert settings.experimental().orphanDocumentMode() == MongoDriverSettings.OrphanDocumentMode.HASTY;
 			LOGGER.debug("Skipping deletePartsUnder({}) because mainRef is different: {}", target, mainRef);
 		}
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -44,7 +44,6 @@ import static org.bson.BsonBoolean.FALSE;
 import static works.bosk.drivers.mongo.Formatter.REVISION_ZERO;
 import static works.bosk.drivers.mongo.Formatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.MainDriver.MANIFEST_ID;
-import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestMode.CREATE_IF_ABSENT;
 import static works.bosk.drivers.mongo.bson.BsonFormatter.referenceTo;
 
 /**
@@ -159,17 +158,15 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 		LOGGER.trace("| Options: {}", options);
 		UpdateResult result = collection.updateOne(filter, update, options);
 		LOGGER.debug("| Result: {}", result);
-		if (settings.experimental().manifestMode() == CREATE_IF_ABSENT) {
-			// This is the only time Sequoia changes two documents for the same operation.
-			// Aside from refurbish, it's the only reason we'd want multi-document transactions,
-			// and it's not even a strong reason, because this still works correctly
-			// if interpreted as two separate events.
-			writeManifest();
-		}
+
+		// This is the only time Sequoia changes two documents for the same operation.
+		// Aside from refurbish, it's the only reason we'd want multi-document transactions,
+		// and it's not even a strong reason, because this still works correctly
+		// if interpreted as two separate events.
+		writeManifest();
 	}
 
 	private void writeManifest() {
-		assert settings.experimental().manifestMode() == CREATE_IF_ABSENT;
 		BsonDocument doc = new BsonDocument("_id", MANIFEST_ID);
 		doc.putAll((BsonDocument) formatter.object2bsonValue(Manifest.forSequoia(), Manifest.class));
 		BsonDocument filter = new BsonDocument("_id", MANIFEST_ID);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/bson/BsonFormatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/bson/BsonFormatter.java
@@ -224,7 +224,6 @@ public class BsonFormatter {
 		// BsonPlugin gives better codecs than CodecRegistry, because BsonPlugin is aware of generics,
 		// so we always try that first. The CodecSupplier protocol uses "null" to indicate that another
 		// CodecSupplier should be used, so we follow that protocol and fall back on the CodecRegistry.
-		// TODO: Should this logic be in BsonPlugin? It has nothing to do with MongoDriver really.
 		Codec<?> result = preferredBoskCodecs.apply(type);
 		if (result == null) {
 			return simpleCodecs.get(rawClass(type));

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -58,10 +58,9 @@ public class SchemaEvolutionTest {
 	@SuppressWarnings("unused")
 	static Stream<Configuration> fromConfig() {
 		return Stream.of(
-			new Configuration(MongoDriverSettings.DatabaseFormat.SEQUOIA, MongoDriverSettings.ManifestMode.USE_IF_EXISTS),
-			new Configuration(MongoDriverSettings.DatabaseFormat.SEQUOIA, MongoDriverSettings.ManifestMode.CREATE_IF_ABSENT),
-			new Configuration(PandoFormat.oneBigDocument(), MongoDriverSettings.ManifestMode.CREATE_IF_ABSENT),
-			new Configuration(PandoFormat.withGraftPoints("/catalog", "/sideTable"), MongoDriverSettings.ManifestMode.CREATE_IF_ABSENT)
+			new Configuration(MongoDriverSettings.DatabaseFormat.SEQUOIA),
+			new Configuration(PandoFormat.oneBigDocument()),
+			new Configuration(PandoFormat.withGraftPoints("/catalog", "/sideTable"))
 		);
 	}
 
@@ -178,16 +177,15 @@ public class SchemaEvolutionTest {
 	}
 
 	private static Bosk<TestEntity> newBosk(Helper helper) {
-		return new Bosk<TestEntity>(boskName(helper.toString()), TestEntity.class, helper::initialRoot, helper.driverFactory);
+		return new Bosk<>(boskName(helper.toString()), TestEntity.class, helper::initialRoot, helper.driverFactory);
 	}
 
 	record Configuration(
-		MongoDriverSettings.DatabaseFormat preferredFormat,
-		MongoDriverSettings.ManifestMode manifestMode
+		MongoDriverSettings.DatabaseFormat preferredFormat
 	) {
 		@Override
 		public String toString() {
-			return preferredFormat + "&" + manifestMode;
+			return preferredFormat.toString();
 		}
 	}
 
@@ -199,9 +197,8 @@ public class SchemaEvolutionTest {
 				.database(SchemaEvolutionTest.class.getSimpleName() + "_" + dbCounter)
 				.preferredDatabaseFormat(config.preferredFormat())
 				.experimental(MongoDriverSettings.Experimental.builder()
-					.manifestMode(config.manifestMode())
 					.build()));
-			this.name = (config.preferredFormat() + ":" + config.manifestMode()).toLowerCase();
+			this.name = config.preferredFormat().toString().toLowerCase();
 		}
 
 		@Override


### PR DESCRIPTION
The `USE_IF_EXISTS` mode was added to support existing production systems that have no manifest file, and allow them to be refurbished gracefully. However, there are currently no production systems using the latest version of Bosk, so this mode isn't needed there.