### PR TITLE
Isolate `ThreadLocal`s in hooks

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -622,7 +622,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 
 	@Override
 	public void registerHooks(Object receiver) throws InvalidTypeException {
-		HookRegistrar.registerHooks(receiver, this);
+		HookScanner.registerHooks(receiver, this);
 	}
 
 	@Override

--- a/bosk-core/src/main/java/works/bosk/HookScanner.java
+++ b/bosk-core/src/main/java/works/bosk/HookScanner.java
@@ -7,7 +7,6 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.annotations.Hook;
@@ -17,8 +16,10 @@ import static java.lang.reflect.Modifier.isPrivate;
 import static java.lang.reflect.Modifier.isStatic;
 import static works.bosk.util.ReflectionHelpers.getDeclaredMethodsInOrder;
 
-@RequiredArgsConstructor
-class HookRegistrar {
+/**
+ * Finds methods annotated with {@link Hook} in the given {@code object} and registers them in the given {@link Bosk}.
+ */
+class HookScanner {
 	static <T> void registerHooks(T receiverObject, Bosk<?> bosk) throws InvalidTypeException {
 		int hookCounter = 0;
 		for (
@@ -91,5 +92,5 @@ class HookRegistrar {
 		}
 	}
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(HookRegistrar.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(HookScanner.class);
 }


### PR DESCRIPTION
Use a virtual thread for each hook to give it its own isolated `ThreadLocal` bindings.

Also, while we're here, let's reclaim the term "hook registrar" for future use.