### PR TITLE
[tail] Restore CurriedFields in ClassBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ In the long run, we'll use the usual semantic versioning.
 
 For 0.x.y releases, all bets are off, and no backward compatibility is guaranteed.
 
+Releases with four numbers, like a.b.c.d, are "tail" releases containing
+important fixes to old releases.
+
 ### Logo
 
 Logo was derived from this public-domain image: https://openclipart.org/detail/44023/small-trees-bushes

--- a/bosk-core/src/main/java/works/bosk/bytecode/CurriedField.java
+++ b/bosk-core/src/main/java/works/bosk/bytecode/CurriedField.java
@@ -1,0 +1,15 @@
+package works.bosk.bytecode;
+
+/**
+ * An object reference that should be passed to the constructor of a generated
+ * class so that it can be referenced from method bodies via
+ * {@link org.objectweb.asm.Opcodes#GETFIELD GETFIELD}.
+ *
+ * @param slot The parameter slot in which this will arrive in the constructor
+ */
+public record CurriedField(
+	int slot,
+	String name,
+	String typeDescriptor,
+	Object value
+) { }


### PR DESCRIPTION
Now that the CallSite table is immortal, everything added to that is a memory leak, so we need to be judicious. Tests with many Bosk objects having large state trees can run out of memory, which is pretty annoying.

The downside of curried fields is that final instance fields are not _really_ final, so they're generally slower than static finals and ConstantCallSites, but at the moment, OOMs caused by leaks seem to be a bigger problem (though unlikely in production, where there's only typically a single, long-lived Bosk object).

Effectively reverts c5d0a0917d5b7c9faf38c38f31697eade75702ce.