### PR TITLE
Peel off dependabot groups for spring-boot and junit.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    groups:
-      all-dependencies:
+    groups: # Separate groups for dependencies that have cause problems in the past
+      spring-boot:
+        patterns:
+          - "org.springframework.boot*"
+      junit:
+        patterns:
+          - "org.junit*"
+      ordinary-dependencies: # Uncontroversial dependencies
         patterns:
           - "*"
+        exclude-patterns:
+          - "org.springframework.boot*"
+          - "org.junit*"


### PR DESCRIPTION
These ones have caused workflow failures in the past.