### PR TITLE
Group dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
In #142 I removed the dependabot groups because I didn't need to isolate certain changes anymore. However, by removing the groups, I also deactivated _grouping_, so we started getting myriad tiny little PRs.

We want all the bumps in one PR.