### PR TITLE
Fixup tombstone message for bosk-spring-boot-3

### DIFF
--- a/bosk-spring-boot-3/build.gradle
+++ b/bosk-spring-boot-3/build.gradle
@@ -28,9 +28,11 @@ repositories {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			description = '''
+			pom {
+				description = '''
 				This library has been renamed. Please use bosk-spring-boot instead.
-			'''.stripIndent().trim()
+				'''.stripIndent().trim()
+			}
 		}
 	}
 }


### PR DESCRIPTION
I didn't nest the `description` inside `pom` so it didn't override the default description.

I tested this one with `gradle :bosk-spring-boot-3:generatePomFileForMavenJavaPublication` and confirmed that the pom contained the desired description.