### PR TITLE
Fixes for ReportingDriver and DriverStateVerifier

### DIFF
--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -16,6 +16,7 @@ import works.bosk.DriverFactory;
 import works.bosk.DriverStack;
 import works.bosk.Reference;
 import works.bosk.StateTreeNode;
+import works.bosk.drivers.operations.FlushOperation;
 import works.bosk.drivers.operations.UpdateOperation;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
@@ -93,7 +94,7 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 			.addLast(updateOperation);
 	}
 
-	private void incomingFlush() {
+	private void incomingFlush(FlushOperation __) {
 		LOGGER.debug("incomingFlush()");
 	}
 
@@ -151,7 +152,7 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 		}
 	}
 
-	private void outgoingFlush() {
+	private void outgoingFlush(FlushOperation __) {
 		LOGGER.debug("outgoingFlush()");
 		pendingOperationsByThreadName.forEach((thread, q) -> {
 			if (!q.isEmpty()) {

--- a/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/DriverStateVerifier.java
@@ -172,13 +172,11 @@ public class DriverStateVerifier<R extends StateTreeNode> {
 
 	@SuppressWarnings("unchecked")
 	private <T> T hypotheticalStateAfter(UpdateOperation op) throws IOException, InterruptedException {
-		T before;
 		R originalState;
 		Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
 		stateTrackingBosk.driver().flush();
 		try (var __ = stateTrackingBosk.readContext()) {
 			originalState = stateTrackingBosk.rootReference().value();
-			before = stateTrackingRef.valueIfExists();
 		}
 		op.submitTo(stateTrackingDriver);
 		stateTrackingBosk.driver().flush();

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -84,6 +84,9 @@ public class ReportingDriver implements BoskDriver {
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		downstream.flush();
+		FlushOperation op = new FlushOperation(diagnosticContext.getAttributes());
+		flushListener.accept(op);
+		op.submitTo(downstream);
 	}
+
 }

--- a/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/ReportingDriver.java
@@ -12,6 +12,8 @@ import works.bosk.Identifier;
 import works.bosk.Reference;
 import works.bosk.StateTreeNode;
 import works.bosk.drivers.operations.ConditionalCreation;
+import works.bosk.drivers.operations.DriverOperation;
+import works.bosk.drivers.operations.FlushOperation;
 import works.bosk.drivers.operations.SubmitConditionalDeletion;
 import works.bosk.drivers.operations.SubmitConditionalReplacement;
 import works.bosk.drivers.operations.SubmitDeletion;
@@ -29,11 +31,15 @@ import works.bosk.exceptions.InvalidTypeException;
 public class ReportingDriver implements BoskDriver {
 	final BoskDriver downstream;
 	final BoskDiagnosticContext diagnosticContext;
-	final Consumer<UpdateOperation> updateListener;
-	final Runnable flushListener;
+	final Consumer<? super UpdateOperation> updateListener;
+	final Consumer<? super FlushOperation> flushListener;
 
-	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<UpdateOperation> listener, Runnable flushListener) {
-		return (b,d) -> new ReportingDriver(d, b.diagnosticContext(), listener, flushListener);
+	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<? super DriverOperation> listener) {
+		return (b,d) -> new ReportingDriver(d, b.diagnosticContext(), listener, listener);
+	}
+
+	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<? super UpdateOperation> updateListener, Consumer<? super FlushOperation> flushListener) {
+		return (b,d) -> new ReportingDriver(d, b.diagnosticContext(), updateListener, flushListener);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/DriverOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/DriverOperation.java
@@ -1,0 +1,17 @@
+package works.bosk.drivers.operations;
+
+import java.io.IOException;
+import works.bosk.BoskDiagnosticContext;
+import works.bosk.BoskDriver;
+import works.bosk.MapValue;
+
+public sealed interface DriverOperation permits UpdateOperation, FlushOperation {
+	MapValue<String> diagnosticAttributes();
+
+	/**
+	 * Calls the appropriate <code>submit</code> method on the given driver.
+	 * Any {@link BoskDiagnosticContext diagnostic context} is <em>not</em> propagated;
+	 * if that behaviour is desired, the caller must do it.
+	 */
+	void submitTo(BoskDriver driver) throws IOException, InterruptedException;
+}

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/FlushOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/FlushOperation.java
@@ -1,0 +1,14 @@
+package works.bosk.drivers.operations;
+
+import java.io.IOException;
+import works.bosk.BoskDriver;
+import works.bosk.MapValue;
+
+public record FlushOperation(
+	MapValue<String> diagnosticAttributes
+) implements DriverOperation {
+	@Override
+	public void submitTo(BoskDriver driver) throws IOException, InterruptedException {
+		driver.flush();
+	}
+}

--- a/bosk-testing/src/main/java/works/bosk/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/drivers/operations/UpdateOperation.java
@@ -1,18 +1,15 @@
 package works.bosk.drivers.operations;
 
 import java.util.Collection;
-import works.bosk.BoskDiagnosticContext;
 import works.bosk.BoskDriver;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 
-public sealed interface UpdateOperation permits
+public sealed interface UpdateOperation extends DriverOperation permits
 	OperationWithPrecondition,
 	DeletionOperation,
 	ReplacementOperation
 {
 	Reference<?> target();
-	MapValue<String> diagnosticAttributes();
 
 	/**
 	 * @return true if this operation matches <code>other</code> ignoring any preconditions.
@@ -20,10 +17,6 @@ public sealed interface UpdateOperation permits
 	boolean matchesIfApplied(UpdateOperation other);
 
 	UpdateOperation withFilteredAttributes(Collection<String> allowedNames);
-	/**
-	 * Calls the appropriate <code>submit</code> method on the given driver.
-	 * Any {@link BoskDiagnosticContext diagnostic context} is <em>not</em> propagated;
-	 * if that behaviour is desired, the caller must do it.
-	 */
-	void submitTo(BoskDriver driver);
+
+	@Override void submitTo(BoskDriver driver); // No checked exceptions
 }

--- a/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverConformanceTest.java
+++ b/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverConformanceTest.java
@@ -6,7 +6,7 @@ class ReportingDriverConformanceTest extends DriverConformanceTest {
 
 	@BeforeEach
 	void setupDriverFactory() {
-		driverFactory = ReportingDriver.factory(op->{}, ()->{});
+		driverFactory = ReportingDriver.factory(_->{}, _->{});
 	}
 
 }

--- a/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/works/bosk/drivers/ReportingDriverTest.java
@@ -48,7 +48,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 	void setUp() throws InvalidTypeException {
 		ops = new ArrayList<>();
 		numFlushes = new AtomicInteger(0);
-		setupBosksAndReferences(ReportingDriver.factory(ops::add, numFlushes::incrementAndGet));
+		setupBosksAndReferences(ReportingDriver.factory(ops::add, _->numFlushes.incrementAndGet()));
 		refs = bosk.buildReferences(Refs.class);
 		bosk.driver().submitReplacement(refs.entity(id1), emptyEntityAt(refs.entity(id1)));
 		ops.clear();


### PR DESCRIPTION
Added `FlushOperation` to `ReportingDriver` for use cases where we care about the order of interleaving of flushes with other operations.

While doing that, I discovered `ReportingDriver` was busted: it wasn't even calling the flush listener. When I fixed that, it turned out `DriverStateVerifier` was also busted, so I fixed that.