### PR TITLE
Change to the OSSRH staging compatibility servers.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,8 +213,8 @@ configure(subprojects.findAll { it.name.startsWith("bosk-") }) {
 
 		repositories {
 			maven {
-				def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-				def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+				def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
+				def snapshotsRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/'
 				url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
 				credentials {


### PR DESCRIPTION
The old servers have been shut down. This is a compatibility measure until we can properly publish to the Central Portal.

Unfortunately, this is hard to test without merging it and trying it.