### PR TITLE
SQL durability test

### DIFF
--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriver.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriver.java
@@ -12,11 +12,14 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import org.jooq.Record;
+import org.jooq.TableField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.BoskDriver;
@@ -28,6 +31,9 @@ import works.bosk.Path;
 import works.bosk.Reference;
 import works.bosk.RootReference;
 import works.bosk.StateTreeNode;
+import works.bosk.drivers.sql.schema.BoskTable;
+import works.bosk.drivers.sql.schema.ChangesTable;
+import works.bosk.drivers.sql.schema.Schema;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
@@ -43,15 +49,8 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.primaryKey;
+import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.using;
-import static works.bosk.drivers.sql.schema.Schema.BOSK;
-import static works.bosk.drivers.sql.schema.Schema.CHANGES;
-import static works.bosk.drivers.sql.schema.Schema.DIAGNOSTICS;
-import static works.bosk.drivers.sql.schema.Schema.ID;
-import static works.bosk.drivers.sql.schema.Schema.NEW_STATE;
-import static works.bosk.drivers.sql.schema.Schema.REF;
-import static works.bosk.drivers.sql.schema.Schema.REVISION;
-import static works.bosk.drivers.sql.schema.Schema.STATE;
 
 public class SqlDriver implements BoskDriver {
 	final SqlDriverSettings settings;
@@ -63,7 +62,20 @@ public class SqlDriver implements BoskDriver {
 
 	final AtomicBoolean isOpen = new AtomicBoolean(true);
 
+	// jOOQ references
+	final TableField<Record, String> DIAGNOSTICS;
+	final ChangesTable CHANGES;
+	final TableField<Record, Long> REVISION;
+	final TableField<Record, String> REF;
+	final TableField<Record, String> NEW_STATE;
+	final TableField<Record, String> STATE;
+	final BoskTable BOSK;
+	final TableField<Record, String> ID;
+
 	final ScheduledExecutorService listener;
+	private final Schema schema;
+
+	private volatile String epoch;
 
 	private final AtomicLong lastChangeSubmittedDownstream = new AtomicLong(-1);
 
@@ -84,6 +96,19 @@ public class SqlDriver implements BoskDriver {
 			result.setAutoCommit(false);
 			return result;
 		};
+
+		// Set up jOOQ references
+		schema = new Schema();
+		REF = schema.REF;
+		NEW_STATE = schema.NEW_STATE;
+		REVISION = schema.REVISION;
+		CHANGES = schema.CHANGES;
+		DIAGNOSTICS = schema.DIAGNOSTICS;
+		STATE = schema.STATE;
+		BOSK = schema.BOSK;
+		ID = schema.ID;
+
+		// Kick off listener thread
 		listener = Executors.newScheduledThreadPool(1, r ->
 			new Thread(r, "SQL listener \""
 				+ bosk.name()
@@ -105,7 +130,7 @@ public class SqlDriver implements BoskDriver {
 		try {
 			try (var c = connectionSource.get()) {
 				var rs = using(c)
-					.select(REF, NEW_STATE, DIAGNOSTICS, REVISION)
+					.select(REF, NEW_STATE, DIAGNOSTICS, CHANGES.EPOCH, REVISION)
 					.from(CHANGES)
 					.where(REVISION.gt(lastChangeSubmittedDownstream.get()))
 					.fetch();
@@ -113,7 +138,12 @@ public class SqlDriver implements BoskDriver {
 					var ref = r.get(REF);
 					var newState = r.get(NEW_STATE);
 					var diagnostics = r.get(DIAGNOSTICS);
+					String epoch = r.get(CHANGES.EPOCH);
 					long changeID = r.get(REVISION);
+
+					if (!epoch.equals(this.epoch)) {
+						throw new NotYetImplementedException("Epoch changed!");
+					}
 
 					if (LOGGER.isTraceEnabled()) {
 						record Change(String ref, String newState, String diagnostics){}
@@ -222,19 +252,21 @@ public class SqlDriver implements BoskDriver {
 			// TODO: It seems wrong to schedule the listener loop here. It should be in the constructor.
 			ensureTablesExist(connection);
 			StateTreeNode result;
-			String json = using(connection)
-				.select(STATE)
+			record Row(String state, String epoch){}
+			var row = using(connection)
+				.select(STATE, BOSK.EPOCH)
 				.from(BOSK)
 				.where(ID.eq("current"))
-				.fetchOne(STATE);
-			if (json == null) {
+				.fetchOneInto(Row.class);
+			if (row == null) {
 				LOGGER.debug("No current state; initializing {} table from downstream", BOSK);
+				this.epoch = UUID.randomUUID().toString();
 				result = downstream.initialRoot(rootType);
 				String stateJson = mapper.writeValueAsString(result);
 
 				using(connection)
-					.insertInto(BOSK).columns(ID, STATE)
-					.values("current", stateJson)
+					.insertInto(BOSK).columns(ID, STATE, BOSK.EPOCH)
+					.values("current", stateJson, epoch)
 					.onConflictDoNothing()
 					.execute();
 				long changeID = insertChange(connection, rootRef, stateJson);
@@ -242,9 +274,10 @@ public class SqlDriver implements BoskDriver {
 				lastChangeSubmittedDownstream.getAndSet(changeID); // Not technically "submitted"
 			} else {
 				LOGGER.debug("Database state exists; initializing downstream from {} table", BOSK);
+				this.epoch = row.epoch;
 				long currentChangeID = latestChangeID(connection);
 				JavaType valueType = TypeFactory.defaultInstance().constructType(rootType);
-				result = mapper.readValue(json, valueType);
+				result = mapper.readValue(row.state, valueType);
 				connection.commit();
 				submitDownstream(rootRef, result, currentChangeID);
 			}
@@ -258,13 +291,13 @@ public class SqlDriver implements BoskDriver {
 	private void ensureTablesExist(Connection connection) throws SQLException {
 		using(connection)
 			.createTableIfNotExists(CHANGES)
-			.columns(REVISION, REF, NEW_STATE, DIAGNOSTICS)
+			.columns(CHANGES.EPOCH, REVISION, REF, NEW_STATE, DIAGNOSTICS)
 			.constraints(primaryKey(REVISION))
 			.execute();
 
 		using(connection)
 			.createTableIfNotExists(BOSK)
-			.columns(ID, STATE)
+			.columns(ID, BOSK.EPOCH, STATE)
 			.constraints(primaryKey(ID))
 			.execute();
 
@@ -376,7 +409,7 @@ public class SqlDriver implements BoskDriver {
 
 	/**
 	 * @param state may be mutated!
-	 * @param newValue if null, this is a delete operation
+	 * @param newValue if null, this is a delete
 	 */
 	private <T> OptionalLong replaceAndCommit(JsonNode state, Reference<T> target, T newValue, Connection connection) throws SQLException {
 		NodeInfo node = surgeon.nodeInfo(state, target);
@@ -436,8 +469,8 @@ public class SqlDriver implements BoskDriver {
 	private long insertChange(Connection c, Reference<?> ref, String newValue) {
 		try {
 			return using(c)
-				.insertInto(CHANGES).columns(REF, NEW_STATE, DIAGNOSTICS)
-				.values(ref.pathString(), newValue, mapper.writeValueAsString(ref.root().diagnosticContext().getAttributes()))
+				.insertInto(CHANGES).columns(CHANGES.EPOCH, REF, NEW_STATE, DIAGNOSTICS)
+				.values(epoch, ref.pathString(), newValue, mapper.writeValueAsString(ref.root().diagnosticContext().getAttributes()))
 				.returning(REVISION)
 				.fetchOptional(REVISION)
 				.orElseThrow(()->new NotYetImplementedException("No change inserted"));
@@ -460,11 +493,21 @@ public class SqlDriver implements BoskDriver {
 	}
 
 	private long latestChangeID(Connection connection) {
-		return using(connection)
-			.select(max(REVISION).as(REVISION))
+		record Row(String epoch, Long revision){}
+		var result = using(connection)
+			.select(CHANGES.EPOCH, REVISION)
 			.from(CHANGES)
-			.fetchOptional(REVISION)
-			.orElse(0L); // TODO: Are we sure auto-increment always generates numbers strictly greater than zero?
+			.where(REVISION.eq(select(max(REVISION)).from(CHANGES)))
+			.fetchOneInto(Row.class);
+		if (result == null) {
+			// No changes yet; return something less than the first change ID
+			return 0L; // TODO: Are we sure auto-increment always generates numbers strictly greater than zero?
+		} else {
+			if (!result.epoch.equals(this.epoch)) {
+				throw new NotYetImplementedException("Epoch mismatch");
+			}
+			return result.revision;
+		}
 	}
 
 	private static JavaType mapValueType(Class<?> entryType) {

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverSettings.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverSettings.java
@@ -1,8 +1,6 @@
 package works.bosk.drivers.sql;
 
 
-import org.jooq.CheckReturnValue;
-
 import static java.lang.Math.multiplyExact;
 
 /**
@@ -21,6 +19,7 @@ public record SqlDriverSettings(
 	long timescaleMS,
 	int patienceFactor
 ) {
+	@SuppressWarnings("ResultOfMethodCallIgnored") // We just want an exception if this is out of range
 	public SqlDriverSettings {
 		multiplyExact(timescaleMS, patienceFactor);
 	}

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/BoskTable.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/BoskTable.java
@@ -2,7 +2,6 @@ package works.bosk.drivers.sql.schema;
 
 import org.jooq.Record;
 import org.jooq.TableField;
-import org.jooq.impl.DSL;
 import org.jooq.impl.TableImpl;
 
 import static org.jooq.impl.DSL.name;
@@ -13,6 +12,8 @@ import static org.jooq.impl.SQLDataType.VARCHAR;
 public class BoskTable extends TableImpl<Record> {
 	public final TableField<Record, String> ID = createField(
 		name("id"), CHAR(7));
+	public final TableField<Record, String> EPOCH = createField(
+		name("epoch"), VARCHAR.notNull());
 	public final TableField<Record, String> STATE = createField(
 		name("state"), CLOB.null_());
 

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/ChangesTable.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/ChangesTable.java
@@ -2,10 +2,8 @@ package works.bosk.drivers.sql.schema;
 
 import org.jooq.Record;
 import org.jooq.TableField;
-import org.jooq.impl.DSL;
 import org.jooq.impl.TableImpl;
 
-import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.name;
 import static org.jooq.impl.SQLDataType.BIGINT;
 import static org.jooq.impl.SQLDataType.CLOB;
@@ -18,7 +16,7 @@ public class ChangesTable extends TableImpl<org.jooq.Record> {
 		name("ref"), VARCHAR.notNull());
 	public final TableField<Record, String> NEW_STATE = createField(
 		name("new_state"), CLOB.null_());
-	public final TableField<Record, String> DIAGONSTICS = createField(
+	public final TableField<Record, String> DIAGNOSTICS = createField(
 		name("diagnostics"), CLOB.notNull());
 
 	ChangesTable() {

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/ChangesTable.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/ChangesTable.java
@@ -10,6 +10,13 @@ import static org.jooq.impl.SQLDataType.CLOB;
 import static org.jooq.impl.SQLDataType.VARCHAR;
 
 public class ChangesTable extends TableImpl<org.jooq.Record> {
+	/**
+	 * A UUID chosen at the time the tables were created.
+	 * Provides a scope for {@link #REVISION}.
+	 * Revisions from different epochs are not comparable.
+	 */
+	public final TableField<Record, String> EPOCH = createField(
+		name("epoch"), VARCHAR.notNull());
 	public final TableField<Record, Long> REVISION = createField(
 		name("revision"), BIGINT.null_().identity(true));
 	public final TableField<Record, String> REF = createField(

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
@@ -1,20 +1,32 @@
 package works.bosk.drivers.sql.schema;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import org.jooq.Record;
 import org.jooq.TableField;
 
+import static org.jooq.impl.DSL.using;
+
 public class Schema {
-	public static final BoskTable BOSK = new BoskTable();
-	public static final ChangesTable CHANGES = new ChangesTable();
+	public final BoskTable BOSK = new BoskTable();
+	public final ChangesTable CHANGES = new ChangesTable();
 
 	// Unqualified field names for convenience
 
-	public static final TableField<Record, String> ID = BOSK.ID;
-	public static final TableField<Record, String> STATE = BOSK.STATE;
-	public static final TableField<Record, Long>   REVISION = CHANGES.REVISION;
-	public static final TableField<Record, String> REF = CHANGES.REF;
-	public static final TableField<Record, String> NEW_STATE = CHANGES.NEW_STATE;
-	public static final TableField<Record, String> DIAGNOSTICS = CHANGES.DIAGNOSTICS;
+	public final TableField<Record, String> ID = BOSK.ID;
+	public final TableField<Record, String> STATE = BOSK.STATE;
+	public final TableField<Record, Long>   REVISION = CHANGES.REVISION;
+	public final TableField<Record, String> REF = CHANGES.REF;
+	public final TableField<Record, String> NEW_STATE = CHANGES.NEW_STATE;
+	public final TableField<Record, String> DIAGNOSTICS = CHANGES.DIAGNOSTICS;
 
-	private Schema() {}
+	public void dropTables(Connection c) throws SQLException {
+		using(c)
+			.dropTable(BOSK)
+			.execute();
+		using(c)
+			.dropTable(CHANGES)
+			.execute();
+		c.commit();
+	}
 }

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
@@ -3,10 +3,6 @@ package works.bosk.drivers.sql.schema;
 import org.jooq.Record;
 import org.jooq.TableField;
 
-import static org.jooq.impl.SQLDataType.BIGINT;
-import static org.jooq.impl.SQLDataType.CLOB;
-import static org.jooq.impl.SQLDataType.VARCHAR;
-
 public class Schema {
 	public static final BoskTable BOSK = new BoskTable();
 	public static final ChangesTable CHANGES = new ChangesTable();
@@ -15,10 +11,10 @@ public class Schema {
 
 	public static final TableField<Record, String> ID = BOSK.ID;
 	public static final TableField<Record, String> STATE = BOSK.STATE;
-	public static final TableField<Record, Long> REVISION = CHANGES.REVISION;
+	public static final TableField<Record, Long>   REVISION = CHANGES.REVISION;
 	public static final TableField<Record, String> REF = CHANGES.REF;
 	public static final TableField<Record, String> NEW_STATE = CHANGES.NEW_STATE;
-	public static final TableField<Record, String> DIAGONSTICS = CHANGES.DIAGONSTICS;
+	public static final TableField<Record, String> DIAGNOSTICS = CHANGES.DIAGNOSTICS;
 
 	private Schema() {}
 }

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
@@ -1,54 +1,33 @@
 package works.bosk.drivers.sql;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import works.bosk.drivers.SharedDriverConformanceTest;
-import works.bosk.drivers.state.TestEntity;
-import works.bosk.jackson.JacksonPlugin;
-import works.bosk.jackson.JacksonPluginConfiguration;
+import works.bosk.drivers.sql.SqlTestService.Database;
+import works.bosk.drivers.sql.schema.Schema;
 import works.bosk.junit.ParametersByName;
-import works.bosk.junit.Slow;
 
-import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
-import static org.jooq.impl.DSL.using;
-import static works.bosk.drivers.sql.SqlDriverConformanceTest.Database.POSTGRES;
-import static works.bosk.drivers.sql.schema.Schema.BOSK;
-import static works.bosk.drivers.sql.schema.Schema.CHANGES;
-import static works.bosk.jackson.JacksonPluginConfiguration.MapShape.ARRAY;
+import static works.bosk.drivers.sql.SqlTestService.Database.POSTGRES;
+import static works.bosk.drivers.sql.SqlTestService.sqlDriverFactory;
 
-@Slow
 @Testcontainers
 class SqlDriverConformanceTest extends SharedDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
-	private final HikariDataSource dataSource;
-
-	enum Database {
-		POSTGRES("postgresql:16"),
-		MYSQL("mysql:8.0.36");
-
-		final String image;
-
-		Database(String image) {
-			this.image = image;
-		}
-	}
-
-	private static final ConcurrentHashMap<Database, HikariDataSource> DATA_SOURCES = new ConcurrentHashMap<>();
+	private final Database database;
+	private final AtomicInteger dbCounter = new AtomicInteger(0);
+	private SqlDriverSettings settings;
+	private HikariDataSource dataSource;
 
 	@ParametersByName
 	SqlDriverConformanceTest(Database database) {
-		this.dataSource = DATA_SOURCES.computeIfAbsent(database, SqlDriverConformanceTest::newHikariDataSource);
+		this.database = database;
 	}
 
 	@SuppressWarnings("unused")
@@ -56,47 +35,33 @@ class SqlDriverConformanceTest extends SharedDriverConformanceTest {
 		return Stream.of(POSTGRES); // MYSQL is very slow for some reason
 	}
 
-	private static HikariDataSource newHikariDataSource(Database database) {
-		HikariConfig config = new HikariConfig();
-		config.setJdbcUrl("jdbc:tc:" + database.image + ":///?TC_DAEMON=true");
-		return new HikariDataSource(config);
-	}
-
 	@BeforeEach
 	void setupDriverFactory() {
+		settings = new SqlDriverSettings(
+			50, 100
+		);
+		String databaseName = SqlDriverConformanceTest.class.getSimpleName()
+			+ dbCounter.incrementAndGet();
+		dataSource = database.dataSourceFor(databaseName);
 		driverFactory = (boskInfo, downstream) -> {
-			SqlDriverSettings settings = new SqlDriverSettings(
-				50, 100
-			);
-			var driver = SqlDriver.<TestEntity>factory(
-				settings, dataSource::getConnection,
-				b -> new ObjectMapper()
-					.enable(INDENT_OUTPUT)
-					// TODO: SqlDriver should add this, not the caller! It's required for correctness
-					.registerModule(new JacksonPlugin(new JacksonPluginConfiguration(ARRAY)).moduleFor(b))
-			).build(boskInfo, downstream);
+			var driver = sqlDriverFactory(settings, dataSource).build(boskInfo, downstream);
 			tearDownActions.addFirst(driver::close);
 			return driver;
 		};
 	}
 
 	@AfterEach
-	void runTearDown() {
+	void runTearDown() throws SQLException {
 		tearDownActions.forEach(Runnable::run);
 		cleanupTables();
 	}
 
-	private void cleanupTables() {
+	private void cleanupTables() throws SQLException {
 		try (
 			var c = dataSource.getConnection()
 		) {
-			using(c).dropTableIfExists(BOSK).execute();
-			using(c).dropTableIfExists(CHANGES).execute();
-			LOGGER.trace("Tables dropped: {}, {}", BOSK, CHANGES);
-		} catch (SQLException e) {
-			throw new AssertionError("Unexpected error cleaning up table", e);
+			new Schema().dropTables(c);
 		}
 	}
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(SqlDriverConformanceTest.class);
 }

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverDurabilityTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverDurabilityTest.java
@@ -1,0 +1,93 @@
+package works.bosk.drivers.sql;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import works.bosk.Bosk;
+import works.bosk.drivers.AbstractDriverTest;
+import works.bosk.drivers.sql.SqlTestService.Database;
+import works.bosk.drivers.sql.schema.Schema;
+import works.bosk.drivers.state.TestEntity;
+import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.junit.ParametersByName;
+
+import static org.jooq.impl.DSL.using;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.drivers.sql.SqlTestService.Database.POSTGRES;
+import static works.bosk.drivers.sql.SqlTestService.sqlDriverFactory;
+
+@Testcontainers
+public class SqlDriverDurabilityTest extends AbstractDriverTest {
+	private final Database database;
+	SqlDriverSettings settings;
+	HikariDataSource dataSource;
+	AtomicInteger dbCounter = new AtomicInteger(0);
+
+	@ParametersByName
+	SqlDriverDurabilityTest(Database database) {
+		this.database = database;
+	}
+
+	@SuppressWarnings("unused")
+	static Stream<Database> database() {
+		return Stream.of(POSTGRES);
+	}
+
+	@BeforeEach
+	void initializeSettings() {
+		settings = new SqlDriverSettings(1000, 100);
+		dataSource = database.dataSourceFor(SqlDriverDurabilityTest.class.getSimpleName() + dbCounter.incrementAndGet());
+	}
+
+	@ParametersByName
+	void tablesDropped_recovers() throws SQLException, IOException, InterruptedException {
+		LOGGER.debug("Initialize database");
+		var factory = sqlDriverFactory(settings, dataSource);
+		var schema = new Schema();
+		setupBosksAndReferences(factory);
+		assertCorrectBoskContents();
+
+		LOGGER.debug("Drop tables");
+		try (var c = dataSource.getConnection()) {
+			using(c)
+				.dropTable(schema.BOSK)
+				.execute();
+
+			using(c)
+				.dropTable(schema.CHANGES)
+				.execute();
+		}
+
+		LOGGER.debug("Use another bosk to recreate the database");
+		var fixer = new Bosk<>("fixer", TestEntity.class, SqlDriverDurabilityTest::differentInitialRoot, factory);
+
+		LOGGER.debug("State should be restored");
+
+		bosk.driver().flush();
+
+		TestEntity actual;
+		try (var __ = bosk.readContext()) {
+			actual = bosk.rootReference().value();
+		}
+
+		TestEntity expected;
+		try (var __ = fixer.readContext()) {
+			expected = fixer.rootReference().value();
+		}
+
+		assertEquals(expected, actual);
+	}
+
+	private static @NotNull TestEntity differentInitialRoot(Bosk<TestEntity> b) throws InvalidTypeException {
+		return AbstractDriverTest.initialRoot(b).withString("Different");
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SqlDriverDurabilityTest.class);
+}

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlTestService.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlTestService.java
@@ -1,0 +1,56 @@
+package works.bosk.drivers.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import works.bosk.drivers.state.TestEntity;
+import works.bosk.jackson.JacksonPlugin;
+import works.bosk.jackson.JacksonPluginConfiguration;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+import static works.bosk.jackson.JacksonPluginConfiguration.MapShape.ARRAY;
+
+public class SqlTestService {
+	record DBKey(Database database, String databaseName) {}
+	private static final ConcurrentHashMap<DBKey, HikariDataSource> DATA_SOURCES = new ConcurrentHashMap<>();
+
+	public enum Database {
+		MYSQL(testcontainers("mysql:8.0.36")),
+		POSTGRES(testcontainers("postgresql:16")),
+		;
+
+		final Function<String, String> url;
+
+		Database(Function<String, String> url) {
+			this.url = url;
+		}
+
+		public HikariDataSource dataSourceFor(String databaseName) {
+			return DATA_SOURCES.computeIfAbsent(new DBKey(this, databaseName), SqlTestService::newHikariDataSource);
+		}
+	}
+
+	private static HikariDataSource newHikariDataSource(DBKey key) {
+		HikariConfig config = new HikariConfig();
+		config.setJdbcUrl(key.database().url.apply(key.databaseName()));
+		config.setAutoCommit(false);
+		return new HikariDataSource(config);
+	}
+
+	private static Function<String, String> testcontainers(String image) {
+		return dbName -> "jdbc:tc:" + image + ":///" + dbName + "?TC_DAEMON=true";
+	}
+
+	public static SqlDriver.SqlDriverFactory<TestEntity> sqlDriverFactory(SqlDriverSettings settings, HikariDataSource dataSource) {
+		return SqlDriver.factory(
+			settings, dataSource::getConnection,
+			b -> new ObjectMapper()
+				.enable(INDENT_OUTPUT)
+				// TODO: SqlDriver should add this, not the caller! It's required for correctness
+				.registerModule(new JacksonPlugin(new JacksonPluginConfiguration(ARRAY)).moduleFor(b))
+		);
+	}
+
+}

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -28,14 +28,18 @@ public abstract class AbstractDriverTest {
 	protected Bosk<TestEntity> canonicalBosk;
 	protected Bosk<TestEntity> bosk;
 	protected BoskDriver driver;
+	private volatile String oldThreadName;
 
 	@BeforeEach
 	void logStart(TestInfo testInfo) {
 		logTest("/=== Start", testInfo);
+		oldThreadName = Thread.currentThread().getName();
+		Thread.currentThread().setName(testInfo.getDisplayName());
 	}
 
 	@AfterEach
 	void logDone(TestInfo testInfo) {
+		Thread.currentThread().setName(oldThreadName);
 		logTest("\\=== Done", testInfo);
 	}
 
@@ -49,10 +53,10 @@ public abstract class AbstractDriverTest {
 
 	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
 		// This is the bosk whose behaviour we'll consider to be correct by definition
-		canonicalBosk = new Bosk<TestEntity>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver());
+		canonicalBosk = new Bosk<>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver());
 
 		// This is the bosk we're testing
-		bosk = new Bosk<TestEntity>(boskName("Test", 1), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
+		bosk = new Bosk<>(boskName("Test", 1), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
 			ReplicaSet.mirroringTo(canonicalBosk),
 			DriverStateVerifier.wrap(driverFactory, TestEntity.class, AbstractDriverTest::initialRoot)
 		));
@@ -89,7 +93,7 @@ public abstract class AbstractDriverTest {
 		return TestEntity.empty(id, enclosingCatalogRef.then(id).thenCatalog(TestEntity.class, TestEntity.Fields.catalog));
 	}
 
-	void assertCorrectBoskContents() {
+	protected void assertCorrectBoskContents() {
 		LOGGER.debug("assertCorrectBoskContents");
 		try {
 			driver.flush();

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
@@ -72,7 +72,6 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		assertCorrectBoskContents();
 	}
 
-	@Order(2)
 	@ParametersByName
 	void replaceIdentical(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
@@ -80,7 +79,6 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		assertCorrectBoskContents();
 	}
 
-	@Order(2)
 	@ParametersByName
 	void replaceDifferent(Path enclosingCatalogPath, Identifier childID) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);

--- a/bosk-testing/src/main/java/works/bosk/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/SharedDriverConformanceTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SharedDriverConformanceTest extends DriverConformanceTest {
 
 	@Override
-	void assertCorrectBoskContents() {
+	protected void assertCorrectBoskContents() {
 		super.assertCorrectBoskContents();
 		var latecomer = new Bosk<>(BoskTestUtils.boskName("latecomer"), TestEntity.class, AbstractDriverTest::initialRoot, driverFactory);
 		try {


### PR DESCRIPTION
Ensure that re-creating the database in one bosk also fixes another. Certainly more tests to come.

This also rearranges how we manage tables to support more databases: creating the database/schema is now the responsibility of the caller, not of bosk itself, and bosk just populates that database with tables. This will help us to support database technologies that don't support multiple schemas.