### PR TITLE
Add hook registrar factory

### DIFF
--- a/bosk-core/src/main/java/works/bosk/HookRegistrar.java
+++ b/bosk-core/src/main/java/works/bosk/HookRegistrar.java
@@ -1,0 +1,5 @@
+package works.bosk;
+
+public interface HookRegistrar {
+	<T> void registerHook(String name, Reference<T> scope, BoskHook<T> hook);
+}

--- a/bosk-core/src/main/java/works/bosk/RegistrarFactory.java
+++ b/bosk-core/src/main/java/works/bosk/RegistrarFactory.java
@@ -1,0 +1,5 @@
+package works.bosk;
+
+public interface RegistrarFactory {
+	HookRegistrar build(BoskInfo<?> boskInfo, HookRegistrar downstream);
+}

--- a/bosk-core/src/test/java/works/bosk/BoskDiagnosticContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskDiagnosticContextTest.java
@@ -29,8 +29,8 @@ class BoskDiagnosticContextTest extends AbstractDriverTest {
 			boskName(),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,
-			Bosk.simpleDriver()
-		);
+			Bosk.simpleDriver(),
+			Bosk.simpleRegistrar());
 	}
 
 	@Test

--- a/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskLocalReferenceTest.java
@@ -61,7 +61,7 @@ class BoskLocalReferenceTest {
 	void initializeBosk() throws InvalidTypeException {
 		boskName = boskName();
 		Root initialRoot = new Root(1, Catalog.empty());
-		bosk = new Bosk<>(boskName, Root.class, _ -> initialRoot, Bosk.simpleDriver());
+		bosk = new Bosk<>(boskName, Root.class, _ -> initialRoot, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 		refs = bosk.rootReference().buildReferences(Refs.class);
 		Identifier ernieID = Identifier.from("ernie");
 		Identifier bertID = Identifier.from("bert");

--- a/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskUpdateTest.java
@@ -39,12 +39,12 @@ public class BoskUpdateTest extends AbstractBoskTest {
 
 	@BeforeEach
 	void createBosk() throws InvalidTypeException {
-		bosk = new Bosk<TestRoot>(
+		bosk = new Bosk<>(
 			boskName(),
 			TestRoot.class,
 			AbstractBoskTest::initialRoot,
-			Bosk.simpleDriver()
-		);
+			Bosk.simpleDriver(),
+			Bosk.simpleRegistrar());
 		refs = bosk.buildReferences(Refs.class);
 		try (var _ = bosk.readContext()) {
 			originalRoot = bosk.rootReference().value();

--- a/bosk-core/src/test/java/works/bosk/CatalogBenchmark.java
+++ b/bosk-core/src/test/java/works/bosk/CatalogBenchmark.java
@@ -29,12 +29,12 @@ public class CatalogBenchmark {
 
 		@Setup(Level.Trial)
 		public void setup() throws InvalidTypeException {
-			Bosk<AbstractBoskTest.TestRoot> bosk = new Bosk<AbstractBoskTest.TestRoot>(
+			Bosk<AbstractBoskTest.TestRoot> bosk = new Bosk<>(
 				boskName(),
 				AbstractBoskTest.TestRoot.class,
 				AbstractBoskTest::initialRoot,
-				Bosk.simpleDriver()
-			);
+				Bosk.simpleDriver(),
+				Bosk.simpleRegistrar());
 			TestEntityBuilder teb = new TestEntityBuilder(bosk);
 			int initialSize = 100_000;
 			catalog = Catalog.of(IntStream.rangeClosed(1, initialSize).mapToObj(i ->

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -50,7 +50,7 @@ class ListingTest {
 			return childrenStream
 					.map(children -> {
 						TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver());
+						Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 						CatalogReference<TestEntity> catalog;
 						try {
 							catalog = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
@@ -69,7 +69,7 @@ class ListingTest {
 			TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 			List<TestEntity> children = singletonList(child);
 			TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver());
+			Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 			CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 			return idStreams().map(list -> Arguments.of(list.map(Identifier::from).collect(toList()), childrenRef, bosk));
 		}
@@ -242,7 +242,7 @@ class ListingTest {
 		TestEntity child = new TestEntity(Identifier.unique("child"), Catalog.empty());
 		List<TestEntity> children = singletonList(child);
 		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.of(children));
-		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver());
+		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> root, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
 
 		Listing<TestEntity> actual = Listing.empty(childrenRef);

--- a/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
+++ b/bosk-core/src/test/java/works/bosk/OptionalRefsTest.java
@@ -18,7 +18,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 
 	@Test
 	void testReferenceOptionalNotAllowed() {
-		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, _ -> new OptionalString(ID, Optional.empty()), Bosk.simpleDriver());
+		Bosk<OptionalString> bosk = new Bosk<>(boskName(), OptionalString.class, _ -> new OptionalString(ID, Optional.empty()), Bosk.simpleDriver(), Bosk.simpleRegistrar());
 		InvalidTypeException e = assertThrows(InvalidTypeException.class, () -> bosk.rootReference().then(Optional.class, Path.just("field")));
 		assertThat(e.getMessage(), containsString("not supported"));
 	}
@@ -100,7 +100,7 @@ class OptionalRefsTest extends AbstractRoundTripTest {
 	}
 
 	private <E extends Entity, V> void doTest(E initialRoot, ValueFactory<E, V> valueFactory, DriverFactory<E> driverFactory) throws InvalidTypeException {
-		Bosk<E> bosk = new Bosk<>(boskName(), initialRoot.getClass(), _ -> initialRoot, driverFactory);
+		Bosk<E> bosk = new Bosk<>(boskName(), initialRoot.getClass(), _ -> initialRoot, driverFactory, Bosk.simpleRegistrar());
 		V value = valueFactory.createFrom(bosk);
 		@SuppressWarnings("unchecked")
 		Reference<V> optionalRef = bosk.rootReference().then((Class<V>)value.getClass(), "field");

--- a/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
+++ b/bosk-core/src/test/java/works/bosk/ReferenceErrorTest.java
@@ -18,7 +18,8 @@ public class ReferenceErrorTest {
 			boskName(),
 			BadGetters.class,
 			_ -> new BadGetters(Identifier.from("test"), new NestedObject(Optional.of("stringValue"))),
-			Bosk.simpleDriver());
+			Bosk.simpleDriver(),
+			Bosk.simpleRegistrar());
 	}
 
 	@Test

--- a/bosk-core/src/test/java/works/bosk/TaggedUnionTest.java
+++ b/bosk-core/src/test/java/works/bosk/TaggedUnionTest.java
@@ -51,7 +51,7 @@ class TaggedUnionTest extends AbstractBoskTest {
 		Identifier idValue = Identifier.from("test2");
 		StringCase stringCase = new StringCase(stringValue);
 		IDCase idCase = new IDCase(idValue);
-		var bosk = new Bosk<>(boskName(), BoskState.class, _ -> new BoskState(TaggedUnion.of(stringCase)), Bosk.simpleDriver());
+		var bosk = new Bosk<>(boskName(), BoskState.class, _ -> new BoskState(TaggedUnion.of(stringCase)), Bosk.simpleDriver(), Bosk.simpleRegistrar());
 		var refs = bosk.rootReference().buildReferences(Refs.class);
 
 		// Initial state

--- a/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
+++ b/bosk-core/src/test/java/works/bosk/dereferencers/PathCompilerTest.java
@@ -268,8 +268,11 @@ public class PathCompilerTest extends AbstractBoskTest {
 			.getConstructor(Identifier.class)
 			.newInstance(rootID);
 		Bosk<StateTreeNode> differentBosk = new Bosk<>(
-			boskName("Different"), differentRootClass, _ -> initialRoot, Bosk.simpleDriver()
-		);
+			boskName("Different"),
+			differentRootClass,
+			_ -> initialRoot,
+			Bosk.simpleDriver(),
+			Bosk.simpleRegistrar());
 		Reference<Identifier> idRef = differentBosk.rootReference().then(Identifier.class, Path.parse(
 			"/id" ));
 

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
@@ -18,7 +18,8 @@ class ReplicaSetConformanceTest extends DriverConformanceTest {
 			boskName("Replica"),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,
-			replicaSet.driverFactory());
+			replicaSet.driverFactory(),
+			Bosk.simpleRegistrar());
 		driverFactory = replicaSet.driverFactory();
 	}
 

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetTest.java
@@ -18,11 +18,11 @@ public class ReplicaSetTest extends AbstractDriverTest {
 	@Test
 	void joinAfterUpdate_correctInitialState() throws InvalidTypeException {
 		var replicaSet = new ReplicaSet<TestEntity>();
-		var bosk1 = new Bosk<>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var bosk1 = new Bosk<>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory(), Bosk.simpleRegistrar());
 		var refs1 = bosk1.rootReference().buildReferences(Refs.class);
 		bosk1.driver().submitReplacement(refs1.string(), "New value");
 
-		var bosk2 = new Bosk<>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var bosk2 = new Bosk<>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory(), Bosk.simpleRegistrar());
 		var refs2 = bosk2.rootReference().buildReferences(Refs.class);
 		try (var _ = bosk2.readContext()) {
 			assertEquals("New value", refs2.string().value());
@@ -32,13 +32,13 @@ public class ReplicaSetTest extends AbstractDriverTest {
 	@Test
 	void secondaryConstructedInPrimaryReadContext_seesLatestState() throws InvalidTypeException {
 		var replicaSet = new ReplicaSet<TestEntity>();
-		var bosk1 = new Bosk<>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+		var bosk1 = new Bosk<>(boskName("bosk1"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory(), Bosk.simpleRegistrar());
 		var refs1 = bosk1.rootReference().buildReferences(Refs.class);
 
 		Bosk<TestEntity> bosk2;
 		try (var _ = bosk1.readContext()) {
 			bosk1.driver().submitReplacement(refs1.string(), "New value");
-			bosk2 = new Bosk<>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory());
+			bosk2 = new Bosk<>(boskName("bosk2"), TestEntity.class, AbstractDriverTest::initialRoot, replicaSet.driverFactory(), Bosk.simpleRegistrar());
 		}
 		var refs2 = bosk2.rootReference().buildReferences(Refs.class);
 		try (var _ = bosk2.readContext()) {

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeSurgeonTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeSurgeonTest.java
@@ -46,11 +46,12 @@ public class JsonNodeSurgeonTest {
 
 	@BeforeEach
 	void setUp() throws InvalidTypeException {
-		bosk = new Bosk<JsonRoot>(
+		bosk = new Bosk<>(
 			boskName(),
 			JsonRoot.class,
-			b->JsonRoot.empty(b.buildReferences(Refs.class)),
-			Bosk.simpleDriver());
+			b -> JsonRoot.empty(b.buildReferences(Refs.class)),
+			Bosk.simpleDriver(),
+			Bosk.simpleRegistrar());
 		refs = bosk.buildReferences(Refs.class);
 		jacksonSerializer = new JacksonSerializer();
 		mapper = new ObjectMapper();

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverInitializationFailureTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverInitializationFailureTest.java
@@ -28,7 +28,7 @@ public class MongoDriverInitializationFailureTest extends AbstractMongoDriverTes
 		mongoService.proxy().setConnectionCut(true);
 		tearDownActions.add(()->mongoService.proxy().setConnectionCut(false));
 		assertThrows(InitialRootFailureException.class, ()->{
-			new Bosk<TestEntity>(boskName("Fail"), TestEntity.class, this::initialRoot, super.createDriverFactory(logController, testInfo));
+			new Bosk<TestEntity>(boskName("Fail"), TestEntity.class, this::initialRoot, super.createDriverFactory(logController, testInfo), Bosk.simpleRegistrar());
 		});
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/MongoDriverRecoveryTest.java
@@ -81,7 +81,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		tearDownActions.add(()->mongoService.proxy().setConnectionCut(false));
 
 		LOGGER.debug("Create a new bosk that can't connect");
-		Bosk<TestEntity> bosk = new Bosk<TestEntity>(getClass().getSimpleName() + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory);
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>(getClass().getSimpleName() + boskCounter.incrementAndGet(), TestEntity.class, this::initialRoot, driverFactory, Bosk.simpleRegistrar());
 
 		MongoDriverSpecialTest.Refs refs = bosk.buildReferences(MongoDriverSpecialTest.Refs.class);
 		BoskDriver driver = bosk.driver();
@@ -206,7 +206,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		LOGGER.debug("Setup database to beforeState");
 		TestEntity beforeState = initializeDatabase("before deletion");
 
-		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(getClass().getSimpleName()), TestEntity.class, this::initialRoot, driverFactory);
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(getClass().getSimpleName()), TestEntity.class, this::initialRoot, driverFactory, Bosk.simpleRegistrar());
 
 		try (var _ = bosk.readContext()) {
 			assertEquals(beforeState, bosk.rootReference().value());
@@ -258,7 +258,8 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 					var mongoDriver = (MongoDriver) driverFactory.build(b, d);
 					driverRef.set(mongoDriver);
 					return mongoDriver;
-				});
+				},
+				Bosk.simpleRegistrar());
 			var driver = driverRef.get();
 			waitFor(driver);
 			driver.close();
@@ -273,7 +274,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		LOGGER.debug("Setup database to beforeState");
 		TestEntity beforeState = initializeDatabase("before disruption");
 
-		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(getClass().getSimpleName()), TestEntity.class, this::initialRoot, driverFactory);
+		Bosk<TestEntity> bosk = new Bosk<TestEntity>(boskName(getClass().getSimpleName()), TestEntity.class, this::initialRoot, driverFactory, Bosk.simpleRegistrar());
 
 		try (var _ = bosk.readContext()) {
 			assertEquals(beforeState, bosk.rootReference().value());

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/SchemaEvolutionTest.java
@@ -179,7 +179,7 @@ public class SchemaEvolutionTest {
 	}
 
 	private static Bosk<TestEntity> newBosk(Helper helper) {
-		return new Bosk<>(boskName(helper.toString()), TestEntity.class, helper::initialRoot, helper.driverFactory);
+		return new Bosk<>(boskName(helper.toString()), TestEntity.class, helper::initialRoot, helper.driverFactory, Bosk.simpleRegistrar());
 	}
 
 	record Configuration(

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/bson/BsonSerializerTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/bson/BsonSerializerTest.java
@@ -29,7 +29,7 @@ class BsonSerializerTest {
 	@Test
 	void sideTableOfSideTables() {
 		BsonSerializer bp = new BsonSerializer();
-		Bosk<Root> bosk = new Bosk<Root>(boskName(), Root.class, this::defaultRoot, Bosk.simpleDriver());
+		Bosk<Root> bosk = new Bosk<Root>(boskName(), Root.class, this::defaultRoot, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 		CodecRegistry registry = CodecRegistries.fromProviders(bp.codecProviderFor(bosk), new ValueCodecProvider());
 		Codec<Root> codec = registry.get(Root.class);
 		try (var _ = bosk.readContext()) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/bson/DottedFieldNameTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/bson/DottedFieldNameTest.java
@@ -23,7 +23,7 @@ class DottedFieldNameTest {
 
 	@BeforeEach
 	void setUpStuff() {
-		bosk = new Bosk<>(boskName(), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver());
+		bosk = new Bosk<>(boskName(), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 	}
 
 	static class PathArgumentProvider implements ArgumentsProvider {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/example/ExampleBosk.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/example/ExampleBosk.java
@@ -16,7 +16,8 @@ public class ExampleBosk extends Bosk<ExampleState> {
 			"ExampleBosk",
 			ExampleState.class,
 			_ -> defaultRoot(),
-			driverFactory());
+			driverFactory(),
+			Bosk.simpleRegistrar());
 	}
 
 	public interface Refs {

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverDurabilityTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverDurabilityTest.java
@@ -61,7 +61,7 @@ public class SqlDriverDurabilityTest extends AbstractDriverTest {
 		// to spontaneous state changes, even though they are valid in a setup with
 		// multiple bosks sharing a database.
 		//
-		bosk = new Bosk<>(boskName("tablesDropped", 1), TestEntity.class, AbstractDriverTest::initialRoot, factory);
+		bosk = new Bosk<>(boskName("tablesDropped", 1), TestEntity.class, AbstractDriverTest::initialRoot, factory, Bosk.simpleRegistrar());
 		driver = bosk.driver();
 
 		var schema = new Schema();
@@ -81,7 +81,7 @@ public class SqlDriverDurabilityTest extends AbstractDriverTest {
 		assertThrows(FlushFailureException.class, () -> bosk.driver().flush());
 
 		LOGGER.debug("Use another bosk to recreate the database");
-		var fixer = new Bosk<>("fixer", TestEntity.class, SqlDriverDurabilityTest::differentInitialRoot, factory);
+		var fixer = new Bosk<>("fixer", TestEntity.class, SqlDriverDurabilityTest::differentInitialRoot, factory, Bosk.simpleRegistrar());
 
 		LOGGER.debug("State should be restored");
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/AbstractDriverTest.java
@@ -55,13 +55,18 @@ public abstract class AbstractDriverTest {
 
 	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
 		// This is the bosk whose behaviour we'll consider to be correct by definition
-		canonicalBosk = new Bosk<>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver());
+		canonicalBosk = new Bosk<>(boskName("Canonical", 1), TestEntity.class, AbstractDriverTest::initialRoot, Bosk.simpleDriver(), Bosk.simpleRegistrar());
 
 		// This is the bosk we're testing
-		bosk = new Bosk<>(boskName("Test", 1), TestEntity.class, AbstractDriverTest::initialRoot, DriverStack.of(
-			ReplicaSet.mirroringTo(canonicalBosk),
-			DriverStateVerifier.wrap(driverFactory, TestEntity.class, AbstractDriverTest::initialRoot)
-		));
+		bosk = new Bosk<>(
+			boskName("Test", 1),
+			TestEntity.class,
+			AbstractDriverTest::initialRoot,
+			DriverStack.of(
+				ReplicaSet.mirroringTo(canonicalBosk),
+				DriverStateVerifier.wrap(driverFactory, TestEntity.class, AbstractDriverTest::initialRoot)
+			),
+			Bosk.simpleRegistrar());
 		driver = bosk.driver();
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -59,9 +59,10 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 	public static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject, Type rootType, Bosk.DefaultRootFunction<RR> defaultRootFunction) {
 		Bosk<RR> stateTrackingBosk = new Bosk<>(
 			boskName(),
-			rootType, defaultRootFunction,
-			Bosk.simpleDriver()
-		);
+			rootType,
+			defaultRootFunction,
+			Bosk.simpleDriver(),
+			Bosk.simpleRegistrar());
 		DriverStateVerifier<RR> verifier = new DriverStateVerifier<>(
 			stateTrackingBosk,
 			ReplicaSet.redirectingTo(stateTrackingBosk)

--- a/bosk-testing/src/main/java/works/bosk/drivers/HanoiTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/HanoiTest.java
@@ -56,12 +56,12 @@ public abstract class HanoiTest {
 
 	@BeforeEach
 	void setup() throws InvalidTypeException {
-		bosk = new Bosk<HanoiState>(
+		bosk = new Bosk<>(
 			boskName(),
 			HanoiState.class,
 			this::defaultRoot,
-			driverFactory
-		);
+			driverFactory,
+			Bosk.simpleRegistrar());
 		refs = bosk.rootReference().buildReferences(Refs.class);
 		numSolved = new LinkedBlockingDeque<>();
 		bosk.registerHooks(this);

--- a/bosk-testing/src/main/java/works/bosk/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/SharedDriverConformanceTest.java
@@ -24,7 +24,7 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 	@Override
 	protected void assertCorrectBoskContents() {
 		super.assertCorrectBoskContents();
-		var latecomer = new Bosk<>(BoskTestUtils.boskName("latecomer"), TestEntity.class, AbstractDriverTest::initialRoot, driverFactory);
+		var latecomer = new Bosk<>(BoskTestUtils.boskName("latecomer"), TestEntity.class, AbstractDriverTest::initialRoot, driverFactory, Bosk.simpleRegistrar());
 		try {
 			latecomer.driver().flush();
 		} catch (Exception e) {
@@ -48,8 +48,8 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			boskName("Original"),
 			TestEntity.class,
 			AbstractDriverTest::initialRoot,
-			driverFactory
-		);
+			driverFactory,
+			Bosk.simpleRegistrar());
 
 		LOGGER.debug("Create Upgradeable bosk");
 		@SuppressWarnings({"rawtypes","unchecked"})
@@ -58,8 +58,8 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			boskName("Upgradeable"),
 			UpgradeableEntity.class,
 			(b) -> { throw new AssertionError("upgradeableBosk should use the state from MongoDB"); },
-			upgradeableDriverFactory
-		);
+			upgradeableDriverFactory,
+			Bosk.simpleRegistrar());
 
 		LOGGER.debug("Ensure polyfill returns the right value on read");
 		TestValues polyfill;

--- a/example-hello/src/main/java/works/bosk/hello/HelloBosk.java
+++ b/example-hello/src/main/java/works/bosk/hello/HelloBosk.java
@@ -18,7 +18,7 @@ import works.bosk.logback.BoskLogFilter.LogController;
 @Component
 public class HelloBosk extends Bosk<BoskState> {
 	public HelloBosk(LogController logController) throws InvalidTypeException {
-		super("Hello", BoskState.class, HelloBosk::defaultRoot, getDriverFactory(logController));
+		super("Hello", BoskState.class, HelloBosk::defaultRoot, getDriverFactory(logController), Bosk.simpleRegistrar());
 	}
 
 	private static DriverFactory<BoskState> getDriverFactory(LogController logController) {

--- a/lib-testing/src/main/java/works/bosk/AbstractBoskTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractBoskTest.java
@@ -137,7 +137,7 @@ public abstract class AbstractBoskTest {
 	public record VariantCase1(String stringField) implements Variant { }
 
 	protected static Bosk<TestRoot> setUpBosk(DriverFactory<TestRoot> driverFactory) {
-		return new Bosk<TestRoot>(boskName(1), TestRoot.class, AbstractRoundTripTest::initialRoot, driverFactory);
+		return new Bosk<TestRoot>(boskName(1), TestRoot.class, AbstractRoundTripTest::initialRoot, driverFactory, Bosk.simpleRegistrar());
 	}
 
 	protected static TestRoot initialRoot(Bosk<TestRoot> bosk) {


### PR DESCRIPTION
OpenTelemetry investigations have shown we have a need for a way to interpose on hooks the same way that drivers can interpose on state updates.

I think we'll ultimately want a higher-level abstraction that handles more of this automatically, but for the time being, accepting layered hook registrars will at least make it possible to customize hook execution right now.

We used this hook registrar concept successfully in Ice Cube to capture crash information, including the bosk contents, when when a hook threw an exception.
