### PR TITLE
Encapsulate ASM

### DIFF
--- a/bosk-core/src/main/java/works/bosk/bytecode/LocalVariable.java
+++ b/bosk-core/src/main/java/works/bosk/bytecode/LocalVariable.java
@@ -1,8 +1,8 @@
 package works.bosk.bytecode;
 
-import org.objectweb.asm.Type;
+import java.lang.classfile.TypeKind;
 
 public record LocalVariable(
-	Type type,
+	TypeKind type,
 	int slot
 ) { }

--- a/bosk-core/src/main/java/works/bosk/bytecode/MethodBuilder.java
+++ b/bosk-core/src/main/java/works/bosk/bytecode/MethodBuilder.java
@@ -1,5 +1,6 @@
 package works.bosk.bytecode;
 
+import java.lang.classfile.TypeKind;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import org.objectweb.asm.ClassVisitor;
@@ -41,8 +42,8 @@ final class MethodBuilder {
 		pushSlots(-numSlots);
 	}
 
-	LocalVariable newLocal(Type type) {
-		return new LocalVariable(type, ++numLocals);
+	LocalVariable newLocal(TypeKind typeKind) {
+		return new LocalVariable(typeKind, ++numLocals);
 	}
 
 }


### PR DESCRIPTION
Take artifacts of the ASM library out of the "public" (but not exported) interface of ClassBuilder to ease the future transition to the class file API.