### PR TITLE
Terraform code for example-hello project

### DIFF
--- a/example-hello/main.tf
+++ b/example-hello/main.tf
@@ -1,0 +1,21 @@
+
+terraform {
+	required_providers {
+		bosk = {
+			source = "vena/bosk"
+			version = "0.0.1"
+		}
+	}
+}
+
+provider "bosk" {
+}
+
+resource "bosk_node" "targets" {
+	url = "http://localhost:1740/bosk/targets"
+	value_json = jsonencode([
+		{ "somebody" = { "id" = "somebody" } },
+		{ "anybody" = { "id" = "anybody" } }
+	])
+}
+

--- a/example-hello/src/main/resources/application.properties
+++ b/example-hello/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-server.port=1111
+server.port=1740
 bosk.web.service-path=/bosk


### PR DESCRIPTION
Some terraform code to use the [Bosk terraform provider](https://github.com/prdoyle/terraform-provider-bosk) to control the example-hello project.

(Also moves the port number for example-hello to one that's less likely to have a conflict with other services.)