### PR TITLE
Refactor in prep for multitenancy work

### DIFF
--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonRoundTripConformanceTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonRoundTripConformanceTest.java
@@ -2,8 +2,10 @@ package works.bosk.bosonSerializer;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.provider.EnumSource;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JavaType;
@@ -27,7 +29,12 @@ import works.bosk.boson.mapping.TypeMap;
 import works.bosk.boson.mapping.TypeScanner;
 import works.bosk.boson.mapping.spec.JsonValueSpec;
 import works.bosk.boson.types.DataType;
+import works.bosk.bosonSerializer.BosonRoundTripConformanceTest.VariantInjector;
 import works.bosk.jackson.JacksonSerializer;
+import works.bosk.junit.InjectFields;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.Injected;
+import works.bosk.junit.Injector;
 import works.bosk.testing.drivers.DriverConformanceTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,12 +42,15 @@ import static tools.jackson.core.StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION;
 import static tools.jackson.databind.cfg.EnumFeature.READ_ENUMS_USING_TO_STRING;
 import static tools.jackson.databind.cfg.EnumFeature.WRITE_ENUMS_USING_TO_STRING;
 
-@ParameterizedClass
-@EnumSource(BosonRoundTripConformanceTest.Variant.class)
+@InjectFields
+@InjectFrom(VariantInjector.class)
 class BosonRoundTripConformanceTest extends DriverConformanceTest {
 	private static final TypeFactory typeFactory = TypeFactory.createDefaultInstance();
 
-	BosonRoundTripConformanceTest(Variant variant) {
+	@Injected Variant variant;
+
+	@BeforeEach
+	void setupVariant() {
 		driverFactory = BosonRoundTripDriver.factory(variant);
 	}
 
@@ -125,6 +135,18 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 	}
 
 	public enum Variant {FAST, VALIDATING, J2B, B2J}
+
+	record VariantInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType.equals(Variant.class);
+		}
+
+		@Override
+		public List<?> values() {
+			return Arrays.asList(Variant.values());
+		}
+	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BosonRoundTripConformanceTest.class);
 }

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -99,7 +99,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	private final ExecutorService hookExecutor = Executors.newThreadPerTaskExecutor(hookThreadBuilder::unstarted);
 
 	// Mutable state
-	private volatile R currentRoot;
+	private volatile R currentState;
 
 	/**
 	 * @param name                A distinctive identifier string. The bosk framework doesn't use this, so there are no requirements on this string: it can be anything that identifies the object.
@@ -138,13 +138,13 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			R initialRoot = switch (initialState) {
 				case SingleTree(var r) -> r;
 			};
-			this.currentRoot = rootRef.targetClass().cast(initialRoot);
+			this.currentState = rootRef.targetClass().cast(initialRoot);
 		} catch (InvalidTypeException | IOException | InterruptedException e) {
 			throw new IllegalArgumentException("Error computing initial state: " + e.getMessage(), e);
 		}
 
 		// Type check
-		rawClass(rootType).cast(this.currentRoot);
+		rawClass(rootType).cast(this.currentState);
 
 		// Ok, we're done initializing
 		boskInfo.boskRef().set(this); // @SuppressWarnings("this-escape")
@@ -361,7 +361,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		@Override
 		public <T> void submitReplacement(Reference<T> target, T newValue) {
 			synchronized (this) {
-				R priorRoot = currentRoot;
+				R priorRoot = currentRoot();
 				if (!tryGraftReplacement(target, newValue)) {
 					return;
 				}
@@ -378,7 +378,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 					preconditionsSatisfied = !target.exists();
 				}
 				if (preconditionsSatisfied) {
-					R priorRoot = currentRoot;
+					R priorRoot = currentRoot();
 					if (!tryGraftReplacement(target, newValue)) {
 						return;
 					}
@@ -391,7 +391,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		@Override
 		public <T> void submitDeletion(Reference<T> target) {
 			synchronized (this) {
-				R priorRoot = currentRoot;
+				R priorRoot = currentRoot();
 				if (!tryGraftDeletion(target)) {
 					return;
 				}
@@ -414,7 +414,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 					preconditionsSatisfied = Objects.equals(precondition.valueIfExists(), requiredValue);
 				}
 				if (preconditionsSatisfied) {
-					R priorRoot = currentRoot;
+					R priorRoot = currentRoot();
 					if (!tryGraftReplacement(target, newValue)) {
 						return;
 					}
@@ -432,7 +432,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 					preconditionsSatisfied = Objects.equals(precondition.valueIfExists(), requiredValue);
 				}
 				if (preconditionsSatisfied) {
-					R priorRoot = currentRoot;
+					R priorRoot = currentRoot();
 					if (!tryGraftDeletion(target)) {
 						return;
 					}
@@ -447,7 +447,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		 */
 		void triggerEverywhere(HookRegistration<?> reg) {
 			synchronized (this) {
-				triggerQueueingOfHooks(rootReference(), null, currentRoot, reg);
+				triggerQueueingOfHooks(rootReference(), null, currentRoot(), reg);
 			}
 			drainQueueIfAllowed();
 		}
