### PR TITLE
Move diagnosticAttributes out of RootReference

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -120,7 +120,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		UnderConstruction<R> boskInfo = new UnderConstruction<>(
-			name, instanceID, rootRef, this::registerHooks, new AtomicReference<>());
+			name, instanceID, rootRef, diagnosticContext, this::registerHooks, new AtomicReference<>());
 
 		// We do this as late as possible because the driver factory is allowed
 		// to do such things as create References, so it needs the rest of the
@@ -149,6 +149,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		String name,
 		Identifier instanceID,
 		RootReference<RR> rootReference,
+		BoskDiagnosticContext diagnosticContext,
 		RegisterHooksMethod m,
 		AtomicReference<Bosk<RR>> boskRef
 	) implements BoskInfo<RR> {
@@ -985,11 +986,6 @@ try (ReadContext originalThReadContext = bosk.readContext()) {
 		@Override
 		public <TT extends VariantCase> Reference<TaggedUnion<TT>> thenTaggedUnion(Class<TT> variantCaseClass, Path path) throws InvalidTypeException {
 			return this.then(Classes.taggedUnion(variantCaseClass), path);
-		}
-
-		@Override
-		public BoskDiagnosticContext diagnosticContext() {
-			return diagnosticContext;
 		}
 
 		@Override

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -180,6 +180,14 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		return (b,d) -> d;
 	}
 
+	/**
+	 * Provides access to the {@link BoskDriver} object to use for submitting updates to this bosk's state tree.
+	 * <p>
+	 * The bosk's driver is fixed for the lifetime of the bosk.
+	 * You can hold on to the returned object if that suits you; there's no need to re-fetch it.
+	 *
+	 * @return the {@link BoskDriver} to use for submitting updates to this bosk's state tree.
+	 */
 	public BoskDriver driver() {
 		return driver;
 	}

--- a/bosk-core/src/main/java/works/bosk/BoskInfo.java
+++ b/bosk-core/src/main/java/works/bosk/BoskInfo.java
@@ -10,10 +10,12 @@ public interface BoskInfo<R extends StateTreeNode> {
 	String name();
 	Identifier instanceID();
 	RootReference<R> rootReference();
+	BoskDiagnosticContext diagnosticContext();
 	void registerHooks(Object receiver) throws InvalidTypeException;
 
 	/**
 	 * @throws IllegalStateException if called before the {@link Bosk} constructor returns
 	 */
 	Bosk<R> bosk();
+
 }

--- a/bosk-core/src/main/java/works/bosk/RootReference.java
+++ b/bosk-core/src/main/java/works/bosk/RootReference.java
@@ -6,6 +6,10 @@ import works.bosk.exceptions.InvalidTypeException;
 /**
  * A {@link Reference} to the root node of a particular bosk's state tree,
  * doubling as the main way to acquire/construct other references.
+ *
+ * <p>
+ * One single {@code RootReference} instance is associated with each {@link Bosk}.
+ * You can hold on to this object; there's no need to re-fetch it from the {@link Bosk} every time.
  */
 public sealed interface RootReference<R>
 	extends Reference<R>

--- a/bosk-core/src/main/java/works/bosk/RootReference.java
+++ b/bosk-core/src/main/java/works/bosk/RootReference.java
@@ -46,5 +46,4 @@ public sealed interface RootReference<R>
 	<T> Reference<Reference<T>> thenReference(Class<T> targetClass, Path path) throws InvalidTypeException;
 	<TT extends VariantCase> Reference<TaggedUnion<TT>> thenTaggedUnion(Class<TT> variantCaseClass, Path path) throws InvalidTypeException;
 
-	BoskDiagnosticContext diagnosticContext();
 }

--- a/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/DiagnosticScopeDriver.java
@@ -27,7 +27,7 @@ public class DiagnosticScopeDriver implements BoskDriver {
 	final Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Function<BoskDiagnosticContext, DiagnosticScope> scopeSupplier) {
-		return (b,d) -> new DiagnosticScopeDriver(d, b.rootReference().diagnosticContext(), scopeSupplier);
+		return (b,d) -> new DiagnosticScopeDriver(d, b.diagnosticContext(), scopeSupplier);
 	}
 
 	@Override

