### PR TITLE
Reuce warnings

### DIFF
--- a/bosk-sql/build.gradle
+++ b/bosk-sql/build.gradle
@@ -14,6 +14,10 @@ dependencies {
 	testImplementation libs.testcontainers.mysql
 	testImplementation libs.mysql
 	testImplementation libs.sqlite
+}
 
-
+tasks.withType(Test).configureEach {
+	// https://github.com/xerial/sqlite-jdbc/issues/1289
+	// Unit tests run on the classpath, hence ALL-UNNAMED
+	jvmArgs '--enable-native-access=ALL-UNNAMED'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ configure(subprojects.findAll {
 		options.compilerArgs << '-Xlint:-serial'     // Don't care about Java serialization
 		options.compilerArgs << '-Xlint:-try'        // Really annoying bogus "auto-closeable never used" warnings
 		options.compilerArgs << '-Xlint:-processing' // Not all annotations are meant for compile-time "annotation processing"
+		options.forkOptions.jvmArgs << '--sun-misc-unsafe-memory-access=allow' // For Lombok
 	}
 
 	if (name != "bosk-annotations") {


### PR DESCRIPTION
Suppress Lombok warnings about sun.misc.Unsafe. JDK24 doesn't like Unsafe one bit.

Also prevent a SQLite JDBC warning.