### PR TITLE
Improve error messages from registerHooks

### DIFF
--- a/bosk-core/src/main/java/works/bosk/HookScanner.java
+++ b/bosk-core/src/main/java/works/bosk/HookScanner.java
@@ -4,6 +4,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -33,56 +34,17 @@ class HookScanner {
 					continue;
 				}
 				if (isStatic(method.getModifiers())) {
-					throw new IllegalArgumentException("Hook method cannot be static: " + method);
+					throw new InvalidTypeException("Hook method cannot be static: " + method);
 				} else if (isPrivate(method.getModifiers())) {
-					throw new IllegalArgumentException("Hook method cannot be private: " + method);
-				}
-				Path path = Path.parseParameterized(hookAnnotation.value());
-
-				Reference<?> plainRef = bosk.rootReference().then(Object.class, path);
-				// Now substitute one of the handy Reference subtypes where possible
-				Reference<?> scope;
-				if (Catalog.class.isAssignableFrom(plainRef.targetClass())) {
-					scope = bosk.rootReference().thenCatalog(Entity.class, path);
-				} else if (Listing.class.isAssignableFrom(plainRef.targetClass())) {
-					scope = bosk.rootReference().thenListing(Entity.class, path);
-				} else if (SideTable.class.isAssignableFrom(plainRef.targetClass())) {
-					scope = bosk.rootReference().thenSideTable(Entity.class, Object.class, path);
-				} else {
-					scope = plainRef;
+					throw new InvalidTypeException("Hook method cannot be private: " + method);
 				}
 
-				List<Function<Reference<?>, Object>> argumentFunctions = new ArrayList<>(method.getParameterCount());
-				argumentFunctions.add(ref -> receiverObject); // The "this" pointer
-				for (Parameter p : method.getParameters()) {
-					if (Reference.class.isAssignableFrom(p.getType())) {
-						if (ReferenceUtils.parameterType(p.getParameterizedType(), Reference.class, 0).equals(scope.targetType())) {
-							argumentFunctions.add(ref -> ref);
-						} else {
-							throw new IllegalArgumentException("Expected reference to " + scope.targetType() + ": " + method.getName() + " parameter " + p);
-						}
-					} else if (p.getType().isAssignableFrom(BindingEnvironment.class)) {
-						argumentFunctions.add(ref -> scope.parametersFrom(ref.path()));
-					} else {
-						throw new IllegalArgumentException("Unsupported parameter type " + p.getType() + ": " + method.getName() + " parameter " + p);
-					}
-				}
-				MethodHandle hook;
 				try {
-					hook = MethodHandles.lookup().unreflect(method);
-				} catch (IllegalAccessException e) {
-					throw new IllegalArgumentException(e);
+					registerOneHookMethod(receiverObject, bosk, method, Path.parseParameterized(hookAnnotation.value()));
+					hookCounter++;
+				} catch (InvalidTypeException e) {
+					throw new InvalidTypeException("Unable to register hook method " + receiverClass.getSimpleName() + "." + method.getName() + ": " + e.getMessage(), e);
 				}
-				bosk.registerHook(method.getName(), scope, ref -> {
-					try {
-						List<Object> arguments = new ArrayList<>(argumentFunctions.size());
-						argumentFunctions.forEach(f -> arguments.add(f.apply(ref)));
-						hook.invokeWithArguments(arguments);
-					} catch (Throwable e) {
-						throw new IllegalStateException("Unable to call hook \"" + method.getName() + "\"", e);
-					}
-				});
-				hookCounter++;
 			}
 		}
 		if (hookCounter == 0) {
@@ -90,6 +52,55 @@ class HookScanner {
 		} else {
 			LOGGER.info("Registered {} hook{} in {}", hookCounter, (hookCounter >= 2) ? "s" : "", receiverObject.getClass().getSimpleName());
 		}
+	}
+
+	private static <T> void registerOneHookMethod(T receiverObject, Bosk<?> bosk, Method method, Path path) throws InvalidTypeException {
+		Reference<?> plainRef = bosk.rootReference().then(Object.class, path);
+
+		// Now substitute one of the handy Reference subtypes where possible
+		Reference<?> scope;
+		if (Catalog.class.isAssignableFrom(plainRef.targetClass())) {
+			scope = bosk.rootReference().thenCatalog(Entity.class, path);
+		} else if (Listing.class.isAssignableFrom(plainRef.targetClass())) {
+			scope = bosk.rootReference().thenListing(Entity.class, path);
+		} else if (SideTable.class.isAssignableFrom(plainRef.targetClass())) {
+			scope = bosk.rootReference().thenSideTable(Entity.class, Object.class, path);
+		} else {
+			scope = plainRef;
+		}
+
+		List<Function<Reference<?>, Object>> argumentFunctions = new ArrayList<>(method.getParameterCount());
+		argumentFunctions.add(ref -> receiverObject); // The "this" pointer
+		for (Parameter p : method.getParameters()) {
+			if (Reference.class.isAssignableFrom(p.getType())) {
+				Type referenceType = ReferenceUtils.parameterType(p.getParameterizedType(), Reference.class, 0);
+				if (referenceType.equals(scope.targetType())) {
+					argumentFunctions.add(ref -> ref);
+				} else {
+					throw new InvalidTypeException("Parameter \"" + p.getName() + "\" should be a reference to " + scope.targetType() + ", not " + referenceType);
+				}
+			} else if (p.getType().isAssignableFrom(BindingEnvironment.class)) {
+				argumentFunctions.add(ref -> scope.parametersFrom(ref.path()));
+			} else {
+				throw new InvalidTypeException("Unsupported parameter type: " + p);
+			}
+		}
+
+		MethodHandle hook;
+		try {
+			hook = MethodHandles.lookup().unreflect(method);
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(e);
+		}
+		bosk.registerHook(method.getName(), scope, ref -> {
+			try {
+				List<Object> arguments = new ArrayList<>(argumentFunctions.size());
+				argumentFunctions.forEach(f -> arguments.add(f.apply(ref)));
+				hook.invokeWithArguments(arguments);
+			} catch (Throwable e) {
+				throw new IllegalStateException("Unable to call hook \"" + method.getName() + "\"", e);
+			}
+		});
 	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(HookScanner.class);

--- a/bosk-mongo/build.gradle
+++ b/bosk-mongo/build.gradle
@@ -2,7 +2,6 @@
 dependencies {
 	api project(":bosk-core")
 	api libs.mongodb
-	implementation libs.spotbugs.annotations
 
 	// Allows us to annotate status objects so they're handy to serialize with jackson
 	implementation libs.jackson.annotations

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,6 @@ opentelemetry = { module="io.opentelemetry:opentelemetry-sdk", version="1.48.0" 
 pcollections = { module = "org.pcollections:pcollections", version.ref="pcollections" }
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.5" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
-spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version="4.8.6" }
 spring-boot-annotation-processor = { module="org.springframework.boot:spring-boot-configuration-processor", version.ref="spring-boot" }
 spring-boot-starter-web = { module="org.springframework.boot:spring-boot-starter-web", version.ref="spring-boot" }
 spring-boot-starter-test = { module="org.springframework.boot:spring-boot-starter-test", version.ref="spring-boot" }


### PR DESCRIPTION
The `InvalidTypeException` thrown from `HookScanner` often didn't describe the method with the bug. I've wrapped the `InvalidTypeException` with another one that provides more context, and added tests to ensure the minimum helpful troubleshooting information is included in the exception message.

I've also removed the unused Spotbugs annotation library. We prefer using config files for this over annotations to reduce runtime dependencies.