--- a/bosk-core/src/test/java/works/bosk/drivers/BufferingDriverConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/BufferingDriverConformanceTest.java
@@ -6,7 +6,7 @@ public class BufferingDriverConformanceTest extends DriverConformanceTest {
 
 	@BeforeEach
 	void setupDriverFactory() {
-		driverFactory = (b,d)-> BufferingDriver.writingTo(d);
+		driverFactory = BufferingDriver.factory();
 	}
 
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/AbstractFormatDriver.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonValue;
+import works.bosk.BoskDiagnosticContext;
 import works.bosk.MapValue;
 import works.bosk.RootReference;
 import works.bosk.StateTreeNode;
@@ -17,6 +18,7 @@ import static works.bosk.drivers.mongo.Formatter.REVISION_ZERO;
 @RequiredArgsConstructor
 non-sealed abstract class AbstractFormatDriver<R extends StateTreeNode> implements FormatDriver<R> {
 	final RootReference<R> rootRef;
+	final BoskDiagnosticContext diagnosticContext;
 	final Formatter formatter;
 
 	@Override

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MainDriver.java
@@ -199,7 +199,7 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			root = callDownstreamInitialRoot(rootType);
 			try (var session = collection.newSession()) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
-				preferredDriver.initializeCollection(new StateAndMetadata<>(root, REVISION_ZERO, boskInfo.rootReference().diagnosticContext().getAttributes()));
+				preferredDriver.initializeCollection(new StateAndMetadata<>(root, REVISION_ZERO, boskInfo.diagnosticContext().getAttributes()));
 				session.commitTransactionIfAny();
 				// We can now publish the driver knowing that the transaction, if there is one, has committed
 				publishFormatDriver(preferredDriver);
@@ -402,7 +402,7 @@ final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				// This causes downstream.submitReplacement to be associated with the last update to the state,
 				// which is of dubious relevance. We might just want to use the context from the current thread,
 				// which is probably empty because this runs on the ChangeReceiver thread.
-				try (var ___ = boskInfo.rootReference().diagnosticContext().withOnly(loadedState.diagnosticAttributes())) {
+				try (var ___ = boskInfo.diagnosticContext().withOnly(loadedState.diagnosticAttributes())) {
 					downstream.submitReplacement(boskInfo.rootReference(), loadedState.state());
 					LOGGER.debug("Done submitting downstream");
 				}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverSpecialTest.java
@@ -103,7 +103,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		// have tight control over all the comings and goings from MongoDriver.
 		BlockingQueue<Reference<?>> replacementsSeen = new LinkedBlockingDeque<>();
 		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(), TestEntity.class, this::initialRoot,
-			(b,d) -> driverFactory.build(b, new BufferingDriver(d) {
+			(b,d) -> driverFactory.build(b, new BufferingDriver(d, b.diagnosticContext()) {
 				@Override
 				public <T> void submitReplacement(Reference<T> target, T newValue) {
 					super.submitReplacement(target, newValue);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoService.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoService.java
@@ -27,9 +27,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * suitable for use by a test class.
  *
  * <p>
- * Use {@link UsesMongoService} and {@link DisruptsMongoProxy} to make sure
- * that the network outage tests don't run at the same time as
- * other tests that need MongoDB.
+ * Use {@link DisruptsMongoProxy} to make sure that
+ * the network outage tests don't run at the same time as other tests that use the proxy.
  *
  * <p>
  * All instances use the same MongoDB container, so

--- a/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AsyncDriver.java
@@ -68,10 +68,10 @@ public class AsyncDriver implements BoskDriver {
 
 	private void submitAsyncTask(String description, Runnable task) {
 		LOGGER.debug("Submit {}", description);
-		var diagnosticAttributes = bosk.rootReference().diagnosticContext().getAttributes();
+		var diagnosticAttributes = bosk.diagnosticContext().getAttributes();
 		executor.submit(()->{
 			LOGGER.debug("Run {}", description);
-			try (var __ = bosk.rootReference().diagnosticContext().withOnly(diagnosticAttributes)) {
+			try (var __ = bosk.diagnosticContext().withOnly(diagnosticAttributes)) {
 				task.run();
 			}
 			LOGGER.trace("Done {}", description);

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -33,7 +33,7 @@ public class ReportingDriver implements BoskDriver {
 	final Runnable flushListener;
 
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<UpdateOperation> listener, Runnable flushListener) {
-		return (b,d) -> new ReportingDriver(d, b.rootReference().diagnosticContext(), listener, flushListener);
+		return (b,d) -> new ReportingDriver(d, b.diagnosticContext(), listener, flushListener);
 	}
 
 	@Override

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -8,9 +8,10 @@ In particular, check out the [Recommendations](#recommendations) section.
 The `Bosk` object is a container for your application state tree.
 If it helps, you can picture it as an `AtomicReference<MyStateTreeRoot>` that your application can access,
 though it actually does several more things:
-- it acts as a factory for `Reference` objects, which provide efficient access to specific nodes of your state tree,
+- it acts as a factory for `Reference` objects, via `RootReference`, which provide efficient access to specific nodes of your state tree,
 - it provides stable thread-local state snapshots, via `ReadContext`,
-- it provides a `BoskDriver` interface, through which you can modify the immutable state tree, and
+- it provides a `BoskDriver` interface, through which you can modify the immutable state tree,
+- it propagates telemetry information, via `BoskDiagnosticContext`, and
 - it can execute _hook_ callback functions when part of the tree changes.
 
 The `Bosk` object is typically a singleton.


### PR DESCRIPTION
It was misplaced on `RootReference`.

I believe I added it there so that a component that has access to only a `Reference` could get its hands on the diagnostic context. However, it's unclear whether this is an important capability: under what circumstances would there be multiple `DiagnosticContext`s in play, and the right one to pick would vary dynamically on a reference-by-reference basis? Really, whatever component needs the `DiagnosticContext` should be designed to accept the right context at creation time and use it.

It's possible I might some day remember why I thought I needed the `DiagnosticContext` to come from a `Reference`, but in the mean time, it just looked funny.
