### PR TITLE
Change BoskLogFilter into a TurboFilter

### DIFF
--- a/bosk-logback/src/main/java/works/bosk/logback/BoskLogFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/BoskLogFilter.java
@@ -1,15 +1,15 @@
 package works.bosk.logback;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
 import works.bosk.Bosk;
 import works.bosk.DriverFactory;
 import works.bosk.StateTreeNode;
@@ -20,7 +20,39 @@ import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
 import static java.util.stream.Collectors.toMap;
 import static works.bosk.logging.MdcKeys.BOSK_INSTANCE_ID;
 
-public class BoskLogFilter extends Filter<ILoggingEvent> {
+/**
+ * A Logback {@link TurboFilter} that provides per-bosk logging control.
+ * Intended to suppress expected warnings and errors during testing.
+ * <p>
+ * A {@link Bosk} whose driver stack includes {@link #withController}
+ * will be able to set log levels using {@link LogController#setLogging}
+ * without affecting other logs.
+ * <p>
+ * This class infers that a log message is associated with a particular bosk
+ * by checking the MDC for the key {@link MdcKeys#BOSK_INSTANCE_ID},
+ * which you can set using {@link works.bosk.logging.MappedDiagnosticContext#setupMDC setupMDC}.
+ * <p>
+ * <em>Note</em>: most bosk drivers don't set this MDC key. TODO: Improve this.
+ * <p>
+ * Log levels are determined using the following precedence:
+ * <ol>
+ *     <li>
+ *         If the specific logger is configured with some level,
+ *         that level is used;
+ *     </li>
+ *     <li>
+ *         otherwise, if the logger is associated with a bosk whose driver
+ *         was configured with {@link #withController} and that controller
+ *         has an override for that specific logger, that override is used;
+ *     </li>
+ *     <li>
+ *         otherwise, the usual Logback rules apply, which means
+ *         that the logger inherits the level from its ancestors.
+ *     </li>
+ * </ol>
+ *
+ */
+public class BoskLogFilter extends TurboFilter {
 	private static final ConcurrentHashMap<String, LogController> controllersByBoskID = new ConcurrentHashMap<>();
 
 	public static final class LogController {
@@ -57,7 +89,11 @@ public class BoskLogFilter extends Filter<ILoggingEvent> {
 	}
 
 	@Override
-	public FilterReply decide(ILoggingEvent event) {
+	public FilterReply decide(Marker marker, Logger logger, Level messageLevel, String format, Object[] params, Throwable t) {
+		if (logger.getLevel() != null) {
+			// Respect user-supplied log levels
+			return NEUTRAL;
+		}
 		String boskID = MDC.get(BOSK_INSTANCE_ID);
 		if (boskID == null) {
 			return NEUTRAL;
@@ -66,16 +102,18 @@ public class BoskLogFilter extends Filter<ILoggingEvent> {
 		if (controller == null) {
 			return NEUTRAL;
 		}
-		Level level = controller.overrides.get(event.getLoggerName());
-		if (level == null) {
+		Level overrideLevel = controller.overrides.get(logger.getName());
+		if (overrideLevel == null) {
 			return NEUTRAL;
 		}
-		if (event.getLevel().isGreaterOrEqual(level)) {
-			return NEUTRAL;
-		} else {
+
+		// There is an override. Deny if the message's level is too low.
+		if (overrideLevel.isGreaterOrEqual(messageLevel)) {
 			return DENY;
+		} else {
+			return NEUTRAL;
 		}
 	}
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(BoskLogFilter.class);
+	private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(BoskLogFilter.class);
 }

--- a/example-hello/src/main/resources/logback.xml
+++ b/example-hello/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
+	<turboFilter class="works.bosk.logback.BoskLogFilter"/>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-		<filter class="works.bosk.logback.BoskLogFilter"/>
 		<encoder>
 			<pattern>%d %-5level [%thread] [%X{bosk.name}]%X{bosk.MongoDriver.transaction}%X{bosk.MongoDriver.event} %logger{25}: %msg%n</pattern>
 		</encoder>

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
+	<turboFilter class="works.bosk.logback.BoskLogFilter"/>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-		<filter class="works.bosk.logback.BoskLogFilter"/>
 		<encoder>
 			<pattern>%d %-5level [%thread] [%X{bosk.name}]%X{bosk.MongoDriver.transaction}%X{bosk.MongoDriver.event} %logger{25}: %msg%n</pattern>
 		</encoder>


### PR DESCRIPTION
`TurboFilter` is better for several reasons:
- It applies to all appenders. Filter must be applied per-appender.
- It's faster than `Filter`
- It has access to the `Logger` so it can honour explicitly configured log levels