### PR TITLE
Proper interrupt handling in ReadContextFilter

### DIFF
--- a/bosk-spring-boot/src/main/java/works/bosk/spring/boot/ReadContextFilter.java
+++ b/bosk-spring-boot/src/main/java/works/bosk/spring/boot/ReadContextFilter.java
@@ -32,6 +32,9 @@ public class ReadContextFilter extends OncePerRequestFilter {
 			try {
 				bosk.driver().flush();
 			} catch (InterruptedException e) {
+				// Assume the user wanted to interrupt the entire request,
+				// not just the flush operation.
+				Thread.currentThread().interrupt();
 				throw new ServletException(e);
 			}
 		}


### PR DESCRIPTION
Doesn't really matter much, but hey, why not.