### PR TITLE
Rename Spring maintenance-path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ giving you "snapshot-at-start" semantics and protecting you from race conditions
 It is an antipattern to use many small read contexts during the course of a single operation.
 
 If you're using Spring Boot 3, you can bring in `bosk-spring-boot-3`
-and set the `bosk.web.service-path` property to get an immediate HTTP REST API to view and edit your state tree.
+and set the `bosk.web.maintenance-path` property to get an immediate HTTP REST API to view and edit your state tree.
 
 To modify state programmatically, use the `BoskDriver` interface:
 

--- a/bosk-spring-boot-3/README.md
+++ b/bosk-spring-boot-3/README.md
@@ -23,6 +23,8 @@ The [`MaintenanceEndpoints`](src/main/java/works/bosk/spring/boot/MaintenanceEnd
 registers HTTP endpoints giving direct `GET`, `PUT`, and `DELETE` access to the bosk state in JSON form.
 The endpoints have a prefix based on the `bosk.web.maintenance-path` setting,
 followed by the path of the node within the bosk state.
+They are intended for troubleshooting, manual operations,
+or integrating with external systems that need full control over the bosk state.
 
 The endpoints also support ETags via `If-Match` and `If-None-Match` headers,
 which exposes a limited ability to do conditional updates.

--- a/bosk-spring-boot-3/README.md
+++ b/bosk-spring-boot-3/README.md
@@ -17,11 +17,11 @@ This feature is enabled by default, and can be disabled by setting `bosk.web.rea
 (Note, though, that if you have a situation where you need more control over read contexts,
 you can consider using `Bosk.supersedingReadContext()` rather than turning off automatic read contexts globally.)
 
-### Service endpoints
+### Maintenance endpoints
 
-The [`ServiceEndpoints`](src/main/java/works/bosk/spring/boot/ServiceEndpoints.java) component
+The [`MaintenanceEndpoints`](src/main/java/works/bosk/spring/boot/MaintenanceEndpoints.java) component
 registers HTTP endpoints giving direct `GET`, `PUT`, and `DELETE` access to the bosk state in JSON form.
-The endpoints have a prefix based on the `bosk.web.service-path` setting,
+The endpoints have a prefix based on the `bosk.web.maintenance-path` setting,
 followed by the path of the node within the bosk state.
 
 The endpoints also support ETags via `If-Match` and `If-None-Match` headers,

--- a/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/BoskAutoConfiguration.java
+++ b/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/BoskAutoConfiguration.java
@@ -27,13 +27,13 @@ public class BoskAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "bosk.web", name = "service-path")
-	ServiceEndpoints serviceEndpoints(
+	@ConditionalOnProperty(prefix = "bosk.web", name = "maintenance-path")
+	MaintenanceEndpoints maintenanceEndpoints(
 		Bosk<?> bosk,
 		ObjectMapper mapper,
 		JacksonSerializer jackson
 	) {
-		return new ServiceEndpoints(bosk, mapper, jackson);
+		return new MaintenanceEndpoints(bosk, mapper, jackson);
 	}
 
 	@Bean

--- a/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/MaintenanceEndpoints.java
+++ b/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/MaintenanceEndpoints.java
@@ -32,13 +32,13 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RestController
-@RequestMapping("${bosk.web.service-path}")
-public class ServiceEndpoints {
+@RequestMapping("${bosk.web.maintenance-path}")
+public class MaintenanceEndpoints {
 	private final Bosk<?> bosk;
 	private final ObjectMapper mapper;
 	private final JacksonSerializer jackson;
 
-	public ServiceEndpoints(
+	public MaintenanceEndpoints(
 		Bosk<?> bosk,
 		ObjectMapper mapper,
 		JacksonSerializer jackson
@@ -223,5 +223,5 @@ public class ServiceEndpoints {
 		}
 	}
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ServiceEndpoints.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(MaintenanceEndpoints.class);
 }

--- a/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/WebProperties.java
+++ b/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/WebProperties.java
@@ -9,5 +9,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Accessors(fluent = false)
 public class WebProperties {
 	Boolean readContext;
-	String servicePath;
+	String maintenancePath;
 }

--- a/example-hello/README.md
+++ b/example-hello/README.md
@@ -17,8 +17,8 @@ The `bosk-spring-boot-3` module automatically establishes a `ReadContext` around
 using the `ReadContextFilter` class.
 (This can be disabled by adding the line `bosk.web.read-context: false` to `application.properties`.)
 
-#### Service endpoints
+#### Maintenance endpoints
 
-By setting `bosk.web.service-path: /bosk` in `application.properties`,
+By setting `bosk.web.maintenance-path: /bosk` in `application.properties`,
 the `bosk-spring-boot-3` module creates `GET`, `PUT`, and `DELETE` endpoints
 that allow users to view and modify the bosk contents over HTTP.

--- a/example-hello/src/main/resources/application.properties
+++ b/example-hello/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=1740
-bosk.web.service-path=/bosk
+bosk.web.maintenance-path=/bosk
 
 # Now that we use this in unit tests, quiet down the logging
 spring.main.banner-mode=off

--- a/example-hello/src/test/java/works/bosk/hello/HelloMaintenanceEndpointsTest.java
+++ b/example-hello/src/test/java/works/bosk/hello/HelloMaintenanceEndpointsTest.java
@@ -38,7 +38,7 @@ import static works.bosk.logging.MdcKeys.BOSK_INSTANCE_ID;
 
 @SpringBootTest(classes = HelloApplication.class)
 @AutoConfigureMockMvc
-public class HelloServiceEndpointsTest {
+public class HelloMaintenanceEndpointsTest {
 	static final Target INITIAL_TARGET = new Target(Identifier.from("world"));
 	static final BoskState INITIAL_STATE = new BoskState(Catalog.of(INITIAL_TARGET));
 


### PR DESCRIPTION
The term "service" in `service-path` is too overloaded to convey any meaning.