### PR TITLE
ReadContextFilterTest

### DIFF
--- a/bosk-spring-boot/build.gradle
+++ b/bosk-spring-boot/build.gradle
@@ -2,6 +2,7 @@
 dependencies {
 	api project(":bosk-jackson")
 	implementation libs.spring.boot.starter.web
+	testImplementation libs.spring.boot.starter.test
 	annotationProcessor libs.spring.boot.annotation.processor
 	testImplementation project(":bosk-testing")
 	testImplementation project(":lib-testing")

--- a/bosk-spring-boot/src/main/java/works/bosk/spring/boot/ReadContextFilter.java
+++ b/bosk-spring-boot/src/main/java/works/bosk/spring/boot/ReadContextFilter.java
@@ -45,8 +45,8 @@ public class ReadContextFilter extends OncePerRequestFilter {
 	}
 
 	/**
-	 * The "safe" HTTP methods won't change server state, so there's no reason not to
-	 * open a
+	 * The "safe" HTTP methods won't change the server state,
+	 * so there's no reason not to open a read context.
 	 */
 	private boolean automaticallyOpenReadContext(HttpServletRequest request) {
 		return switch (request.getMethod()) {

--- a/bosk-spring-boot/src/test/java/works/bosk/spring/boot/ReadContextFilterTest.java
+++ b/bosk-spring-boot/src/test/java/works/bosk/spring/boot/ReadContextFilterTest.java
@@ -1,0 +1,101 @@
+package works.bosk.spring.boot;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import works.bosk.Bosk;
+import works.bosk.StateTreeNode;
+import works.bosk.drivers.ReportingDriver;
+import works.bosk.exceptions.NoReadContextException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReadContextFilterTest {
+	Bosk<State> bosk;
+	ReadContextFilter filter;
+	List<String> events;
+	MockHttpServletRequest req;
+	MockHttpServletResponse res;
+
+	public record State() implements StateTreeNode {}
+
+	@BeforeEach
+	void setup() {
+		events = new ArrayList<>();
+		bosk = new Bosk<>(
+			ReadContextFilterTest.class.getSimpleName(),
+			State.class,
+			b->new State(),
+			ReportingDriver.factory(op -> events.add(op.getClass().getSimpleName())),
+			Bosk.simpleRegistrar()
+		);
+		filter = new ReadContextFilter(bosk);
+		req = new MockHttpServletRequest();
+		res = new MockHttpServletResponse();
+	}
+
+	@Test
+	void noHeaders_noOperations() throws ServletException, IOException {
+		filter.doFilter(req, res, new ReportingFilterChain());
+		assertEquals(List.of("filter chain"), events);
+	}
+
+	@Test
+	void noCache_flushesFirst() throws ServletException, IOException {
+		req.addHeader("Cache-Control", "no-cache");
+		filter.doFilter(req, res, new ReportingFilterChain());
+		assertEquals(List.of("FlushOperation", "filter chain"), events);
+	}
+
+	@Test
+	void noCacheWeirdCase_flushes() throws ServletException, IOException {
+		req.addHeader("Cache-Control", "nO-CAchE");
+		filter.doFilter(req, res, new ReportingFilterChain());
+		assertEquals(List.of("FlushOperation", "filter chain"), events);
+	}
+
+
+	@Test
+	void otherCacheControl_noOperations() throws ServletException, IOException {
+		req.addHeader("Cache-Control", "no-cash");
+		filter.doFilter(req, res, new ReportingFilterChain());
+		assertEquals(List.of("filter chain"), events);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "GET", "HEAD", "OPTIONS" })
+	void readOnlyMethods_createReadContext(String method) throws ServletException, IOException {
+		req.setMethod(method);
+		filter.doFilter(req, res, (_, _) -> {
+			assertEquals(new State(), bosk.rootReference().value());
+		});
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "POST", "PUT", "PATCH", "DELETE", "TRACE" })
+	void otherMethods_noReadContext(String method) throws ServletException, IOException {
+		req.setMethod(method);
+		filter.doFilter(req, res, (_, _) -> {
+			assertThrows(NoReadContextException.class, bosk.rootReference()::value);
+		});
+	}
+
+	private class ReportingFilterChain extends MockFilterChain {
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+			events.add("filter chain");
+		}
+	}
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version="4.8.6" }
 spring-boot-annotation-processor = { module="org.springframework.boot:spring-boot-configuration-processor", version.ref="spring-boot" }
 spring-boot-starter-web = { module="org.springframework.boot:spring-boot-starter-web", version.ref="spring-boot" }
+spring-boot-starter-test = { module="org.springframework.boot:spring-boot-starter-test", version.ref="spring-boot" }
 sqlite = { module = "org.xerial:sqlite-jdbc", version = "3.49.1.0" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }


### PR DESCRIPTION
In #93 we added support for case-insensitive `Cache-Control` header values in `ReadContextFilter` but had no automated tests. This PR rectifies that.