### PR TITLE
Add Sync Docs workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,23 @@
+name: Sync Docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@v5
+
+      - name: Sync javadoc.io
+        run: |
+          LIBRARIES=$(./gradlew listPublishedLibraries -q --console=plain)
+          for lib in $LIBRARIES; do
+            lib_path="${lib//://}"
+            curl -s -o /dev/null -w "%{http_code} - $lib\n" "https://javadoc.io/task/sync_latest/$lib_path"
+          done

--- a/build.gradle
+++ b/build.gradle
@@ -288,3 +288,18 @@ nexusPublishing {
 		}
 	}
 }
+
+def publishedLibraryCoordinates = rootProject.subprojects.findAll { sub ->
+	sub.plugins.hasPlugin('maven-publish')
+}.collect { sub ->
+	def pub = sub.publishing.publications.mavenJava
+	"${pub.groupId}:${pub.artifactId}"
+}
+
+tasks.register('listPublishedLibraries') {
+	group = 'publishing'
+	description = 'Prints all published libraries for doc sync'
+	doLast {
+		println publishedLibraryCoordinates.join(' ')
+	}
+}


### PR DESCRIPTION
This way I don't have to manually refresh javadoc.io on each library.