### PR TITLE
Add domain-only tests to DriverConformanceTest

### DIFF
--- a/bosk-testing/src/main/java/works/bosk/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/SharedDriverConformanceTest.java
@@ -19,7 +19,7 @@ import static works.bosk.BoskTestUtils.boskName;
 /**
  * Tests the ability of a driver to share state between two bosks.
  */
-public class SharedDriverConformanceTest extends DriverConformanceTest {
+public abstract class SharedDriverConformanceTest extends DriverConformanceTest {
 
 	@Override
 	protected void assertCorrectBoskContents() {


### PR DESCRIPTION
Ensure updates work correctly if only the domain of a `Listing` or `SideTable` is changed.