### PR TITLE
Rename submitConditionalCreation

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -224,9 +224,9 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		@Override
-		public <T> void submitInitialization(Reference<T> target, T newValue) {
+		public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 			assertCorrectBosk(target);
-			downstream.submitInitialization(target, newValue);
+			downstream.submitConditionalCreation(target, newValue);
 		}
 
 		@Override
@@ -323,7 +323,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		@Override
-		public <T> void submitInitialization(Reference<T> target, T newValue) {
+		public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 			synchronized (this) {
 				boolean preconditionsSatisfied;
 				try (@SuppressWarnings("unused") ReadContext executionContext = supersedingReadContext()) {

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -72,7 +72,7 @@ public interface BoskDriver {
 	 *
 	 * @see #submitReplacement
 	 */
-	<T> void submitInitialization(Reference<T> target, T newValue);
+	<T> void submitConditionalCreation(Reference<T> target, T newValue);
 
 	/**
 	 * Requests that the object referenced by <code>target</code> be deleted.

--- a/bosk-core/src/main/java/works/bosk/SerializationPlugin.java
+++ b/bosk-core/src/main/java/works/bosk/SerializationPlugin.java
@@ -332,7 +332,7 @@ public abstract class SerializationPlugin {
 			if (StateTreeNode.class.isAssignableFrom(enclosing)) {
 				Object result = infoFor(enclosing).polyfills().get(ref.path().lastSegment());
 				if (result != null) {
-					driver.submitInitialization(ref, ref.targetClass().cast(result));
+					driver.submitConditionalCreation(ref, ref.targetClass().cast(result));
 				}
 			}
 		}

--- a/bosk-core/src/main/java/works/bosk/drivers/BufferingDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/BufferingDriver.java
@@ -59,8 +59,8 @@ public class BufferingDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
-		enqueue(d -> d.submitInitialization(target, newValue), target.root().diagnosticContext());
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+		enqueue(d -> d.submitConditionalCreation(target, newValue), target.root().diagnosticContext());
 	}
 
 	@Override

--- a/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
@@ -51,9 +51,9 @@ public class DiagnosticScopeDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		try (var __ = scopeSupplier.apply(diagnosticContext)) {
-			downstream.submitInitialization(target, newValue);
+			downstream.submitConditionalCreation(target, newValue);
 		}
 	}
 

--- a/bosk-core/src/main/java/works/bosk/drivers/ForwardingDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ForwardingDriver.java
@@ -37,8 +37,8 @@ public class ForwardingDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
-		downstream.submitInitialization(target, newValue);
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+		downstream.submitConditionalCreation(target, newValue);
 	}
 
 	@Override

--- a/bosk-core/src/main/java/works/bosk/drivers/NoOpDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/NoOpDriver.java
@@ -21,7 +21,7 @@ public class NoOpDriver implements BoskDriver {
 
 	@Override public <T> void submitReplacement(Reference<T> target, T newValue) { }
 	@Override public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) { }
-	@Override public <T> void submitInitialization(Reference<T> target, T newValue) { }
+	@Override public <T> void submitConditionalCreation(Reference<T> target, T newValue) { }
 	@Override public <T> void submitDeletion(Reference<T> target) { }
 	@Override public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) { }
 	@Override public void flush() throws IOException, InterruptedException { }

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -172,9 +172,9 @@ public class ReplicaSet<R extends StateTreeNode> {
 		}
 
 		@Override
-		public <T> void submitInitialization(Reference<T> target, T newValue) {
+		public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 			replicas.forEach(r -> r.driver
-				.submitInitialization(
+				.submitConditionalCreation(
 					r.correspondingReference(target), newValue));
 		}
 

--- a/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
@@ -87,7 +87,7 @@ public class BoskUpdateTest extends AbstractBoskTest {
 	void initializeNonexistent_nodeCreated() throws IOException, InterruptedException {
 		TestChild newValue = new TestChild(CHILD_4_ID, "string", TestEnum.OK, Catalog.empty());
 		Reference<TestChild> ref = refs.child(PARENT_ID, CHILD_4_ID);
-		bosk.driver().submitInitialization(ref, newValue);
+		bosk.driver().submitConditionalCreation(ref, newValue);
 		assertValueEquals(newValue, ref);
 	}
 
@@ -96,8 +96,8 @@ public class BoskUpdateTest extends AbstractBoskTest {
 		TestChild newValue = new TestChild(CHILD_1_ID, "string", TestEnum.OK, Catalog.empty());
 		Reference<TestChild> ref = refs.child(PARENT_ID, CHILD_1_ID);
 
-		// Child 1 already exists, so submitInitialization should have no effect
-		bosk.driver().submitInitialization(ref, newValue);
+		// Child 1 already exists, so submitConditionalCreation should have no effect
+		bosk.driver().submitConditionalCreation(ref, newValue);
 		assertValueEquals(originalRoot, bosk.rootReference());
 		assertValueEquals(originalChild1, ref);
 	}

--- a/bosk-core/src/test/java/works/bosk/HooksTest.java
+++ b/bosk-core/src/test/java/works/bosk/HooksTest.java
@@ -258,7 +258,7 @@ public class HooksTest extends AbstractBoskTest {
 			.withId(child4ID);
 		Reference<TestChild> child4Ref = refs.anyChild().boundTo(Identifier.from("parent"), child4ID);
 
-		bosk.driver().submitInitialization(child4Ref, newValue);
+		bosk.driver().submitConditionalCreation(child4Ref, newValue);
 		TestEntity newParent = originalParent.withChildren(originalParent.children().with(newValue));
 		assertEquals(
 			asList(
@@ -276,7 +276,7 @@ public class HooksTest extends AbstractBoskTest {
 		TestChild newValue = originalChild1
 			.withString("replacement");
 
-		bosk.driver().submitInitialization(refs.child(child1), newValue);
+		bosk.driver().submitConditionalCreation(refs.child(child1), newValue);
 
 		assertEquals(
 			emptyList(),
@@ -293,7 +293,7 @@ public class HooksTest extends AbstractBoskTest {
 			.withId(child4ID);
 		Reference<TestChild> child4Ref = refs.anyChild().boundTo(Identifier.from("nonexistent"), child4ID);
 
-		bosk.driver().submitInitialization(child4Ref, newValue);
+		bosk.driver().submitConditionalCreation(child4Ref, newValue);
 
 		assertEquals(
 			emptyList(),

--- a/bosk-core/src/test/java/works/bosk/HooksTest.java
+++ b/bosk-core/src/test/java/works/bosk/HooksTest.java
@@ -250,7 +250,7 @@ public class HooksTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void basic_initialization() {
+	void basic_creation() {
 		registerInterleavedHooks();
 
 		Identifier child4ID = Identifier.from("child4");
@@ -270,7 +270,7 @@ public class HooksTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void basic_reinitialization() {
+	void basic_creationAlreadyExists() {
 		registerInterleavedHooks();
 
 		TestChild newValue = originalChild1
@@ -285,7 +285,7 @@ public class HooksTest extends AbstractBoskTest {
 	}
 
 	@Test
-	void basic_initializationInNonexistentParent() {
+	void basic_creationInNonexistentParent() {
 		registerInterleavedHooks();
 
 		Identifier child4ID = Identifier.from("child4");

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
@@ -66,13 +66,13 @@ public class JsonNodeDriver implements BoskDriver {
 	}
 
 	@Override
-	public synchronized <T> void submitInitialization(Reference<T> target, T newValue) {
-		traceCurrentState("Before submitInitialization");
+	public synchronized <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+		traceCurrentState("Before submitConditionalCreation");
 		if (surgeon.valueNode(currentRoot, target) == null) {
 			doReplacement(surgeon.nodeInfo(currentRoot, target), target.path().lastSegment(), newValue);
 		}
-		downstream.submitInitialization(target, newValue);
-		traceCurrentState("After submitInitialization");
+		downstream.submitConditionalCreation(target, newValue);
+		traceCurrentState("After submitConditionalCreation");
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/DisconnectedDriver.java
@@ -24,7 +24,7 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		throw disconnected();
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
@@ -292,11 +292,11 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		doRetryableDriverOperation(()->{
 			bsonPlugin.initializeEnclosingPolyfills(target, formatDriver);
-			formatDriver.submitInitialization(target, newValue);
-		}, "submitInitialization({})", target);
+			formatDriver.submitConditionalCreation(target, newValue);
+		}, "submitConditionalCreation({})", target);
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormatDriver.java
@@ -117,7 +117,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		collection.ensureTransactionStarted();
 		Reference<?> mainRef = mainRef(target);
 		BsonDocument filter = documentFilter(mainRef)

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/SequoiaFormatDriver.java
@@ -80,7 +80,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		BsonDocument filter = standardPreconditions(target);
 		filter.put(dottedFieldNameOf(target, rootRef), new BsonDocument("$exists", FALSE));
 		if (doUpdate(replacementDoc(target, newValue), filter)) {

--- a/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/ServiceEndpoints.java
+++ b/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/ServiceEndpoints.java
@@ -94,7 +94,7 @@ public class ServiceEndpoints {
 
 			@Override
 			public void ifMustNotExist() {
-				bosk.driver().submitInitialization(ref, newValue);
+				bosk.driver().submitConditionalCreation(ref, newValue);
 			}
 		});
 		rsp.setStatus(ACCEPTED.value());

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriver.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriver.java
@@ -355,8 +355,8 @@ public class SqlDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
-		LOGGER.debug("submitInitialization({}, {})", target, newValue);
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+		LOGGER.debug("submitConditionalCreation({}, {})", target, newValue);
 		try (
 			var connection = connectionSource.get()
 		){

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractDriverTest {
 		} else {
 			autoInitialize(ref.enclosingReference(TestEntity.class));
 			TestEntity newEntity = emptyEntityAt(ref);
-			driver.submitInitialization(ref, newEntity);
+			driver.submitConditionalCreation(ref, newEntity);
 			return newEntity;
 		}
 	}

--- a/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
@@ -44,8 +44,8 @@ public class AsyncDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
-		submitAsyncTask("submitInitialization", () -> downstream.submitInitialization(target, newValue));
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+		submitAsyncTask("submitConditionalCreation", () -> downstream.submitConditionalCreation(target, newValue));
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
@@ -440,7 +440,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@ParametersByName
-	void submitInitialization_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
+	void submitConditionalCreation_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
 		initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Refs refs = bosk.buildReferences(Refs.class);
 		Identifier id = Identifier.from("testEntity");

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverConformanceTest.java
@@ -445,7 +445,7 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		Refs refs = bosk.buildReferences(Refs.class);
 		Identifier id = Identifier.from("testEntity");
 		Reference<TestEntity> ref = refs.catalogEntry(id);
-		testDiagnosticContextPropagation(() -> bosk.driver().submitInitialization(ref, emptyEntityAt(ref)));
+		testDiagnosticContextPropagation(() -> bosk.driver().submitConditionalCreation(ref, emptyEntityAt(ref)));
 	}
 
 	@ParametersByName

--- a/bosk-testing/src/main/java/works/bosk/drivers/JitterDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/JitterDriver.java
@@ -63,9 +63,9 @@ public final class JitterDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		sleep();
-		downstream.submitInitialization(target, newValue);
+		downstream.submitConditionalCreation(target, newValue);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -56,7 +56,7 @@ public class ReportingDriver implements BoskDriver {
 	}
 
 	@Override
-	public <T> void submitInitialization(Reference<T> target, T newValue) {
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		SubmitInitialization<T> op = new SubmitInitialization<>(target, newValue, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -11,10 +11,10 @@ import works.bosk.DriverFactory;
 import works.bosk.Identifier;
 import works.bosk.Reference;
 import works.bosk.StateTreeNode;
+import works.bosk.drivers.operations.ConditionalCreation;
 import works.bosk.drivers.operations.SubmitConditionalDeletion;
 import works.bosk.drivers.operations.SubmitConditionalReplacement;
 import works.bosk.drivers.operations.SubmitDeletion;
-import works.bosk.drivers.operations.SubmitInitialization;
 import works.bosk.drivers.operations.SubmitReplacement;
 import works.bosk.drivers.operations.UpdateOperation;
 import works.bosk.exceptions.InvalidTypeException;
@@ -57,7 +57,7 @@ public class ReportingDriver implements BoskDriver {
 
 	@Override
 	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
-		SubmitInitialization<T> op = new SubmitInitialization<>(target, newValue, diagnosticContext.getAttributes());
+		ConditionalCreation<T> op = new ConditionalCreation<>(target, newValue, diagnosticContext.getAttributes());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/ConditionalCreation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/ConditionalCreation.java
@@ -5,15 +5,15 @@ import works.bosk.BoskDriver;
 import works.bosk.MapValue;
 import works.bosk.Reference;
 
-public record SubmitInitialization<T>(
+public record ConditionalCreation<T>(
 	Reference<T> target,
 	T newValue,
 	MapValue<String> diagnosticAttributes
 ) implements ReplacementOperation<T> {
 
 	@Override
-	public SubmitInitialization<T> withFilteredAttributes(Collection<String> allowedNames) {
-		return new SubmitInitialization<>(target, newValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	public ConditionalCreation<T> withFilteredAttributes(Collection<String> allowedNames) {
+		return new ConditionalCreation<>(target, newValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/OperationWithPrecondition.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/OperationWithPrecondition.java
@@ -3,10 +3,7 @@ package works.bosk.drivers.operations;
 import works.bosk.Identifier;
 import works.bosk.Reference;
 
-/**
- * Doesn't include {@link SubmitInitialization} because that has a different kind of precondition.
- */
-public sealed interface ConditionalOperation extends UpdateOperation permits
+public sealed interface OperationWithPrecondition extends UpdateOperation permits
 	SubmitConditionalDeletion,
 	SubmitConditionalReplacement
 {

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/ReplacementOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/ReplacementOperation.java
@@ -2,7 +2,7 @@ package works.bosk.drivers.operations;
 
 public sealed interface ReplacementOperation<T> extends UpdateOperation permits
 	SubmitConditionalReplacement,
-	SubmitInitialization,
+	ConditionalCreation,
 	SubmitReplacement
 {
 	T newValue();

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalDeletion.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalDeletion.java
@@ -11,7 +11,7 @@ public record SubmitConditionalDeletion<T>(
 	Reference<Identifier> precondition,
 	Identifier requiredValue,
 	MapValue<String> diagnosticAttributes
-) implements DeletionOperation<T>, ConditionalOperation {
+) implements DeletionOperation<T>, OperationWithPrecondition {
 
 	@Override
 	public SubmitDeletion<T> unconditional() {

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalReplacement.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitConditionalReplacement.java
@@ -12,7 +12,7 @@ public record SubmitConditionalReplacement<T>(
 	Reference<Identifier> precondition,
 	Identifier requiredValue,
 	MapValue<String> diagnosticAttributes
-) implements ReplacementOperation<T>, ConditionalOperation {
+) implements ReplacementOperation<T>, OperationWithPrecondition {
 
 	@Override
 	public SubmitReplacement<T> unconditional() {

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitInitialization.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/SubmitInitialization.java
@@ -18,7 +18,7 @@ public record SubmitInitialization<T>(
 
 	@Override
 	public void submitTo(BoskDriver driver) {
-		driver.submitInitialization(target, newValue);
+		driver.submitConditionalCreation(target, newValue);
 	}
 
 }

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/UpdateOperation.java
@@ -7,7 +7,7 @@ import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public sealed interface UpdateOperation permits
-	ConditionalOperation,
+	OperationWithPrecondition,
 	DeletionOperation,
 	ReplacementOperation
 {

--- a/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverTest.java
@@ -14,10 +14,10 @@ import works.bosk.ListingEntry;
 import works.bosk.MapValue;
 import works.bosk.Reference;
 import works.bosk.annotations.ReferencePath;
+import works.bosk.drivers.operations.ConditionalCreation;
 import works.bosk.drivers.operations.SubmitConditionalDeletion;
 import works.bosk.drivers.operations.SubmitConditionalReplacement;
 import works.bosk.drivers.operations.SubmitDeletion;
-import works.bosk.drivers.operations.SubmitInitialization;
 import works.bosk.drivers.operations.SubmitReplacement;
 import works.bosk.drivers.operations.UpdateOperation;
 import works.bosk.drivers.state.TestEntity;
@@ -95,7 +95,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<TestEntity> ref = refs.entity(id2);
 		TestEntity newValue = emptyEntityAt(ref);
 		bosk.driver().submitConditionalCreation(ref, newValue);
-		assertExpectedEvents(new SubmitInitialization<>(ref, newValue, expectedAttributes));
+		assertExpectedEvents(new ConditionalCreation<>(ref, newValue, expectedAttributes));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}

--- a/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverTest.java
@@ -91,10 +91,10 @@ class ReportingDriverTest extends AbstractDriverTest {
 	}
 
 	@Test
-	void submitInitialization() {
+	void submitConditionalCreation() {
 		Reference<TestEntity> ref = refs.entity(id2);
 		TestEntity newValue = emptyEntityAt(ref);
-		bosk.driver().submitInitialization(ref, newValue);
+		bosk.driver().submitConditionalCreation(ref, newValue);
 		assertExpectedEvents(new SubmitInitialization<>(ref, newValue, expectedAttributes));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -447,7 +447,7 @@ For example, `submitConditionalReplacement(target, newValue, precondition, requi
 
 `submitConditionalDeletion` is similar.
 
-A third kind of conditional update, called `submitInitialization`, is like `submitReplacement` except ignored if the target node already exists.
+A third kind of conditional update, called `submitConditionalCreation`, is like `submitReplacement` except ignored if the target node already exists.
 
 #### `flush()`
 

--- a/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
@@ -233,8 +233,8 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 		}
 
 		@Override
-		public <T> void submitInitialization(Reference<T> target, T newValue) {
-			downstream.submitInitialization(target, preprocess(target, newValue));
+		public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+			downstream.submitConditionalCreation(target, preprocess(target, newValue));
 		}
 
 		abstract <T> T preprocess(Reference<T> reference, T newValue);


### PR DESCRIPTION
The name `submitInitialization` is too generic and easily confused with a hundred other kinds of initialization.