@@ -460,10 +460,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			Dereferencer dereferencer = dereferencerFor(target);
 			try {
 				LOGGER.debug("Applying replacement at {}", target);
-				R oldRoot = currentRoot;
+				R oldRoot = currentRoot();
 				@SuppressWarnings("unchecked")
 				R newRoot = (R) requireNonNull(dereferencer.with(oldRoot, target, requireNonNull(newValue)));
-				currentRoot = newRoot;
+				currentState = newRoot;
 				if (LOGGER.isTraceEnabled()) {
 					LOGGER.trace("Replacement at {} changed root from {} to {}",
 						target,
@@ -487,10 +487,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			Dereferencer dereferencer = dereferencerFor(target);
 			try {
 				LOGGER.debug("Applying deletion at {}", target);
-				R oldRoot = currentRoot;
+				R oldRoot = currentRoot();
 				@SuppressWarnings("unchecked")
 				R newRoot = (R) requireNonNull(dereferencer.without(oldRoot, target));
-				currentRoot = newRoot;
+				currentState = newRoot;
 				if (LOGGER.isTraceEnabled()) {
 					LOGGER.trace("Deletion at {} changed root from {} to {}",
 						target,
@@ -510,7 +510,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		private <T> void queueHooks(Reference<T> target, @Nullable R priorRoot) {
-			R rootForHook = currentRoot;
+			R rootForHook = currentRoot();
 			for (HookRegistration<?> reg : hooks) {
 				triggerQueueingOfHooks(target, priorRoot, rootForHook, reg);
 			}
@@ -895,7 +895,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		private ReadSession() {
 			originalRoot = rootSnapshot.get();
 			if (originalRoot == null) {
-				snapshot = currentRoot;
+				snapshot = currentState;
 				if (snapshot == null) {
 					throw new IllegalStateException("Bosk constructor has not yet finished; cannot create a ReadSession");
 				}
@@ -1036,7 +1036,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * @see #readSession()
 	 */
 	public final ReadSession supersedingReadSession() {
-		R snapshot = currentRoot;
+		R snapshot = currentState;
 		if (snapshot == null) {
 			throw new IllegalStateException("Bosk constructor has not yet finished; cannot create a ReadSession");
 		}
@@ -1424,11 +1424,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		return instanceID() + " \"" + name + "\"::" + rootRef.targetClass().getSimpleName();
 	}
 
-	/**
-	 * FOR UNIT TESTING
-	 */
 	final R currentRoot() {
-		return currentRoot;
+		return currentState;
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonRoundTripConformanceTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonRoundTripConformanceTest.java
@@ -1,22 +1,39 @@
 package works.bosk.jackson;
 
+import java.lang.reflect.AnnotatedElement;
 import java.util.List;
-import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.BeforeEach;
+import works.bosk.jackson.JacksonRoundTripConformanceTest.ConfigurationInjector;
+import works.bosk.junit.InjectFields;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.Injected;
+import works.bosk.junit.Injector;
 import works.bosk.testing.drivers.DriverConformanceTest;
 
 import static works.bosk.AbstractRoundTripTest.jacksonRoundTripFactory;
 
-@ParameterizedClass
-@MethodSource("configs")
+@InjectFields
+@InjectFrom(ConfigurationInjector.class)
 public class JacksonRoundTripConformanceTest extends DriverConformanceTest {
-	JacksonRoundTripConformanceTest(JacksonSerializerConfiguration config) {
+	@Injected JacksonSerializerConfiguration config;
+
+	@BeforeEach
+	void setupDriverFactory() {
 		driverFactory = jacksonRoundTripFactory(config);
 	}
 
-	static List<JacksonSerializerConfiguration> configs() {
-		return List.of(
-			JacksonSerializerConfiguration.defaultConfiguration()
-		);
+	record ConfigurationInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType == JacksonSerializerConfiguration.class;
+		}
+
+		@Override
+		public List<?> values() {
+			return List.of(
+				JacksonSerializerConfiguration.defaultConfiguration()
+			);
+		}
 	}
+
 }

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
@@ -1,5 +1,6 @@
 package works.bosk.drivers.mongo.internal;
 
+import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -9,8 +10,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.DriverFactory;
@@ -19,20 +18,26 @@ import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.drivers.mongo.internal.MongoDriverConformanceTest.ParameterSetInjector;
 import works.bosk.drivers.mongo.internal.TestParameters.EventTiming;
 import works.bosk.drivers.mongo.internal.TestParameters.ParameterSet;
+import works.bosk.junit.InjectFields;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.Injected;
+import works.bosk.junit.Injector;
 import works.bosk.testing.drivers.SharedDriverConformanceTest;
 import works.bosk.testing.junit.Slow;
 
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 
 @Slow
-@ParameterizedClass
-@MethodSource("parameterSets")
+@InjectFields
+@InjectFrom(ParameterSetInjector.class)
 class MongoDriverConformanceTest extends SharedDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
 	private static MongoService mongoService;
-	private final MongoDriverSettings driverSettings;
+	@Injected ParameterSet parameters;
+	private MongoDriverSettings driverSettings;
 	private final AtomicInteger numOpenDrivers = new AtomicInteger(0);
 	private ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
 
@@ -46,10 +51,6 @@ class MongoDriverConformanceTest extends SharedDriverConformanceTest {
 	void teardownErrorRecording() {
 		errorRecorder.assertAllClear("after test");
 		MainDriver.LISTENER_FACTORY.remove();
-	}
-
-	public MongoDriverConformanceTest(ParameterSet parameters) {
-		this.driverSettings = parameters.driverSettingsBuilder().build();
 	}
 
 	static List<ParameterSet> parameterSets() {
@@ -67,6 +68,18 @@ class MongoDriverConformanceTest extends SharedDriverConformanceTest {
 			.toList();
 	}
 
+	record ParameterSetInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType == ParameterSet.class;
+		}
+
+		@Override
+		public List<?> values() {
+			return parameterSets();
+		}
+	}
+
 	@BeforeAll
 	static void setupMongoConnection() {
 		mongoService = new MongoService();
@@ -74,6 +87,7 @@ class MongoDriverConformanceTest extends SharedDriverConformanceTest {
 
 	@BeforeEach
 	void setupDriverFactory(TestInfo testInfo) {
+		driverSettings = parameters.driverSettingsBuilder().build();
 		driverFactory = createDriverFactory(testInfo);
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
@@ -47,7 +47,7 @@ public class SchemaEvolutionTest {
 	private Helper toHelper;
 
 	@BeforeEach
-	void setup(TestInfo testInfo) {
+	void setup() {
 		int dbCounter = DB_COUNTER.incrementAndGet();
 		this.fromHelper = new Helper(fromConfig, dbCounter);
 		this.toHelper = new Helper(toConfig, dbCounter);

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
@@ -22,10 +22,10 @@ public class Schema {
 
 	public void dropTables(Connection c) throws SQLException {
 		using(c)
-			.dropTable(BOSK)
+			.dropTableIfExists(BOSK)
 			.execute();
 		using(c)
-			.dropTable(CHANGES)
+			.dropTableIfExists(CHANGES)
 			.execute();
 		c.commit();
 	}

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/DatabaseInjector.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/DatabaseInjector.java
@@ -5,6 +5,10 @@ import java.util.List;
 import works.bosk.drivers.sql.SqlTestService.Database;
 import works.bosk.junit.Injector;
 
+import static works.bosk.drivers.sql.SqlTestService.Database.MYSQL;
+import static works.bosk.drivers.sql.SqlTestService.Database.POSTGRES;
+import static works.bosk.drivers.sql.SqlTestService.Database.SQLITE;
+
 record DatabaseInjector() implements Injector {
 	@Override
 	public boolean supports(AnnotatedElement element, Class<?> elementType) {
@@ -13,6 +17,6 @@ record DatabaseInjector() implements Injector {
 
 	@Override
 	public List<Database> values() {
-		return List.of(Database.POSTGRES, Database.SQLITE);
+		return List.of(POSTGRES, SQLITE, MYSQL);
 	}
 }

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
@@ -1,6 +1,7 @@
 package works.bosk.drivers.sql;
 
 import com.zaxxer.hikari.HikariDataSource;
+import java.lang.reflect.AnnotatedElement;
 import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -12,11 +13,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import works.bosk.drivers.sql.SqlTestService.Database;
 import works.bosk.drivers.sql.schema.Schema;
+import works.bosk.junit.InjectFields;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.Injected;
+import works.bosk.junit.Injector;
 import works.bosk.testing.drivers.SharedDriverConformanceTest;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -25,12 +28,12 @@ import static works.bosk.drivers.sql.SqlTestService.Database.POSTGRES;
 import static works.bosk.drivers.sql.SqlTestService.Database.SQLITE;
 import static works.bosk.drivers.sql.SqlTestService.sqlDriverFactory;
 
+@InjectFields
+@InjectFrom(SqlDriverConformanceTest.DatabaseInjector.class)
 @Testcontainers
-@ParameterizedClass
-@MethodSource("databases")
 class SqlDriverConformanceTest extends SharedDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
-	private final Database database;
+	@Injected Database database;
 	private final AtomicInteger dbCounter = new AtomicInteger(0);
 	private SqlDriverSettings settings;
 	private HikariDataSource dataSource;
@@ -48,14 +51,23 @@ class SqlDriverConformanceTest extends SharedDriverConformanceTest {
 		}
 	}
 
-	SqlDriverConformanceTest(Database database, TestInfo testInfo) {
-		this.database = database;
+	@BeforeEach
+	void skipSlowForSmokeTest(TestInfo testInfo) {
 		assumeTrue(SMOKE_TEST_DBS.contains(database)
 			|| testInfo.getTags().contains("slow"));
 	}
 
-	static List<Database> databases() {
-		return List.of(POSTGRES, MYSQL, SQLITE);
+	record DatabaseInjector() implements Injector {
+
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType == Database.class;
+		}
+
+		@Override
+		public List<?> values() {
+			return List.of(POSTGRES, MYSQL, SQLITE);
+		}
 	}
 
 	@BeforeEach

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
@@ -1,35 +1,25 @@
 package works.bosk.drivers.sql;
 
 import com.zaxxer.hikari.HikariDataSource;
-import java.lang.reflect.AnnotatedElement;
 import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import works.bosk.drivers.sql.SqlTestService.Database;
 import works.bosk.drivers.sql.schema.Schema;
 import works.bosk.junit.InjectFields;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
-import works.bosk.junit.Injector;
 import works.bosk.testing.drivers.SharedDriverConformanceTest;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static works.bosk.drivers.sql.SqlTestService.Database.MYSQL;
-import static works.bosk.drivers.sql.SqlTestService.Database.POSTGRES;
-import static works.bosk.drivers.sql.SqlTestService.Database.SQLITE;
 import static works.bosk.drivers.sql.SqlTestService.sqlDriverFactory;
 
 @InjectFields
-@InjectFrom(SqlDriverConformanceTest.DatabaseInjector.class)
+@InjectFrom(DatabaseInjector.class)
 @Testcontainers
 class SqlDriverConformanceTest extends SharedDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
@@ -38,35 +28,14 @@ class SqlDriverConformanceTest extends SharedDriverConformanceTest {
 	private SqlDriverSettings settings;
 	private HikariDataSource dataSource;
 
-	private static final Set<Database> SMOKE_TEST_DBS = EnumSet.of(POSTGRES);
-
 	@BeforeAll
 	static void validateSmokeTestDatabases() {
 		// Fail this test promptly if we can't connect to the smoke test databases,
 		// instead of painstakingly hitting this error on every single test.
-		for (Database database : SMOKE_TEST_DBS) {
+		for (Database database : Database.values()) {
 			try (var ds = database.dataSourceFor("smoke-test")) {
 				ds.validate();
 			}
-		}
-	}
-
-	@BeforeEach
-	void skipSlowForSmokeTest(TestInfo testInfo) {
-		assumeTrue(SMOKE_TEST_DBS.contains(database)
-			|| testInfo.getTags().contains("slow"));
-	}
-
-	record DatabaseInjector() implements Injector {
-
-		@Override
-		public boolean supports(AnnotatedElement element, Class<?> elementType) {
-			return elementType == Database.class;
-		}
-
-		@Override
-		public List<?> values() {
-			return List.of(POSTGRES, MYSQL, SQLITE);
 		}
 	}
 

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlTestService.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlTestService.java
@@ -29,8 +29,9 @@ public class SqlTestService {
 	}
 
 	public enum Database {
-		MYSQL(testcontainers("mysql:8.0.36", "/var/lib/mysql")),
-		POSTGRES(testcontainers("postgresql:17", "/var/lib/postgresql/data")),
+		// TODO: Use a dockerfile like we do for MongoDB so dependabot can keep these up to date
+		MYSQL(testcontainers("mysql:9.6.0", "/var/lib/mysql")),
+		POSTGRES(testcontainers("postgresql:18.3", "/var/lib/postgresql")),
 		SQLITE(dbName -> "jdbc:sqlite:" + TEMP_DIR.resolve(dbName + ".db")),
 		;
 


### PR DESCRIPTION
The changes to `AsyncDriver.flush` are pretty horrendous. TBH I can't quite recall why I wanted the flush called from inside the executor's thread. If that turns out not to be necessary I probably ought to revert that change because it's pretty ugly.