### PR TITLE
Remove compilerArg "-parameters"

### DIFF
--- a/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/WebProperties.java
+++ b/bosk-spring-boot-3/src/main/java/works/bosk/spring/boot/WebProperties.java
@@ -1,13 +1,9 @@
 package works.bosk.spring.boot;
 
-import lombok.Value;
-import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "bosk.web")
-@Value
-@Accessors(fluent = false)
-public class WebProperties {
-	Boolean readContext;
-	String maintenancePath;
-}
+public record WebProperties(
+	Boolean readContext,
+	String maintenancePath
+) {}

--- a/bosk-testing/build.gradle
+++ b/bosk-testing/build.gradle
@@ -13,6 +13,7 @@ java {
 
 compileJava {
 	options.release = prodJavaVersion
+	options.compilerArgs << '-parameters' // For @ParametersByName
 }
 
 compileTestJava {

--- a/buildSrc/src/main/groovy/bosk.development.gradle
+++ b/buildSrc/src/main/groovy/bosk.development.gradle
@@ -35,7 +35,6 @@ allprojects {
 
 dependencies {
 	compileJava {
-		options.compilerArgs << '-parameters'        // @ParametersByName doesn't work without this; not sure why
 		options.compilerArgs << '-Xlint'
 		options.compilerArgs << '-Xlint:-serial'     // Don't care about Java serialization
 		options.compilerArgs << '-Xlint:-try'        // Really annoying bogus "auto-closeable never used" warnings


### PR DESCRIPTION
This hasn't been needed for a long time, for the most part. Turns out there were two remaining speed bumps.
- Our `@ParametersByName` JUnit extension needs the names. But that doesn't mean we need them in production code.
- Our Spring Boot `WebProperties` class was unknowingly relying on parameter names. But Spring now supports records, so let's just use that.