### PR TITLE
[tail] Enable gradle caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
I don't know if this will actually speed up the builds, which are currently a painful 14+ minutes, but it sure can't hurt.

I'm afraid most of the time savings on `main` actually came from switching to the "timescale" system for `MongoDriver` in #137, but why not.