### PR TITLE
Use Jackson BOM

### DIFF
--- a/bosk-jackson/build.gradle
+++ b/bosk-jackson/build.gradle
@@ -1,5 +1,6 @@
 
 dependencies {
+	api platform(libs.jackson.bom)
 	api libs.jackson.databind
 	api project(":bosk-core")
 

--- a/bosk-mongo/build.gradle
+++ b/bosk-mongo/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly libs.jsr305 // Mongo client uses nullability annotations
 
 	// Allows us to annotate status objects so they're handy to serialize with jackson
+	implementation platform(libs.jackson.bom)
 	implementation libs.jackson.annotations
 
 	testImplementation project(":bosk-logback")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,8 +17,9 @@ asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
 hikari = { module = "com.zaxxer:HikariCP", version = "7.0.2" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref="jackson" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref="jetbrains-annotations" }
 jmh-apt = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }


### PR DESCRIPTION
Since 2.20, per [this](https://github.com/FasterXML/jackson-annotations/issues/294), the annotations library's version number no longer necessarily matches that of the other jackson libraries.