### PR TITLE
Tenant IDs in thread context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,10 @@ The usual Gradle commands, plus:
 
 ### General
 - We take warnings seriously. If a build issues a warning, it should be fixed at the earliest convenience.
-- Code in each file is ordered use-before-definition so it can be read and understood by a human from start to end, to the extent possible
+- Code in each file is ordered use-before-definition so it can be read and understood by a human from start to end, to the extent possible.
+- To the extent possible, we separate complex logic from side effects to facilitate unit testing.
+- When something can't always work, we prefer it _never_ to work rather than _sometimes_ to work.
+  - The overarching goal of Bosk is to reduce the behaviour gap between local development and production. If your code works, you probably did things right.
 
 ### Formatting
 

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -18,11 +18,20 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import works.bosk.BoskContext.ContextScope;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskConfig.TenancyModel.Explicit;
+import works.bosk.BoskConfig.TenancyModel.Fixed;
+import works.bosk.BoskConfig.TenancyModel.None;
+import works.bosk.BoskConfig.TenancyModel.Transient;
+import works.bosk.BoskContext.Context;
+import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.Established;
+import works.bosk.BoskContext.Tenant.NotEstablished;
 import works.bosk.BoskDriver.InitialState;
 import works.bosk.BoskDriver.InitialState.SingleTree;
 import works.bosk.ReferenceUtils.CatalogRef;
@@ -83,12 +92,13 @@ import static works.bosk.TypeValidation.validateType;
 public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	private final String name;
 	private final Identifier instanceID = Identifier.from(randomUUID().toString());
-	private final BoskContext context = new BoskContext();
+	private final BoskContext context;
+	private final TenancyModel tenancyModel;
 
 	private final InitialDriver initialDriver;
 	private final LocalDriver localDriver;
 	private final RootRef rootRef;
-	private final ThreadLocal<R> rootSnapshot = new ThreadLocal<>();
+	private final ThreadLocal<InitialState<R>> rootSnapshot = new ThreadLocal<>();
 	private final HookRegistrar hookRegistrar;
 	private final Queue<HookRegistration<?>> hooks = new ConcurrentLinkedQueue<>();
 	private final PathCompiler pathCompiler;
@@ -98,8 +108,17 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		.name("bosk-hook-", 1);
 	private final ExecutorService hookExecutor = Executors.newThreadPerTaskExecutor(hookThreadBuilder::unstarted);
 
-	// Mutable state
-	private volatile R currentState;
+	/**
+	 * Mutable state.
+	 * <p>
+	 * This is declared of type {@link InitialState} because that has all the data we need to manage the state.
+	 * The name looks weird in this context because it's not really the <em>initial</em> state,
+	 * but we want to use the name "InitialState" in the {@link BoskDriver} interface,
+	 * so that's what we're calling it.
+	 * <p>
+	 * This is null before the constructor finishes.
+	 */
+	@Nullable private volatile InitialState<R> currentState;
 
 	/**
 	 * @param name                A distinctive identifier string. The bosk framework doesn't use this, so there are no requirements on this string: it can be anything that identifies the object.
@@ -117,14 +136,21 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		this.pathCompiler = PathCompiler.withSourceType(requireNonNull(rootType)); // Required before rootRef
 		this.localDriver = new LocalDriver(requireNonNull(defaultStateFunction));
 		this.rootRef = new RootRef(rootType);
+		this.tenancyModel = boskConfig.tenancyModel();
 		try {
 			validateType(rootType);
 		} catch (InvalidTypeException e) {
 			throw new IllegalArgumentException("Invalid root type " + rootType + ": " + e.getMessage(), e);
 		}
 
+		Supplier<Context> initialContextSupplier = switch (tenancyModel) {
+			case None _ -> Context::emptyWithNoTenant;
+			case Fixed(var id) -> () -> new Context(new Tenant.SetTo(id), MapValue.empty());
+			case Explicit _ -> Context::empty;
+		};
+		context = new BoskContext(initialContextSupplier, name);
 		Info<R> boskInfo = new Info<>(
-			name, instanceID, rootRef, context, new AtomicReference<>());
+			name, instanceID, rootRef, context, tenancyModel, new AtomicReference<>());
 
 		// We do this as late as possible because the driver factory is allowed
 		// to do such things as create References, so it needs the rest of the
@@ -134,17 +160,12 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		this.hookRegistrar = requireNonNull(boskConfig.registrarFactory().build(boskInfo, this::localRegisterHook));
 
 		try {
-			InitialState<R> initialState = requireNonNull(initialDriver.initialState(rootRef.targetClass()));
-			R initialRoot = switch (initialState) {
-				case SingleTree(var r) -> r;
-			};
-			this.currentState = rootRef.targetClass().cast(initialRoot);
+			this.currentState = initialDriver
+				.initialState(rootRef.targetClass())
+				.cast(rootRef.targetClass()); // Double check!
 		} catch (InvalidTypeException | IOException | InterruptedException e) {
 			throw new IllegalArgumentException("Error computing initial state: " + e.getMessage(), e);
 		}
-
-		// Type check
-		rawClass(rootType).cast(this.currentState);
 
 		// Ok, we're done initializing
 		boskInfo.boskRef().set(this); // @SuppressWarnings("this-escape")
@@ -163,6 +184,11 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	@Override
 	public BoskContext context() {
 		return this.context;
+	}
+
+	@Override
+	public TenancyModel tenancyModel() {
+		return this.tenancyModel;
 	}
 
 	/**
@@ -187,6 +213,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		Identifier instanceID,
 		RootReference<RR> rootReference,
 		BoskContext context,
+		TenancyModel tenancyModel,
 		AtomicReference<Bosk<RR>> boskRef
 	) implements BoskInfo<RR> {
 		@Override
@@ -256,12 +283,14 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 
 		@Override
 		public <T> void submitReplacement(Reference<T> target, T newValue) {
+			assertTenantEstablished();
 			assertCorrectBosk(target);
 			downstream.submitReplacement(target, newValue);
 		}
 
 		@Override
 		public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+			assertTenantEstablished();
 			assertCorrectBosk(target);
 			assertCorrectBosk(precondition);
 			downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
@@ -269,6 +298,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 
 		@Override
 		public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+			assertTenantEstablished();
 			assertCorrectBosk(target);
 			downstream.submitConditionalCreation(target, newValue);
 		}
@@ -279,12 +309,14 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 				// TODO: Augment dereferencer so it can tell us this for all references, not just the root
 				throw new IllegalArgumentException("Cannot delete root object");
 			}
+			assertTenantEstablished();
 			assertCorrectBosk(target);
 			downstream.submitDeletion(target);
 		}
 
 		@Override
 		public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+			assertTenantEstablished();
 			assertCorrectBosk(target);
 			assertCorrectBosk(precondition);
 			downstream.submitConditionalDeletion(target, precondition, requiredValue);
@@ -299,7 +331,16 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 
 		@Override
 		public void flush() throws IOException, InterruptedException {
-			downstream.flush();
+			// Flushes can lead to downstream updates against any number of different tenants.
+			// We must clear the tenant context because other drivers have no way to do so.
+			try (var _ = context.withTenantTemporarilyIgnored()) {
+				downstream.flush();
+			}
+		}
+
+		private void assertTenantEstablished() {
+			assert context().getTenant() instanceof Established:
+				"Tenant must be established for driver operations";
 		}
 
 		private <T> void assertCorrectBosk(Reference<T> target) {
@@ -447,10 +488,66 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		 */
 		void triggerEverywhere(HookRegistration<?> reg) {
 			synchronized (this) {
-				triggerQueueingOfHooks(rootReference(), null, currentRoot(), reg);
+				forEachRoot(root ->
+					triggerQueueingOfHooks(rootReference(), null, root, reg));
 			}
 			drainQueueIfAllowed();
 		}
+
+		/**
+		 * Runs {@code action} in a {@link works.bosk.BoskContext.ContextScope}
+		 * with the appropriate tenant information established.
+		 */
+		private void forEachRoot(Consumer<R> action) {
+			switch (currentState) {
+				case null -> throw new IllegalStateException("Bosk state is not yet initialized");
+				case SingleTree<R>(var root) -> {
+					var tenant = switch (tenancyModel) {
+						case None _ -> Tenant.NONE;
+						case Fixed(var id) -> new Tenant.SetTo(id);
+						case Explicit _ -> {
+							// This is a wart in the shared tree model. I suspect this is fatal, and we'll
+							// deprecate and remove the shared tree model.
+							//
+							// When an update comes in, we have tenant info and could propagate it to hooks,
+							// but during `triggerEverywhere`, we have no tenant info for what amounts to
+							// past updates. Using NOT_ESTABLISHED lets the hooks themselves set
+							// the tenant info if they need to make further updates.
+							//
+							// Based on the principle that if it can't always work it should never work,
+							// we ought to use NOT_ESTABLISHED for all hooks, even those triggered by new updates,
+							// at least in Explicit mode but probably in all modes.
+							// However, given that only the shared tree model has this problem,
+							// and that we're likely to remove that model soon enough,
+							// I think it makes more sense to limit the scope of the weirdness,
+							// so we use NOT_ESTABLISHED only here.
+							//
+							// This is a problem we didn't encounter with the diagnostic attributes, only because
+							// it's questionable whether diagnostics ought to be propagated from past updates anyway.
+							// It will be a problem for any new piece of context though, which is unfortunate.
+							//
+							// Hooks run during `triggerEverywhere` seem doomed to be different from hooks run
+							// during normal updates unless we keep all context from past updates, which seems infeasible.
+							//
+							yield Tenant.NOT_ESTABLISHED;
+						}
+					};
+					switch (tenant) {
+						case NotEstablished _ -> {
+							try (var _ = context.withTenantTemporarilyIgnored()) {
+								action.accept(root);
+							}
+						}
+						case Established t -> {
+							try (var _ = context.withTenant(t)) {
+								action.accept(root);
+							}
+						}
+					}
+				}
+			}
+		}
+
 
 		/**
 		 * @return false if the update was ignored
@@ -463,7 +560,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 				R oldRoot = currentRoot();
 				@SuppressWarnings("unchecked")
 				R newRoot = (R) requireNonNull(dereferencer.with(oldRoot, target, requireNonNull(newValue)));
-				currentState = newRoot;
+				currentState = switch (currentState) {
+					case null -> InitialState.of(newRoot);
+					case SingleTree<R> _ -> InitialState.of(newRoot);
+				};
 				if (LOGGER.isTraceEnabled()) {
 					LOGGER.trace("Replacement at {} changed root from {} to {}",
 						target,
@@ -490,7 +590,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 				R oldRoot = currentRoot();
 				@SuppressWarnings("unchecked")
 				R newRoot = (R) requireNonNull(dereferencer.without(oldRoot, target));
-				currentState = newRoot;
+				currentState = switch (currentState) {
+					case null -> throw new IllegalStateException("Cannot delete from uninitialized state");
+					case SingleTree<R> _ -> InitialState.of(newRoot);
+				};
 				if (LOGGER.isTraceEnabled()) {
 					LOGGER.trace("Deletion at {} changed root from {} to {}",
 						target,
@@ -523,13 +626,19 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		 * on every matching object that exists in <code>rootForHook</code>.
 		 */
 		private <T, S> void triggerQueueingOfHooks(Reference<T> target, @Nullable R priorRoot, R rootForHook, HookRegistration<S> reg) {
+			Tenant tenant = switch (tenancyModel) {
+				case Transient _ -> Tenant.NOT_ESTABLISHED;
+				default -> context.getEstablishedTenant();
+			};
 			MapValue<String> attributes = context.getAttributes();
 			reg.triggerAction(priorRoot, rootForHook, target, changedRef -> {
 				LOGGER.debug("Hook: queue {}({}) due to {}", reg.name, changedRef, target);
 				hookExecutionQueue.addLast(() -> {
 					// We use two nested try statements here so that the "finally" clause runs within the diagnostic scope
-					try (ContextScope _ = context.withOnly(attributes)) {
-						try (ReadSession _ = new ReadSession(rootForHook)) {
+					try (var _ = context.withOnly(attributes);
+						var _ = context.withMaybeTenant(tenant) // Can be withTenant once TenancyModel.Transient is gone
+					) {
+						try (ReadSession _ = new ReadSession(InitialState.of(rootForHook))) {
 							LOGGER.debug("Hook: RUN {}({})", reg.name, changedRef);
 							reg.hook.onChanged(changedRef);
 						} catch (Exception e) {
@@ -870,7 +979,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			// TODO: This would be less cumbersome if we could apply a Reference to an arbitrary root object.
 			// For now, References only apply to the current ReadSession, so we need a new ReadSession every time
 			// we want to change roots.
-			try (var _ = new ReadSession(root)) {
+			try (var _ = new ReadSession(InitialState.of(root))) {
 				return containerRef.valueIfExists();
 			}
 		}
@@ -884,8 +993,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * @author pdoyle
 	 */
 	public final class ReadSession implements AutoCloseable {
-		final R originalRoot;
-		final R snapshot; // Mostly for adopt()
+		final InitialState<R> originalRoot;
+		final InitialState<R> snapshot; // Mostly for adopt()
 
 		/**
 		 * Creates a {@link ReadSession} for the current thread. If one is already
@@ -909,7 +1018,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		private ReadSession(ReadSession toAdopt) {
-			R snapshotToInherit = requireNonNull(toAdopt.snapshot);
+			InitialState<R> snapshotToInherit = requireNonNull(toAdopt.snapshot);
 			originalRoot = rootSnapshot.get();
 			if (originalRoot == null) {
 				rootSnapshot.set(this.snapshot = snapshotToInherit);
@@ -924,15 +1033,15 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		}
 
 		/**
-		 * Internal constructor to use a given root.
+		 * Internal constructor to use a given state.
 		 *
 		 * <p>
-		 * Unlike the other constructors, this can be used to substitute a new root temporarily,
+		 * Unlike the other constructors, this can be used to substitute a new state temporarily,
 		 * even if there's already one active on the current thread.
 		 */
-		ReadSession(@NotNull R root) {
+		ReadSession(@NotNull InitialState<R> state) {
 			originalRoot = rootSnapshot.get();
-			snapshot = requireNonNull(root);
+			snapshot = requireNonNull(state);
 			rootSnapshot.set(snapshot);
 			LOGGER.trace("Using {}", this);
 		}
@@ -1036,7 +1145,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * @see #readSession()
 	 */
 	public final ReadSession supersedingReadSession() {
-		R snapshot = currentState;
+		InitialState<R> snapshot = currentState;
 		if (snapshot == null) {
 			throw new IllegalStateException("Bosk constructor has not yet finished; cannot create a ReadSession");
 		}
@@ -1301,11 +1410,12 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		@Override
 		@SuppressWarnings("unchecked")
 		public T valueIfExists() {
-			R snapshot = rootSnapshot.get();
+			R snapshot = switch (rootSnapshot.get()) {
+				case null -> throw new NoReadSessionException("No active read session for " + name + " in " + Thread.currentThread());
+				case SingleTree<R>(var r) -> r;
+			};
 			LOGGER.trace("Snapshot is {}", System.identityHashCode(snapshot));
-			if (snapshot == null) {
-				throw new NoReadSessionException("No active read session for " + name + " in " + Thread.currentThread());
-			} else try {
+			try {
 				return (T) dereferencer().get(snapshot, this);
 			} catch (NonexistentEntryException e) {
 				return null;
@@ -1424,8 +1534,12 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		return instanceID() + " \"" + name + "\"::" + rootRef.targetClass().getSimpleName();
 	}
 
+	@Nullable
 	final R currentRoot() {
-		return currentState;
+		return switch (currentState) {
+			case null -> null; // Bosk is still initializing
+			case SingleTree<R>(var r) -> r;
+		};
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -293,8 +293,8 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		@Override
 		public <RR extends StateTreeNode> InitialState<RR> initialState(Class<RR> rootType) throws InvalidTypeException, IOException, InterruptedException {
 			return downstream.initialState(rootType)
-				.map(rootRef.targetClass()::cast)
-				.map(rootType::cast);
+				.cast(rootRef.targetClass())
+				.cast(rootType);
 		}
 
 		@Override
@@ -355,7 +355,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		@Override
 		public <RR extends StateTreeNode> InitialState<RR> initialState(Class<RR> rootType) throws InvalidTypeException, IOException, InterruptedException {
 			return requireNonNull(initialStateFunction.apply(Bosk.this))
-				.map(rootType::cast);
+				.cast(rootType);
 		}
 
 		@Override

--- a/bosk-core/src/main/java/works/bosk/BoskConfig.java
+++ b/bosk-core/src/main/java/works/bosk/BoskConfig.java
@@ -1,18 +1,14 @@
 package works.bosk;
 
+import works.bosk.BoskContext.Tenant;
+
 import static java.util.Objects.requireNonNull;
 
-public final class BoskConfig<R extends StateTreeNode> {
-	private final DriverFactory<R> driverFactory;
-	private final RegistrarFactory registrarFactory;
-
-	private BoskConfig(
-		DriverFactory<R> driverFactory,
-		RegistrarFactory registrarFactory
-	) {
-		this.driverFactory = driverFactory;
-		this.registrarFactory = registrarFactory;
-	}
+public record BoskConfig<R extends StateTreeNode> (
+	DriverFactory<R> driverFactory,
+	RegistrarFactory registrarFactory,
+	TenancyModel tenancyModel
+) {
 
 	/**
 	 * Calls {@code BoskConfig.builder().build()} and returns the result.
@@ -42,21 +38,15 @@ public final class BoskConfig<R extends StateTreeNode> {
 		return SIMPLE_REGISTRAR_FACTORY;
 	}
 
-	public DriverFactory<R> driverFactory() {
-		return driverFactory;
-	}
-
-	public RegistrarFactory registrarFactory() {
-		return registrarFactory;
-	}
-
 	public static class Builder<R extends StateTreeNode> {
 		private DriverFactory<R> driverFactory;
 		private RegistrarFactory registrarFactory;
+		private TenancyModel tenancyModel;
 
 		Builder() {
 			driverFactory = simpleDriver();
 			registrarFactory = simpleRegistrar();
+			tenancyModel = TenancyModel.NONE;
 		}
 
 		public Builder<R> driverFactory(DriverFactory<R> driverFactory) {
@@ -69,14 +59,110 @@ public final class BoskConfig<R extends StateTreeNode> {
 			return this;
 		}
 
+		public Builder<R> noTenants() {
+			return tenancyModel(TenancyModel.NONE);
+		}
+
+		public Builder<R> fixedTenant(Identifier tenantId) {
+			return tenancyModel(new TenancyModel.Fixed(tenantId));
+		}
+
+		public Builder<R> transientTenants() {
+			return tenancyModel(TenancyModel.TRANSIENT);
+		}
+
+//		public Builder<R> persistentTenants() {
+//			return tenancyModel(TenancyModel.PERSISTENT);
+//		}
+
+		public Builder<R> tenancyModel(TenancyModel tenancyModel) {
+			this.tenancyModel = requireNonNull(tenancyModel);
+			return this;
+		}
+
 		public BoskConfig<R> build() {
-			return new BoskConfig<R>(this.driverFactory, this.registrarFactory);
+			return new BoskConfig<>(
+				this.driverFactory,
+				this.registrarFactory,
+				this.tenancyModel
+			);
 		}
 
 		@Override
 		public String toString() {
 			return "BoskConfig.Builder(driverFactory=" + this.driverFactory + ", registrarFactory=" + this.registrarFactory + ")";
 		}
+	}
+
+	public sealed interface TenancyModel {
+		/**
+		 * All threads are automatically {@link Tenant.Established},
+		 * so driver updates can be called without first establishing a tenant on the thread.
+		 */
+		sealed interface Implicit extends TenancyModel {}
+
+		/**
+		 * All threads are initially {@link Tenant.NotEstablished not established}.
+		 * Most bosk operations won't work until a tenant is {@link works.bosk.BoskContext#withTenant(Tenant.Established) established}.
+		 */
+		sealed interface Explicit extends TenancyModel {}
+
+		/**
+		 * {@link Tenant.None} is automatically established on all threads, including in hooks.
+		 * <p>
+		 * This is a good default choice for a bosk that doesn't yet need multitenancy.
+		 */
+		record None() implements Implicit {}
+
+		/**
+		 * {@link Tenant.SetTo} is automatically established on all threads,
+		 * and the tenant is fixed to the given identifier, including in hooks.
+		 * <p>
+		 * This can be a useful first step during a transition to multitenancy,
+		 * updating databases or other systems to become tenant-aware with a single tenant
+		 * without having to update all application code to establish the tenant context.
+		 */
+		record Fixed(Identifier id) implements Implicit {}
+
+		/**
+		 * Tenant information is not stored in the bosk state
+		 * and is only propagated by driver updates.
+		 * <p>
+		 * Tenant information is not propagated into hooks:
+		 * because it's not stored in the bosk state, any hooks that fire initially upon registration can't be given tenant information,
+		 * and so for consistency, <em>no</em> hooks get tenant information.
+		 * <p>
+		 * This is useful in a shared-tree system, where all tenants use the same bosk state,
+		 * and the tenant information, while reliable, is advisory only
+		 * and has no other effect on reads or updates.
+		 * <p>
+		 * <em>Evolution note</em>: Due to the weirdness around hooks,
+		 * this tenancy model is likely to disappear.
+		 */
+		record Transient() implements Explicit {}
+
+//		/**
+//		 * Tenant information is stored in the bosk state, and is propagated into hooks.
+//		 * <p>
+//		 * This is useful in a multi-tree system, where each tenant has its own state,
+//		 * since tenant information is essential for disambiguating reads and updates.
+//		 */
+//		record Persistent() implements Explicit {}
+
+		/**
+		 * @see works.bosk.BoskConfig.TenancyModel.None
+		 */
+		None NONE = new None();
+
+		/**
+		 * @see works.bosk.BoskConfig.TenancyModel.Transient
+		 */
+		Transient TRANSIENT = new Transient();
+
+//		/**
+//		 * @see works.bosk.BoskConfig.TenancyModel.Persistent
+//		 */
+//		Persistent PERSISTENT = new Persistent();
 	}
 
 	private static final DriverFactory<?> SIMPLE_DRIVER_FACTORY = (_, d) -> d;

--- a/bosk-core/src/main/java/works/bosk/BoskContext.java
+++ b/bosk-core/src/main/java/works/bosk/BoskContext.java
@@ -1,8 +1,13 @@
 package works.bosk;
 
+import java.util.Objects;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
 
 /**
@@ -15,36 +20,149 @@ import static java.util.function.Predicate.not;
  * You can hold on to this object; there's no need to re-fetch it from the {@link Bosk} every time.
  */
 public final class BoskContext {
-	private final ThreadLocal<Context> currentContext = ThreadLocal.withInitial(Context::empty);
+	private final ThreadLocal<Context> currentContext;
 
-	record Context(MapValue<String> diagnosticAttributes) {
-		Context withAttribute(String name, String value) {
-			return new Context(diagnosticAttributes.with(name, value));
+	private final String boskName; // For diagnostics
+
+	BoskContext(Supplier<Context> initialContextSupplier, String boskName) {
+		currentContext = ThreadLocal.withInitial(initialContextSupplier);
+		this.boskName = boskName;
+	}
+
+	ContextScope newContextScope(Context newContext) {
+		ContextScope result = new ContextScope(newContext);
+		validateTenantTransition(result.oldContext.tenant(), newContext.tenant());
+		// ^-- Must validate before this side effect --v
+		currentContext.set(newContext);
+		return result;
+	}
+
+	private void validateTenantTransition(Tenant oldTenant, Tenant newTenant) {
+		if (oldTenant.equals(newTenant)) {
+			LOGGER.trace("Reestablishing same tenant: {}", newTenant);
+		} else if (oldTenant instanceof Tenant.NotEstablished) {
+			LOGGER.debug("Establishing tenant: {}", newTenant);
+		} else {
+			throw new IllegalArgumentException(
+				"Tenant for bosk " + boskName + " is already " + oldTenant
+					+ "; cannot change to: " + newTenant
+					+ " on thread [" + Thread.currentThread() + "]");
+		}
+	}
+
+	public record Context(
+		Tenant tenant,
+		MapValue<String> diagnosticAttributes
+	) {
+		public Context {
+			requireNonNull(tenant);
+			requireNonNull(diagnosticAttributes);
 		}
 
-		Context withAttributes(MapValue<String> additionalAttributes) {
-			return new Context(diagnosticAttributes.withAll(additionalAttributes));
+		public Context withTenant(Tenant tenant) {
+			return new Context(tenant, diagnosticAttributes);
 		}
 
-		Context withOnly(MapValue<String> attributes) {
-			return new Context(attributes);
+		public Context withAttribute(String name, String value) {
+			return new Context(tenant, diagnosticAttributes.with(name, value));
 		}
 
-		static Context empty() {
-			return new Context(MapValue.empty());
+		public Context withAttributes(MapValue<String> additionalAttributes) {
+			return new Context(tenant, diagnosticAttributes.withAll(additionalAttributes));
+		}
+
+		public Context withOnlyAttributes(MapValue<String> attributes) {
+			return new Context(tenant, attributes);
+		}
+
+		public static Context empty() {
+			return new Context(Tenant.NOT_ESTABLISHED, MapValue.empty());
+		}
+
+		public static Context emptyWithNoTenant() {
+			return new Context(Tenant.NONE, MapValue.empty());
+		}
+	}
+
+	public sealed interface Tenant {
+		/**
+		 * Tenant information has not yet been set on this thread.
+		 * In this state, a new {@link ContextScope} can set the tenant ID
+		 * to an {@link Established} value.
+		 */
+		record NotEstablished() implements Tenant {}
+
+		/**
+		 * Tenant information has been set on this thread by a {@link ContextScope}.
+		 */
+		sealed interface Established extends Tenant { }
+
+		/**
+		 * For a bosk configured without multi-tenancy, this is the only valid value,
+		 * and it is automatically established on all threads.
+		 * <p>
+		 * For a multi-tenant bosk, this value is not allowed.
+		 */
+		record None() implements Established {}
+
+		/**
+		 * For a multi-tenant bosk, this indicates the current thread's tenant ID.
+		 * <p>
+		 * For a bosk configured without multi-tenancy, this value is not allowed.
+		 */
+		record SetTo(Identifier tenant) implements Established {}
+
+		/**
+		 * @see NotEstablished
+		 */
+		NotEstablished NOT_ESTABLISHED = new NotEstablished();
+
+		/**
+		 * @see None
+		 */
+		None NONE = new None();
+
+		static SetTo setTo(Identifier tenant) {
+			return new SetTo(tenant);
 		}
 	}
 
 	public final class ContextScope implements AutoCloseable {
-		final Context oldContext = currentContext.get();
+		final Context oldContext;
+		final Context newContext;
 
-		ContextScope(Context newContext) {
-			currentContext.set(newContext);
+		private ContextScope(Context newContext) {
+			this.oldContext = currentContext.get();
+			this.newContext = newContext;
 		}
 
 		@Override
 		public void close() {
+			if (!Objects.equals(newContext, currentContext.get())) {
+				throw new IllegalStateException("ContextScopes closed out of order");
+			}
 			currentContext.set(oldContext);
+		}
+	}
+
+	public Context get() {
+		return currentContext.get();
+	}
+
+	public Tenant getTenant() {
+		return currentContext.get().tenant();
+	}
+
+	/**
+	 * @return {@link #getTenant()}
+	 * @throws IllegalStateException if the tenant is not established on this thread
+	 */
+	public Tenant.Established getEstablishedTenant() {
+		Tenant tenant = getTenant();
+		if (tenant instanceof Tenant.Established established) {
+			return established;
+		} else {
+			throw new IllegalStateException("Tenant is not established on thread " + Thread.currentThread());
 		}
 	}
 
@@ -61,11 +179,50 @@ public final class BoskContext {
 	}
 
 	/**
+	 * Adds tenant information to the current thread's context.
+	 * This is idempotent: it's always valid to reestablish the same tenant information on a thread.
+	 *
+	 * @param tenant the tenant information to be established on this thread
+	 * @throws IllegalArgumentException if tenant information is already established on this thread and is different from the given tenant
+	 * @return an {@link AutoCloseable} that will restore the previous tenant information when closed
+	 */
+	public ContextScope withTenant(Tenant.Established tenant) {
+		return newContextScope(currentContext.get().withTenant(tenant));
+	}
+
+	/**
+	 * Like {@link #withTenant(Tenant.Established)}, but allows {@link Tenant#NOT_ESTABLISHED}
+	 * Useful in situations where you want to mimic the tenant context of
+	 * some other operation without asserting that it must be established.
+	 * <p>
+	 * The "maybe" in the name indicates the tenant can be not established,
+	 * not that the method might choose to ignore the tenant argument.
+	 *
+	 * @see #withTenant(Tenant.Established)
+	 */
+	public ContextScope withMaybeTenant(Tenant tenant) {
+		return newContextScope(currentContext.get().withTenant(tenant));
+	}
+
+	/**
+	 * Removes any tenant information from the current thread's context.
+	 * <p>
+	 * Package-private because this is only intended for use by Bosk itself.
+	 * All outside code must be bound by the constraints of the tenant already established.
+	 */
+	ContextScope withTenantTemporarilyIgnored() {
+		ContextScope contextScope = new ContextScope(currentContext.get().withTenant(Tenant.NOT_ESTABLISHED));
+		// No validation required; we're specifically forcing the tenant to be ignored here
+		currentContext.set(contextScope.newContext);
+		return contextScope;
+	}
+
+	/**
 	 * Adds a single diagnostic attribute to the current thread's context.
 	 * If the attribute already exists, it will be replaced.
 	 */
 	public ContextScope withAttribute(String name, String value) {
-		return new ContextScope(currentContext.get().withAttribute(name, value));
+		return newContextScope(currentContext.get().withAttribute(name, value));
 	}
 
 	/**
@@ -73,7 +230,7 @@ public final class BoskContext {
 	 * If an attribute already exists, it will be replaced.
 	 */
 	public ContextScope withAttributes(@NotNull MapValue<String> additionalAttributes) {
-		return new ContextScope(currentContext.get().withAttributes(additionalAttributes));
+		return newContextScope(currentContext.get().withAttributes(additionalAttributes));
 	}
 
 	/**
@@ -87,9 +244,9 @@ public final class BoskContext {
 	 */
 	public ContextScope withOnly(@Nullable MapValue<String> attributes) {
 		if (attributes == null) {
-			return new ContextScope(currentContext.get());
+			return newContextScope(currentContext.get());
 		} else {
-			return new ContextScope(currentContext.get().withOnly(attributes));
+			return newContextScope(currentContext.get().withOnlyAttributes(attributes));
 		}
 	}
 
@@ -104,8 +261,11 @@ public final class BoskContext {
 		assert prefix.endsWith("."): "Prefix must end with a dot: " + prefix;
 		assert prefix.length() >= 2: "Prefix must be at least two characters long: " + prefix;
 		MapValue<String> prefixedAttributes = MapValue.fromFunctions(replacementAttributes.keySet(), k -> prefix+k, replacementAttributes::get);
-		return new ContextScope(new Context(currentContext.get().diagnosticAttributes().withOnly(
+		Context current = currentContext.get();
+		return newContextScope(new Context(current.tenant(), current.diagnosticAttributes().withOnly(
 			not(k -> k.startsWith(prefix))
 		).withAll(prefixedAttributes)));
 	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(BoskContext.class);
 }

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -47,20 +47,31 @@ public interface BoskDriver {
 	<R extends StateTreeNode> InitialState<R> initialState(Class<R> rootType) throws InvalidTypeException, IOException, InterruptedException;
 
 	sealed interface InitialState<R extends StateTreeNode> {
-		<T extends StateTreeNode> InitialState<T> map(Function<R,T> function) throws InvalidTypeException, IOException, InterruptedException;
+		<T extends StateTreeNode> InitialState<T> map(InitialStateFunction<R,T> function) throws InvalidTypeException, IOException, InterruptedException;
+
+		<T extends StateTreeNode> InitialState<T> cast(Class<T> newRootType);
 
 		static <R extends StateTreeNode> SingleTree<R> of(R root) {
 			return new SingleTree<>(root);
 		}
 
+		/**
+		 * This bosk has zero or more tenants,
+		 * but they all share the same state tree whose node is {@code rootNode}.
+		 */
 		record SingleTree<R extends StateTreeNode>(R rootNode) implements InitialState<R> {
 			public SingleTree {
 				requireNonNull(rootNode);
 			}
 
 			@Override
-			public <T extends StateTreeNode> InitialState<T> map(Function<R, T> function) throws InvalidTypeException, IOException, InterruptedException {
-				return new SingleTree<>(function.apply(rootNode));
+			public <T extends StateTreeNode> SingleTree<T> cast(Class<T> newRootType) {
+				return new SingleTree<>(newRootType.cast(rootNode()));
+			}
+
+			@Override
+			public <T extends StateTreeNode> SingleTree<T> map(InitialStateFunction<R, T> function) throws InvalidTypeException, IOException, InterruptedException {
+				return new SingleTree<>(function.apply(rootNode()));
 			}
 		}
 
@@ -68,7 +79,7 @@ public interface BoskDriver {
 		 * A version of {@link java.util.function.Function} that, for convenience,
 		 * is allowed to throw exceptions permitted by {@link BoskDriver#initialState(Class) initialState}.
 		 */
-		interface Function<FROM extends StateTreeNode, TO extends StateTreeNode> {
+		interface InitialStateFunction<FROM extends StateTreeNode, TO extends StateTreeNode> {
 			TO apply(FROM root) throws InvalidTypeException, IOException, InterruptedException;
 		}
 	}

--- a/bosk-core/src/main/java/works/bosk/BoskInfo.java
+++ b/bosk-core/src/main/java/works/bosk/BoskInfo.java
@@ -1,5 +1,7 @@
 package works.bosk;
 
+import works.bosk.BoskConfig.TenancyModel;
+
 /**
  * Provides access to a subset of bosk functionality that is available while the
  * {@link BoskDriver} is being constructed, before the {@link Bosk} itself is fully initialized.
@@ -9,6 +11,7 @@ public interface BoskInfo<R extends StateTreeNode> {
 	Identifier instanceID();
 	RootReference<R> rootReference();
 	BoskContext context();
+	TenancyModel tenancyModel();
 
 	/**
 	 * @throws IllegalStateException if called before the {@link Bosk} constructor returns

--- a/bosk-core/src/main/java/works/bosk/drivers/BufferingDriver.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/BufferingDriver.java
@@ -86,9 +86,13 @@ public class BufferingDriver implements BoskDriver {
 	private void enqueue(Consumer<BoskDriver> action) {
 		long changeID = this.changeID.incrementAndGet();
 		LOGGER.debug("Buffering action {} {}", changeID, context.getAttributes());
+		BoskContext.Tenant.Established capturedTenant = context.getEstablishedTenant();
 		MapValue<String> capturedAttributes = context.getAttributes();
 		updateQueue.add(d -> {
-			try (var _ = context.withOnly(capturedAttributes)) {
+			try (
+				var _ = context.withTenant(capturedTenant);
+				var _ = context.withOnly(capturedAttributes)
+			) {
 				LOGGER.debug("Running action {} {}", changeID, context.getAttributes());
 				action.accept(d);
 			}

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -60,9 +60,12 @@ public class ReplicaSet<R extends StateTreeNode> {
 	public DriverFactory<R> driverFactory() {
 		return (b,d) -> {
 			Replica<R> replica = new Replica<>(b, d);
-			seed.compareAndSet(null, replica);
+			var existing = seed.compareAndExchange(null, replica);
+			var theSeed = existing != null ? existing : replica;
+			assert theSeed.boskInfo.rootReference().targetType().equals(b.rootReference().targetType()):
+				"All bosks in a replica set must have the same root type because they share state data";
 			replicas.add(replica);
-			return new BroadcastDriver(b.context());
+			return new BroadcastDriver(b.context(), d);
 		};
 
 		/*
@@ -117,10 +120,19 @@ public class ReplicaSet<R extends StateTreeNode> {
 	}
 
 	final class BroadcastDriver implements BoskDriver {
-		final BoskContext context;
+		/**
+		 * The context from the bosk that has this driver in its stack.
+		 */
+		final BoskContext originContext;
 
-		BroadcastDriver(BoskContext context) {
-			this.context = context;
+		/**
+		 * Use this sparingly! Updates should be sent to all replicas.
+		 */
+		final BoskDriver downstream;
+
+		BroadcastDriver(BoskContext originContext, BoskDriver downstream) {
+			this.originContext = originContext;
+			this.downstream = downstream;
 		}
 
 		/**
@@ -201,15 +213,20 @@ public class ReplicaSet<R extends StateTreeNode> {
 
 		@Override
 		public void flush() throws IOException, InterruptedException {
-			for (var r : replicas) {
-				r.driver().flush();
-			}
+			// We don't broadcast flushes.
+			// A flush ensures all prior updates have been applied to the bosk;
+			// it says nothing about other bosks.
+			downstream.flush();
 		}
 
 		private void broadcast(Consumer<Replica<R>> action) {
-			var tenant = context.getEstablishedTenant();
+			var tenant = originContext.getEstablishedTenant();
+			var diagnosticContext = originContext.getAttributes();
 			replicas.forEach(replica -> {
-				try (var _ = replica.boskInfo.context().withTenant(tenant)) {
+				try (
+					var _ = replica.boskInfo.context().withTenant(tenant);
+					var _ = replica.boskInfo.context().withOnly(diagnosticContext)
+				) {
 					action.accept(replica);
 				}
 			});

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -139,7 +139,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 				// because at this point in the code, we cannot tell which replica we're initializing.
 				try (var _ = seedReadSession(seed)) {
 					return InitialState.of(seed.boskInfo().rootReference().value())
-						.map(rootType::cast);
+						.cast(rootType);
 				}
 			} else {
 				// The first time this is called, we assume it's for the seed replica.

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -48,10 +48,10 @@ public class ReplicaSet<R extends StateTreeNode> {
 	/**
 	 * The bosk whose state is returned by {@link BroadcastDriver#initialState}.
 	 */
-	final AtomicReference<Replica<R>> primary = new AtomicReference<>(null);
+	final AtomicReference<Replica<R>> seed = new AtomicReference<>(null);
 
 	/**
-	 * Whether {@link BoskDriver#initialState} has been called for the primary replica.
+	 * Whether {@link BoskDriver#initialState} has been called for the seed replica.
 	 */
 	final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
@@ -64,7 +64,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 	public DriverFactory<R> driverFactory() {
 		return (b,d) -> {
 			Replica<R> replica = new Replica<>(b, d);
-			primary.compareAndSet(null, replica);
+			seed.compareAndSet(null, replica);
 			replicas.add(replica);
 			return broadcastDriver;
 		};
@@ -108,7 +108,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 	 * The resulting driver can accept references to a different bosk
 	 * with the same root type.
 	 * <p>
-	 * Note that there is no "primary" bosk in this case.
+	 * Note that there is no "seed" bosk in this case.
 	 * The returned driver will send updates only to the {@code other} bosk.
 	 */
 	public static <RR extends StateTreeNode> BoskDriver redirectingTo(Bosk<RR> other) {
@@ -122,41 +122,41 @@ public class ReplicaSet<R extends StateTreeNode> {
 
 	final class BroadcastDriver implements BoskDriver {
 		/**
-		 * @return the <em>current state</em> of the replica set, which is the state of its primary
+		 * @return the <em>current state</em> of the replica set, which is the state of its seed replica
 		 * as obtained by {@link Bosk#supersedingReadSession()}.
 		 */
 		@Override
 		public <RR extends StateTreeNode> InitialState<RR> initialState(Class<RR> rootType) throws InvalidTypeException, IOException, InterruptedException {
 			assert !replicas.isEmpty(): "Replicas must be added during by the driver factory before the drivers are used";
-			var primary = requireNonNull(ReplicaSet.this.primary.get());
+			var seed = requireNonNull(ReplicaSet.this.seed.get());
 			if (isInitialized.getAndSet(true)) {
-				// Secondary replicas should take their initial state from the primary.
+				// Later-joining replicas should take their initial state from the seed replica.
 				//
-				// We assume the primary's constructor has finished by this point,
+				// We assume the seed replica's constructor has finished by this point,
 				// which is true if the bosks are constructed in the same order as their drivers.
 				// This should be a safe assumption--some shenanigans would be required
 				// to violate this--but unfortunately we have no way to verify it here,
 				// because at this point in the code, we cannot tell which replica we're initializing.
-				try (var _ = primaryReadSession(primary)) {
-					return InitialState.of(primary.boskInfo().rootReference().value())
+				try (var _ = seedReadSession(seed)) {
+					return InitialState.of(seed.boskInfo().rootReference().value())
 						.map(rootType::cast);
 				}
 			} else {
-				// The first time this is called, we assume it's for the primary replica.
-				return primary.driver().initialState(rootType);
+				// The first time this is called, we assume it's for the seed replica.
+				return seed.driver().initialState(rootType);
 			}
 		}
 
-		private static <R extends StateTreeNode> Bosk<R>.ReadSession primaryReadSession(Replica<R> primary) {
+		private static <R extends StateTreeNode> Bosk<R>.ReadSession seedReadSession(Replica<R> seed) {
 			try {
 				// We use supersedingReadSession here on the assumption that if the user,
 				// for some reason, created a secondary replica in the midst
-				// of a ReadSession on the primary, they would still want that secondary
+				// of a ReadSession on the seed, they would still want that secondary
 				// to see the "real" state.
-				return primary.boskInfo.bosk().supersedingReadSession();
+				return seed.boskInfo.bosk().supersedingReadSession();
 			} catch (IllegalStateException e) {
 				// You have engaged in the aforementioned shenanigans.
-				throw new IllegalStateException("Unable to acquire primary read session; multiple replicas are being initialized simultaneously", e);
+				throw new IllegalStateException("Unable to acquire seed read session; multiple replicas are being initialized simultaneously", e);
 			}
 		}
 

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import works.bosk.Bosk;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
 import works.bosk.DriverFactory;
@@ -47,6 +48,7 @@ public class ReplicaSet<R extends StateTreeNode> {
 
 	/**
 	 * The bosk whose state is returned by {@link BroadcastDriver#initialState}.
+	 * Besides this, all replicas are treated symmetrically.
 	 */
 	final AtomicReference<Replica<R>> seed = new AtomicReference<>(null);
 
@@ -55,18 +57,12 @@ public class ReplicaSet<R extends StateTreeNode> {
 	 */
 	final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
-	/**
-	 * We can actually use the same driver for every bosk in the replica set
-	 * because they all do the same thing!
-	 */
-	final BroadcastDriver broadcastDriver = new BroadcastDriver();
-
 	public DriverFactory<R> driverFactory() {
 		return (b,d) -> {
 			Replica<R> replica = new Replica<>(b, d);
 			seed.compareAndSet(null, replica);
 			replicas.add(replica);
-			return broadcastDriver;
+			return new BroadcastDriver(b.context());
 		};
 
 		/*
@@ -121,6 +117,12 @@ public class ReplicaSet<R extends StateTreeNode> {
 	}
 
 	final class BroadcastDriver implements BoskDriver {
+		final BoskContext context;
+
+		BroadcastDriver(BoskContext context) {
+			this.context = context;
+		}
+
 		/**
 		 * @return the <em>current state</em> of the replica set, which is the state of its seed replica
 		 * as obtained by {@link Bosk#supersedingReadSession()}.
@@ -205,7 +207,12 @@ public class ReplicaSet<R extends StateTreeNode> {
 		}
 
 		private void broadcast(Consumer<Replica<R>> action) {
-			replicas.forEach(action);
+			var tenant = context.getEstablishedTenant();
+			replicas.forEach(replica -> {
+				try (var _ = replica.boskInfo.context().withTenant(tenant)) {
+					action.accept(replica);
+				}
+			});
 		}
 
 	}
@@ -233,6 +240,4 @@ public class ReplicaSet<R extends StateTreeNode> {
 		}
 
 	}
-
-
 }

--- a/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskConstructorTest.java
@@ -152,7 +152,7 @@ public class BoskConstructorTest {
 		return (_, _) -> new NoOpDriver() {
 			@Override
 			public <RR extends StateTreeNode> InitialState<RR> initialState(Class<RR> rootType) throws InvalidTypeException, IOException, InterruptedException {
-				return initialStateFunction.get().map(rootType::cast);
+				return initialStateFunction.get().cast(rootType);
 			}
 		};
 	}

--- a/bosk-core/src/test/java/works/bosk/BoskContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskContextTest.java
@@ -2,9 +2,15 @@ package works.bosk;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import works.bosk.BoskConfig.TenancyModel.Explicit;
+import works.bosk.BoskConfig.TenancyModel.Implicit;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.annotations.ReferencePath;
 import works.bosk.testing.drivers.AbstractDriverTest;
 import works.bosk.testing.drivers.DriverConformanceTest;
@@ -12,13 +18,17 @@ import works.bosk.testing.drivers.state.TestEntity;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static works.bosk.BoskContext.Tenant.NOT_ESTABLISHED;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 /**
  * Note that context propagation for driver operations is tested by {@link DriverConformanceTest}.
  */
 class BoskContextTest extends AbstractDriverTest {
+	final Tenant.SetTo tenant1 = Tenant.setTo(Identifier.from("tenant1"));
+	final Tenant.SetTo tenant2 = Tenant.setTo(Identifier.from("tenant2"));
 
 	public interface Refs {
 		@ReferencePath("/string") Reference<String> string();
@@ -30,7 +40,9 @@ class BoskContextTest extends AbstractDriverTest {
 			boskName(),
 			TestEntity.class,
 			this::initialState,
-			BoskConfig.simple()
+			BoskConfig.<TestEntity>builder()
+				.tenancyModel(scenario.tenancyModel)
+				.build()
 		);
 	}
 
@@ -72,5 +84,78 @@ class BoskContextTest extends AbstractDriverTest {
 				assertEquals(expectedInner, context.getAttributes());
 			}
 		}
+	}
+
+	@Test
+	void validTenant_works() {
+		var context = bosk.context();
+		assertEquals(scenario.automaticallyEstablishedTenant(), context.getTenant());
+		try (var _ = context.withMaybeTenant(scenario.startingTenant)) {
+			assertEquals(scenario.startingTenant, context.getTenant());
+		}
+		assertEquals(scenario.automaticallyEstablishedTenant(), context.getTenant());
+
+		switch (scenario.tenancyModel) {
+			case Implicit _ -> {
+				assertThrows(IllegalArgumentException.class, () -> context.withTenant(tenant2).close(),
+					"Must not allow establishing different tenant");
+			}
+			case Explicit _ -> {
+				assertEquals(NOT_ESTABLISHED, context.getTenant());
+				try (var _ = context.withTenant(tenant1)) {
+					assertEquals(tenant1, context.getTenant());
+					assertThrows(IllegalArgumentException.class, () -> context.withTenant(tenant2).close(),
+						"Must not allow establishing different tenant on the same thread");
+					assertThrows(IllegalArgumentException.class, () -> context.withMaybeTenant(NOT_ESTABLISHED).close(),
+						"Must not allow un-establishing tenant");
+				}
+				assertEquals(NOT_ESTABLISHED, context.getTenant(),
+					"Tenant should be reset to initial tenant after closing ContextScope");
+			}
+		}
+	}
+
+	@Test
+	void withTenant_perThread() throws ExecutionException, InterruptedException, TimeoutException {
+		if (scenario.tenancyModel instanceof Implicit) {
+			// Not relevant; every thread will have the same tenant anyway
+			return;
+		}
+		try (var virtualThreads = Executors.newVirtualThreadPerTaskExecutor()) {
+			var context = bosk.context();
+
+			try (var _ = context.withTenant(tenant1)) {
+				assertEquals(tenant1, context.getTenant());
+				virtualThreads.submit(()-> {
+					assertEquals(NOT_ESTABLISHED, context.getTenant(),
+						"New thread should not inherit tenant");
+					try (var _ = context.withTenant(tenant2)) {
+						assertEquals(tenant2, context.getTenant(),
+							"Should be able to establish a distinct tenant on a different thread");
+					}
+					assertEquals(NOT_ESTABLISHED, context.getTenant(),
+						"Tenant should be reset when ContextScope is closed");
+				}).get(10, SECONDS);
+				assertEquals(tenant1, context.getTenant(),
+					"Tenant on original thread should be unaffected by operations on other thread");
+			}
+
+			assertEquals(NOT_ESTABLISHED, context.getTenant());
+		}
+	}
+
+	@Test
+	void wrongOrder_throws() {
+		var context = bosk.context();
+		try (
+			var scope1 = context.withAttribute("key", "scope1");
+			var _ = context.withAttribute("key", "scope2")
+		) {
+			assertThrows(IllegalStateException.class, scope1::close,
+				"Closing ContextScopes in the wrong order should throw");
+		}
+
+		// (If we made it to this point, we were able to close the scopes
+		// in the correct order even after trying to close them in the wrong order.)
 	}
 }

--- a/bosk-core/src/test/java/works/bosk/TaggedUnionTest.java
+++ b/bosk-core/src/test/java/works/bosk/TaggedUnionTest.java
@@ -65,6 +65,7 @@ class TaggedUnionTest extends AbstractBoskTest {
 		}
 
 		bosk.driver().submitReplacement(refs.v(), TaggedUnion.of(idCase));
+
 		bosk.driver().flush();
 
 		try (var _ = bosk.readSession()) {

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
@@ -20,7 +20,10 @@ class ReplicaSetConformanceTest extends DriverConformanceTest {
 			boskName("Replica"),
 			TestEntity.class,
 			this::initialState,
-			BoskConfig.<TestEntity>builder().driverFactory(replicaSet.driverFactory()).build());
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(replicaSet.driverFactory())
+				.tenancyModel(scenario.tenancyModel)
+				.build());
 		driverFactory = replicaSet.driverFactory();
 	}
 

--- a/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
+++ b/bosk-core/src/test/java/works/bosk/drivers/ReplicaSetConformanceTest.java
@@ -4,13 +4,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
-import works.bosk.testing.drivers.DriverConformanceTest;
+import works.bosk.testing.drivers.SharedDriverConformanceTest;
 import works.bosk.testing.drivers.state.TestEntity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
-class ReplicaSetConformanceTest extends DriverConformanceTest {
+class ReplicaSetConformanceTest extends SharedDriverConformanceTest {
 	Bosk<TestEntity> replicaBosk;
 
 	@BeforeEach

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -81,6 +81,10 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 					DocumentFields.diagnostics.name(),
 					formatter.encodeDiagnostics(context.getAttributes())
 				)
+				.append(
+					DocumentFields.tenant.name(),
+					formatter.encodeTenant(context.getEstablishedTenant())
+				)
 			);
 	}
 
@@ -90,6 +94,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		fieldValues.put(DocumentFields.path.name(), new BsonString("/"));
 		fieldValues.put(DocumentFields.state.name(), initialState);
 		fieldValues.put(DocumentFields.revision.name(), revision);
+		fieldValues.put(DocumentFields.tenant.name(), formatter.encodeMaybeTenant(context.getTenant()));
 		fieldValues.put(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(context.getAttributes()));
 
 		return fieldValues;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonFormatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonFormatter.java
@@ -312,6 +312,11 @@ public class BsonFormatter {
 		revision,
 
 		/**
+		 * The contents of {@link BoskContext#getTenant()} corresponding to this document's last update.
+		 */
+		tenant,
+
+		/**
 		 * The contents of {@link BoskContext#getAttributes()} corresponding to this
 		 * document's last update.
 		 */

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
@@ -3,16 +3,19 @@ package works.bosk.drivers.mongo.internal;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.UpdateDescription;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.bson.BsonBinaryWriter;
+import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentReader;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
+import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.BsonValueCodec;
@@ -22,7 +25,9 @@ import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskInfo;
+import works.bosk.Identifier;
 import works.bosk.MapValue;
 import works.bosk.Reference;
 import works.bosk.StateTreeSerializer;
@@ -30,6 +35,7 @@ import works.bosk.drivers.mongo.BsonSerializer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 import static works.bosk.ReferenceUtils.rawClass;
 
 /**
@@ -38,6 +44,8 @@ import static works.bosk.ReferenceUtils.rawClass;
  * @author pdoyle
  */
 final class Formatter extends BsonFormatter {
+
+	private volatile Tenant.Established lastEventTenant = null;
 
 	/**
 	 * If the diagnostic attributes are identical from one update to the next,
@@ -135,6 +143,35 @@ final class Formatter extends BsonFormatter {
 				DecoderContext.builder().build());
 	}
 
+	BsonValue encodeMaybeTenant(Tenant tenant) {
+		return switch(tenant) {
+			case Tenant.NotEstablished _ -> new BsonNull();
+			case Tenant.Established t -> encodeTenant(t);
+		};
+	}
+
+	BsonValue encodeTenant(Tenant.Established tenant) {
+		return switch(tenant) {
+			case Tenant.None _ -> new BsonBoolean(false);
+			case Tenant.SetTo(var id) -> new BsonString(id.toString());
+		};
+	}
+
+	Tenant.Established decodeTenant(BsonValue tenant) {
+		return switch (tenant) {
+			case BsonNull _ -> Tenant.NONE;
+			case BsonBoolean b -> {
+				if (b.getValue()) {
+					throw new IllegalArgumentException("Unexpected tenant value: " + tenant);
+				} else {
+					yield Tenant.NONE;
+				}
+			}
+			case BsonString s -> new Tenant.SetTo(Identifier.from(s.getValue()));
+			default -> throw new IllegalArgumentException("Unexpected tenant value: " + tenant);
+		};
+	}
+
 	BsonDocument encodeDiagnostics(MapValue<String> attributes) {
 		BsonDocument result = new BsonDocument();
 		attributes.forEach((name, value) -> result.put(name, new BsonString(value)));
@@ -169,8 +206,17 @@ final class Formatter extends BsonFormatter {
 		return fullDocument.getInt64(DocumentFields.revision.name(), null);
 	}
 
+	@Nonnull Tenant.Established eventTenantFromFullDocument(BsonDocument fullDocument) {
+		return getOrSetEventTenant(getTenantFromFullDocument(fullDocument));
+	}
+
 	@Nonnull MapValue<String> eventDiagnosticAttributesFromFullDocument(BsonDocument fullDocument) {
 		return getOrSetEventDiagnosticAttributes(getDiagnosticAttributesFromFullDocument(fullDocument));
+	}
+
+	Tenant.Established getTenantFromFullDocument(BsonDocument fullDocument) {
+		BsonValue tenant = getTenantIfAny(fullDocument);
+		return tenant == null ? null : decodeTenant(tenant);
 	}
 
 	MapValue<String> getDiagnosticAttributesFromFullDocument(BsonDocument fullDocument) {
@@ -186,8 +232,18 @@ final class Formatter extends BsonFormatter {
 		return updatedFields.getInt64(DocumentFields.revision.name(), null);
 	}
 
+	@Nonnull Tenant.Established eventTenantFromUpdate(ChangeStreamDocument<BsonDocument> event) {
+		return getOrSetEventTenant(getTenantFromUpdateEvent(event));
+	}
+
 	@Nonnull MapValue<String> eventDiagnosticAttributesFromUpdate(ChangeStreamDocument<BsonDocument> event) {
 		return getOrSetEventDiagnosticAttributes(getDiagnosticAttributesFromUpdateEvent(event));
+	}
+
+	Tenant.Established getTenantFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
+		BsonDocument updatedFields = getUpdatedFieldsIfAny(event);
+		BsonValue tenant = getTenantIfAny(updatedFields);
+		return tenant == null ? null : decodeTenant(tenant);
 	}
 
 	MapValue<String> getDiagnosticAttributesFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
@@ -207,6 +263,13 @@ final class Formatter extends BsonFormatter {
 		return updateDescription.getUpdatedFields();
 	}
 
+	static BsonValue getTenantIfAny(BsonDocument fullDocument) {
+		if (fullDocument == null) {
+			return null;
+		}
+		return fullDocument.get(DocumentFields.tenant.name(), null);
+	}
+
 	static BsonDocument getDiagnosticAttributesIfAny(BsonDocument fullDocument) {
 		if (fullDocument == null) {
 			return null;
@@ -220,6 +283,17 @@ final class Formatter extends BsonFormatter {
 			return lastEventDiagnosticAttributes;
 		} else {
 			lastEventDiagnosticAttributes = fromEvent;
+			return fromEvent;
+		}
+	}
+
+	@Nonnull private Tenant.Established getOrSetEventTenant(@Nullable Tenant.Established fromEvent) {
+		if (fromEvent == null) {
+			LOGGER.debug("No tenant info in event; assuming unchanged");
+			return requireNonNull(lastEventTenant,
+				"If event has no tenant info, we must have it from a prior event");
+		} else {
+			lastEventTenant = fromEvent;
 			return fromEvent;
 		}
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
@@ -289,10 +289,11 @@ final class Formatter extends BsonFormatter {
 
 	@Nonnull private Tenant.Established getOrSetEventTenant(@Nullable Tenant.Established fromEvent) {
 		if (fromEvent == null) {
-			LOGGER.debug("No tenant info in event; assuming unchanged");
+			LOGGER.debug("No tenant info in event; assuming unchanged: {}", lastEventTenant);
 			return requireNonNull(lastEventTenant,
 				"If event has no tenant info, we must have it from a prior event");
 		} else {
+			LOGGER.debug("Saving tenant info from event: {}", fromEvent);
 			lastEventTenant = fromEvent;
 			return fromEvent;
 		}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -205,7 +205,8 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 			MongoCollection<BsonDocument> changeStreamCollection = changeStreamClient
 				.getDatabase(driverSettings.database())
-				.getCollection(COLLECTION_NAME, BsonDocument.class);
+				.getCollection(COLLECTION_NAME, BsonDocument.class)
+				;
 			this.receiver = new ChangeReceiver(boskInfo.name(), boskInfo.instanceID(), listener, driverSettings, changeStreamCollection);
 		}
 
@@ -283,7 +284,9 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// Annoying in tests, so we log it with UNINITIALIZED_COLLECTION_LOGGER so we can selectively disable it.
 			UNINITIALIZED_COLLECTION_LOGGER.warn("Database collection is uninitialized; initializing now. ({})", e.getMessage());
 			initialState = callDownstreamInitialState(rootType);
-			try (var session = queryCollection.newSession()) {
+			try (
+				var session = queryCollection.newSession()
+			) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
 				var root = switch (initialState) {
 					case InitialState.SingleTree(var r) -> r;
@@ -501,7 +504,9 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				// This causes downstream.submitReplacement to be associated with the last update to the state,
 				// which is of dubious relevance. We might just want to use the context from the current thread,
 				// which is probably empty because this runs on the ChangeReceiver thread.
-				try (var _ = boskInfo.context().withOnly(loadedState.diagnosticAttributes())) {
+				try (
+					var _ = boskInfo.context().withOnly(loadedState.diagnosticAttributes());
+				) {
 					downstream.submitReplacement(boskInfo.rootReference(), loadedState.state());
 					LOGGER.debug("Done submitting downstream");
 				}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -221,7 +221,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				throw new IllegalStateException("initialState has already run");
 			}
 			try {
-				return task.get().map(rootType::cast);
+				return task.get().cast(rootType);
 			} catch (ExecutionException e) {
 				switch (e.getCause()) {
 					case InitialStateFailureException i -> throw i;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -672,7 +672,13 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			throw new IllegalStateException("Driver is closed");
 		}
 		MDCScope ex = setupMDC(boskInfo.name(), boskInfo.instanceID());
-		LOGGER.debug(description + " w/" + this.formatDriver.getClass().getSimpleName(), args);
+		if (LOGGER.isDebugEnabled()) {
+			Object[] argsWithContext = new Object[args.length + 2];
+			System.arraycopy(args, 0, argsWithContext, 0, args.length);
+			argsWithContext[args.length] = boskInfo.name();
+			argsWithContext[args.length + 1] = boskInfo.context().getTenant();
+			LOGGER.debug(description + " w/{}@{}", argsWithContext);
+		}
 		if (driverSettings.testing().eventDelayMS() < 0) {
 			LOGGER.debug("| eventDelayMS {}ms ", driverSettings.testing().eventDelayMS());
 			try {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -31,6 +31,7 @@ import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
 import works.bosk.Entity;
@@ -190,6 +191,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			throw new IllegalStateException("Cannot locate root document");
 		}
 
+		formatter.eventTenantFromFullDocument(mainPart); // Saves the tenant info for subsequent events
 		return new BsonStateAndMetadata(
 			bsonSurgeon.gather(allParts),
 			mainPart.getInt64(DocumentFields.revision.name(), null),
@@ -279,14 +281,21 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					throw new UnprocessableEventException("Missing fullDocument on final event", finalEvent.getOperationType());
 				}
 
+				// Grab the tenant and diagnostics early. If we're supposed to skip this event,
+				// we still need to stash the tenant for later events.
+				Tenant.Established tenant = formatter.eventTenantFromFullDocument(fullDocument);
+				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
+
 				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
 				if (shouldSkip(revision)) {
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
 
-				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
-				try (var _ = context.withOnly(diagnosticAttributes)) {
+				try (
+					var _ = context.withTenant(tenant);
+					var _ = context.withOnly(diagnosticAttributes)
+				) {
 					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
 					if (state == null) {
 						ChangeStreamDocument<BsonDocument> mainEvent = events.get(events.size() - 2);
@@ -307,8 +316,12 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
+				Tenant.Established tenant = formatter.eventTenantFromUpdate(finalEvent);
 				MapValue<String> attributes = formatter.eventDiagnosticAttributesFromUpdate(finalEvent);
-				try (var _ = context.withOnly(attributes)) {
+				try (
+					var _ = context.withTenant(tenant);
+					var _ = context.withOnly(attributes)
+				) {
 					boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
 					if (mainEventIsFinalEvent) {
 						LOGGER.debug("Main event is final event");

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -21,6 +21,7 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
 import works.bosk.Identifier;
@@ -131,6 +132,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			.cursor()
 		) {
 			BsonDocument document = cursor.next();
+			formatter.eventTenantFromFullDocument(document); // Saves the tenant info for subsequent events
 			return new BsonStateAndMetadata(
 				document.getDocument(DocumentFields.state.name(), null),
 				document.getInt64(DocumentFields.revision.name(), null),
@@ -202,8 +204,12 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					// also REPLACE. That would imply that this case is impossible.
 					throw new UnprocessableEventException("Missing fullDocument", event.getOperationType());
 				}
+				Tenant.Established tenant = formatter.eventTenantFromFullDocument(fullDocument);
 				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
-				try (var _ = context.withOnly(diagnosticAttributes)) {
+				try (
+					var _ = context.withTenant(tenant);
+					var _ = context.withOnly(diagnosticAttributes)
+				) {
 					BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
 					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name(), null);
 					if (state == null) {
@@ -223,8 +229,12 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				if (updateDescription != null) {
 					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
 					if (shouldNotSkip(revision)) {
+						Tenant.Established tenant = formatter.eventTenantFromUpdate(event);
 						MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromUpdate(event);
-						try (var _ = context.withOnly(diagnosticAttributes)) {
+						try (
+							var _ = context.withTenant(tenant);
+							var _ = context.withOnly(diagnosticAttributes)
+						) {
 							replaceUpdatedFields(updateDescription.getUpdatedFields());
 							deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
 						}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
@@ -25,7 +25,7 @@ import works.bosk.junit.InjectFields;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
 import works.bosk.junit.Injector;
-import works.bosk.testing.drivers.SharedDriverConformanceTest;
+import works.bosk.testing.drivers.PolyfillDriverConformanceTest;
 import works.bosk.testing.junit.Slow;
 
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
@@ -33,7 +33,7 @@ import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOI
 @Slow
 @InjectFields
 @InjectFrom(ParameterSetInjector.class)
-class MongoDriverConformanceTest extends SharedDriverConformanceTest {
+class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
 	private static MongoService mongoService;
 	@Injected ParameterSet parameters;

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/TestParameters.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/TestParameters.java
@@ -40,7 +40,7 @@ public class TestParameters {
 				+ "_" + format.getClass().getSimpleName()
 				+ timing.suffix;
 			return new ParameterSet(
-				timing + "," + format,
+				format + "," + timing,
 				MongoDriverSettings.builder()
 					.preferredDatabaseFormat(format)
 					.timescaleMS(LONG_TIMESCALE)

--- a/bosk-sql/src/main/java/module-info.java
+++ b/bosk-sql/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module works.bosk.sql {
 	requires org.slf4j;
 	requires transitive works.bosk.core;
 	requires works.bosk.jackson;
+	requires jakarta.annotation;
 
 	exports works.bosk.drivers.sql;
 }

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
@@ -1,5 +1,6 @@
 package works.bosk.drivers.sql;
 
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.sql.Connection;
@@ -21,6 +22,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.StringNode;
 import tools.jackson.databind.type.TypeFactory;
 import works.bosk.BoskContext;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
 import works.bosk.Identifier;
@@ -67,6 +69,7 @@ class SqlDriverImpl implements SqlDriver {
 
 	// jOOQ references
 	private final TableField<Record, String> DIAGNOSTICS;
+	private final TableField<Record, String> TENANT;
 	private final ChangesTable CHANGES;
 	private final TableField<Record, Long> REVISION;
 	private final TableField<Record, String> REF;
@@ -109,6 +112,7 @@ class SqlDriverImpl implements SqlDriver {
 		REVISION = schema.REVISION;
 		CHANGES = schema.CHANGES;
 		DIAGNOSTICS = schema.DIAGNOSTICS;
+		TENANT = schema.TENANT;
 		STATE = schema.STATE;
 		BOSK = schema.BOSK;
 		ID = schema.ID;
@@ -132,7 +136,7 @@ class SqlDriverImpl implements SqlDriver {
 			try {
 				try (var c = connectionSource.get()) {
 					var rs = using(c)
-						.select(REF, NEW_STATE, DIAGNOSTICS, CHANGES.EPOCH, REVISION)
+						.select(REF, NEW_STATE, DIAGNOSTICS, TENANT, CHANGES.EPOCH, REVISION)
 						.from(CHANGES)
 						.where(REVISION.gt(lastChangeSubmittedDownstream.get()))
 						.fetch();
@@ -140,6 +144,7 @@ class SqlDriverImpl implements SqlDriver {
 						var ref = r.get(REF);
 						var newState = r.get(NEW_STATE);
 						var diagnostics = r.get(DIAGNOSTICS);
+						var tenantString = r.get(TENANT);
 						String epoch = r.get(CHANGES.EPOCH);
 						long changeID = r.get(REVISION);
 
@@ -165,7 +170,13 @@ class SqlDriverImpl implements SqlDriver {
 								diagnosticAttributes = MapValue.empty();
 							}
 						}
-						try (var _ = context.withOnly(diagnosticAttributes)) {
+
+						Tenant tenant = decodeTenant(tenantString);
+
+						try (
+							var _ = context.withMaybeTenant(tenant);
+							var _ = context.withOnly(diagnosticAttributes)
+						) {
 							Reference<Object> target = rootRef.then(Object.class, Path.parse(ref));
 							Object newValue;
 							if (newState == null) {
@@ -306,7 +317,7 @@ class SqlDriverImpl implements SqlDriver {
 	private void ensureTablesExist(Connection connection) throws SQLException {
 		using(connection)
 			.createTableIfNotExists(CHANGES)
-			.columns(CHANGES.EPOCH, REVISION, REF, NEW_STATE, DIAGNOSTICS)
+			.columns(CHANGES.EPOCH, REVISION, REF, NEW_STATE, DIAGNOSTICS, TENANT)
 			.constraints(primaryKey(REVISION))
 			.execute();
 
@@ -497,8 +508,14 @@ class SqlDriverImpl implements SqlDriver {
 	private long insertChange(Connection c, Reference<?> ref, String newValue) {
 		try {
 			return using(c)
-				.insertInto(CHANGES).columns(CHANGES.EPOCH, REF, NEW_STATE, DIAGNOSTICS)
-				.values(epoch, ref.pathString(), newValue, mapper.writeValueAsString(context.getAttributes()))
+				.insertInto(CHANGES).columns(CHANGES.EPOCH, REF, NEW_STATE, DIAGNOSTICS, TENANT)
+				.values(
+					epoch,
+					ref.pathString(),
+					newValue,
+					mapper.writeValueAsString(context.getAttributes()),
+					encodeTenant(context.getTenant())
+				)
 				.returning(REVISION)
 				.fetchOptional(REVISION)
 				.orElseThrow(()->new NotYetImplementedException("No change inserted"));
@@ -545,6 +562,26 @@ class SqlDriverImpl implements SqlDriver {
 
 	private static JavaType mapValueType(Class<?> entryType) {
 		return typeFactory.constructParametricType(MapValue.class, entryType);
+	}
+
+	private @Nullable String encodeTenant(Tenant tenant) {
+		return switch (tenant) {
+			case Tenant.NotEstablished _ -> null;
+			case Tenant.None _ -> "none";
+			case Tenant.SetTo(var id) -> "t:" + id;
+		};
+	}
+
+	private Tenant decodeTenant(@Nullable String tenantString) {
+		if (tenantString == null) {
+			return Tenant.NOT_ESTABLISHED;
+		} else if (tenantString.equals("none")) {
+			return Tenant.NONE;
+		} else if (tenantString.startsWith("t:")) {
+			return Tenant.setTo(Identifier.from(tenantString.substring(2)));
+		} else {
+			throw new IllegalArgumentException("Unrecognized tenant string: " + tenantString);
+		}
 	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SqlDriverImpl.class);

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/ChangesTable.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/ChangesTable.java
@@ -25,6 +25,8 @@ public class ChangesTable extends TableImpl<org.jooq.Record> {
 		name("new_state"), CLOB.null_());
 	public final TableField<Record, String> DIAGNOSTICS = createField(
 		name("diagnostics"), CLOB.notNull());
+	public final TableField<Record, String> TENANT = createField(
+		name("tenant"), VARCHAR.null_());
 
 	ChangesTable() {
 		super(name("bosk_changes"));

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/schema/Schema.java
@@ -19,6 +19,7 @@ public class Schema {
 	public final TableField<Record, String> REF = CHANGES.REF;
 	public final TableField<Record, String> NEW_STATE = CHANGES.NEW_STATE;
 	public final TableField<Record, String> DIAGNOSTICS = CHANGES.DIAGNOSTICS;
+	public final TableField<Record, String> TENANT = CHANGES.TENANT;
 
 	public void dropTables(Connection c) throws SQLException {
 		using(c)

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/DatabaseInjector.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/DatabaseInjector.java
@@ -5,9 +5,7 @@ import java.util.List;
 import works.bosk.drivers.sql.SqlTestService.Database;
 import works.bosk.junit.Injector;
 
-import static works.bosk.drivers.sql.SqlTestService.Database.MYSQL;
 import static works.bosk.drivers.sql.SqlTestService.Database.POSTGRES;
-import static works.bosk.drivers.sql.SqlTestService.Database.SQLITE;
 
 record DatabaseInjector() implements Injector {
 	@Override
@@ -17,6 +15,6 @@ record DatabaseInjector() implements Injector {
 
 	@Override
 	public List<Database> values() {
-		return List.of(POSTGRES, SQLITE, MYSQL);
+		return List.of(POSTGRES /*, SQLITE, MYSQL */);
 	}
 }

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
@@ -14,14 +14,14 @@ import works.bosk.drivers.sql.schema.Schema;
 import works.bosk.junit.InjectFields;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
-import works.bosk.testing.drivers.SharedDriverConformanceTest;
+import works.bosk.testing.drivers.PolyfillDriverConformanceTest;
 
 import static works.bosk.drivers.sql.SqlTestService.sqlDriverFactory;
 
 @InjectFields
 @InjectFrom(DatabaseInjector.class)
 @Testcontainers
-class SqlDriverConformanceTest extends SharedDriverConformanceTest {
+class SqlDriverConformanceTest extends PolyfillDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
 	@Injected Database database;
 	private final AtomicInteger dbCounter = new AtomicInteger(0);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/AbstractDriverTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractDriverTest {
 	public enum Scenario {
 		NO_TENANTS(TenancyModel.NONE, Tenant.NONE),
 		FIXED_TENANT(new Fixed(TENANT1), Tenant.setTo(TENANT1)),
-		TRANSIENT(TenancyModel.TRANSIENT, Tenant.setTo(TENANT1))
+		TRANSIENT_TENANT(TenancyModel.TRANSIENT, Tenant.setTo(TENANT1))
 		;
 
 		public final TenancyModel tenancyModel;

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/AbstractDriverTest.java
@@ -1,7 +1,10 @@
 package works.bosk.testing.drivers;
 
 import java.io.IOException;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
@@ -9,6 +12,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskConfig.TenancyModel.Explicit;
+import works.bosk.BoskConfig.TenancyModel.Fixed;
+import works.bosk.BoskConfig.TenancyModel.None;
+import works.bosk.BoskContext.ContextScope;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.BoskDriver.InitialState;
 import works.bosk.CatalogReference;
@@ -20,28 +29,100 @@ import works.bosk.Reference;
 import works.bosk.SideTable;
 import works.bosk.drivers.ReplicaSet;
 import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.junit.InjectFields;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.Injected;
+import works.bosk.junit.Injector;
+import works.bosk.testing.drivers.AbstractDriverTest.ScenarioInjector;
 import works.bosk.testing.drivers.state.TestEntity;
+import works.bosk.testing.drivers.state.TestEntity.Fields;
 import works.bosk.util.Classes;
 
 import static java.lang.Thread.currentThread;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
+@InjectFields
+@InjectFrom(ScenarioInjector.class)
 public abstract class AbstractDriverTest {
+	public static final Identifier TENANT1 = Identifier.from("tenant1");
 	protected final Identifier child1ID = Identifier.from("child1");
 	protected final Identifier child2ID = Identifier.from("child2");
-	private TestInfo testInfo;
+	protected TestInfo testInfo;
+	@Injected protected Scenario scenario;
 	protected Bosk<TestEntity> canonicalBosk;
 	protected Bosk<TestEntity> bosk;
+	protected ContextScope tenantScope;
 	protected BoskDriver driver;
 	private volatile String oldThreadName;
+
+	public enum Scenario {
+		NO_TENANTS(TenancyModel.NONE, Tenant.NONE),
+		FIXED_TENANT(new Fixed(TENANT1), Tenant.setTo(TENANT1)),
+		TRANSIENT(TenancyModel.TRANSIENT, Tenant.setTo(TENANT1))
+		;
+
+		public final TenancyModel tenancyModel;
+
+		/**
+		 * The tenant to establish at the start of tests.
+		 * This is intended as a convenience to allow the bulk of tests
+		 * to run without worrying about establishing a tenant,
+		 * not to describe the tenant state automatically established by the tenancy model.
+		 *
+		 * @see #automaticallyEstablishedTenant()
+		 */
+		public final Tenant startingTenant;
+
+		/**
+		 * @return the tenant state automatically established by the tenancy model
+		 */
+		public Tenant automaticallyEstablishedTenant() {
+			return switch (tenancyModel) {
+				case None _ -> Tenant.NONE;
+				case Explicit _ -> Tenant.NOT_ESTABLISHED;
+				case Fixed(var id) -> Tenant.setTo(id);
+			};
+		}
+
+		Scenario(TenancyModel tenancyModel, Tenant startingTenant) {
+			this.tenancyModel = tenancyModel;
+			this.startingTenant = startingTenant;
+		}
+
+	}
+
+	record ScenarioInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType.equals(Scenario.class);
+		}
+
+		@Override
+		public List<?> values() {
+			return Arrays.asList(Scenario.values());
+		}
+	}
+
+	@BeforeEach
+	void clearTenantScope() {
+		tenantScope = null;
+	}
+
+	@AfterEach
+	void closeTenantScope() {
+		if (tenantScope != null) {
+			tenantScope.close();
+			tenantScope = null;
+		}
+	}
 
 	@BeforeEach
 	void logStart(TestInfo testInfo) {
 		this.testInfo = testInfo;
-		oldThreadName = Thread.currentThread().getName();
+		oldThreadName = currentThread().getName();
 		String newThreadName = "test: " + testInfo.getDisplayName();
-		Thread.currentThread().setName(newThreadName);
+		currentThread().setName(newThreadName);
 		logTest("/=== Start");
 		LOGGER.debug("Old thread name was {}", oldThreadName);
 	}
@@ -49,7 +130,7 @@ public abstract class AbstractDriverTest {
 	@AfterEach
 	void logDone() {
 		logTest("\\=== Done");
-		Thread.currentThread().setName(oldThreadName);
+		currentThread().setName(oldThreadName);
 	}
 
 	private void logTest(String verb) {
@@ -61,25 +142,37 @@ public abstract class AbstractDriverTest {
 	}
 
 	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
+		TenancyModel tenancyModel = scenario.tenancyModel;
+
 		// This is the bosk whose behaviour we'll consider to be correct by definition
-		canonicalBosk = new Bosk<>(boskName("Canonical", 1), TestEntity.class, this::initialState, BoskConfig.simple());
+		canonicalBosk = new Bosk<>(
+			boskName("Canonical", 1),
+			TestEntity.class,
+			this::initialState,
+			BoskConfig.<TestEntity>builder()
+				.tenancyModel(tenancyModel)
+				.build()
+		);
 
 		// This is the bosk we're testing
 		bosk = new Bosk<>(
 			boskName("Test", 1),
 			TestEntity.class,
 			this::initialState,
-			BoskConfig.<TestEntity>builder().driverFactory(DriverStack.of(
-				ReplicaSet.mirroringTo(canonicalBosk),
-				DriverStateVerifier.wrap(driverFactory, TestEntity.class, this::initialState)
-			)).build());
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(DriverStack.of(
+					ReplicaSet.mirroringTo(canonicalBosk),
+					DriverStateVerifier.wrap(driverFactory, TestEntity.class, this::initialState)
+				))
+				.tenancyModel(tenancyModel)
+				.build());
 		driver = bosk.driver();
+		tenantScope = bosk.context().withMaybeTenant(scenario.startingTenant);
 	}
 
 	public InitialState<TestEntity> initialState(Bosk<TestEntity> b) throws InvalidTypeException {
-		return InitialState.of(
-			TestEntity.empty(Identifier.from("root"), b.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)))
-		);
+		TestEntity root = TestEntity.empty(Identifier.from("root"), b.rootReference().thenCatalog(TestEntity.class, Path.just(Fields.catalog)));
+		return InitialState.of(root);
 	}
 
 	protected TestEntity autoInitialize(Reference<TestEntity> ref) {
@@ -109,14 +202,14 @@ public abstract class AbstractDriverTest {
 		if (path.length() < 3) {
 			return false;
 		} else {
-			return path.truncatedBy(2).lastSegment().equals(TestEntity.Fields.nestedSideTable);
+			return path.truncatedBy(2).lastSegment().equals(Fields.nestedSideTable);
 		}
 	}
 
 	TestEntity emptyEntityAt(Reference<TestEntity> ref) {
 		CatalogReference<TestEntity> catalogRef;
 		try {
-			catalogRef = ref.thenCatalog(TestEntity.class, TestEntity.Fields.catalog);
+			catalogRef = ref.thenCatalog(TestEntity.class, Fields.catalog);
 		} catch (InvalidTypeException e) {
 			throw new AssertionError("Every entity should have a catalog in it", e);
 		}
@@ -124,7 +217,7 @@ public abstract class AbstractDriverTest {
 	}
 
 	protected TestEntity newEntity(Identifier id, CatalogReference<TestEntity> enclosingCatalogRef) throws InvalidTypeException {
-		return TestEntity.empty(id, enclosingCatalogRef.then(id).thenCatalog(TestEntity.class, TestEntity.Fields.catalog));
+		return TestEntity.empty(id, enclosingCatalogRef.then(id).thenCatalog(TestEntity.class, Fields.catalog));
 	}
 
 	protected void assertCorrectBoskContents() {

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/AsyncDriver.java
@@ -77,10 +77,14 @@ public class AsyncDriver implements BoskDriver {
 
 	private void submitAsyncTask(String description, Runnable task) {
 		LOGGER.debug("Submit {}", description);
+		var tenant = bosk.context().getTenant();
 		var diagnosticAttributes = bosk.context().getAttributes();
 		executor.submit(()->{
 			LOGGER.debug("Run {}", description);
-			try (var _ = bosk.context().withOnly(diagnosticAttributes)) {
+			try (
+				var _ = bosk.context().withMaybeTenant(tenant);
+				var _ = bosk.context().withOnly(diagnosticAttributes)
+			) {
 				task.run();
 			} finally {
 				LOGGER.debug("Proceeding after {}", description);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/AsyncDriver.java
@@ -1,9 +1,9 @@
 package works.bosk.testing.drivers;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,9 +59,19 @@ public class AsyncDriver implements BoskDriver {
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		Semaphore semaphore = new Semaphore(0);
-		submitAsyncTask("flush", semaphore::release);
-		semaphore.acquire();
+		// The executor is single-threaded, so this will run after all previously submitted tasks
+		var nonceTask = executor.submit(()->{});
+		try {
+			nonceTask.get();
+		} catch (ExecutionException e) {
+			try {
+				throw e.getCause();
+			} catch (IOException | InterruptedException | RuntimeException ex) {
+				throw ex;
+			} catch (Throwable ex) {
+				throw new IllegalStateException("Unexpected exception from flush task", ex);
+			}
+		}
 		downstream.flush();
 	}
 
@@ -72,6 +82,8 @@ public class AsyncDriver implements BoskDriver {
 			LOGGER.debug("Run {}", description);
 			try (var _ = bosk.context().withOnly(diagnosticAttributes)) {
 				task.run();
+			} finally {
+				LOGGER.debug("Proceeding after {}", description);
 			}
 			LOGGER.trace("Done {}", description);
 		});

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
@@ -19,7 +19,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.BoskConfig;
+import works.bosk.BoskConfig.TenancyModel.Implicit;
+import works.bosk.BoskConfig.TenancyModel.Transient;
 import works.bosk.BoskContext;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
@@ -529,71 +532,79 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@Test
-	void submitReplacement_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
+	void submitReplacement_propagatesContext() throws InvalidTypeException, IOException, InterruptedException {
 		initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Reference<String> ref = bosk.rootReference().then(String.class, "string");
-		testDiagnosticContextPropagation(() -> bosk.driver().submitReplacement(ref, "value1"));
+		testContextPropagation(() -> bosk.driver().submitReplacement(ref, "value1"));
 		// Do a second one with the same diagnostics to verify that they
 		// still propagate even when they don't change
-		testDiagnosticContextPropagation(() -> bosk.driver().submitReplacement(ref, "value2"));
+		testContextPropagation(() -> bosk.driver().submitReplacement(ref, "value2"));
 	}
 
 	@Test
-	void submitConditionalReplacement_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
+	void submitConditionalReplacement_propagatesContext() throws InvalidTypeException, IOException, InterruptedException {
 		initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Refs refs = bosk.buildReferences(Refs.class);
 		Reference<String> ref = bosk.rootReference().then(String.class, "string");
-		testDiagnosticContextPropagation(() -> bosk.driver().submitConditionalReplacement(ref, "newValue", refs.rootID(), Identifier.from("root")));
+		testContextPropagation(() -> bosk.driver().submitConditionalReplacement(ref, "newValue", refs.rootID(), Identifier.from("root")));
 	}
 
 	@Test
-	void submitConditionalCreation_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
+	void submitConditionalCreation_propagatesContext() throws InvalidTypeException, IOException, InterruptedException {
 		initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Refs refs = bosk.buildReferences(Refs.class);
 		Identifier id = Identifier.from("testEntity");
 		Reference<TestEntity> ref = refs.catalogEntry(id);
-		testDiagnosticContextPropagation(() -> bosk.driver().submitConditionalCreation(ref, emptyEntityAt(ref)));
+		testContextPropagation(() -> bosk.driver().submitConditionalCreation(ref, emptyEntityAt(ref)));
 	}
 
 	@Test
-	void submitDeletion_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
+	void submitDeletion_propagatesContext() throws InvalidTypeException, IOException, InterruptedException {
 		initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Refs refs = bosk.buildReferences(Refs.class);
 		Reference<TestEntity> ref = refs.catalogEntry(Identifier.unique("e"));
 		autoInitialize(ref);
-		testDiagnosticContextPropagation(() -> bosk.driver().submitDeletion(ref));
+		testContextPropagation(() -> bosk.driver().submitDeletion(ref));
 	}
 
 	@Test
-	void submitConditionalDeletion_propagatesDiagnosticContext() throws InvalidTypeException, IOException, InterruptedException {
+	void submitConditionalDeletion_propagatesContext() throws InvalidTypeException, IOException, InterruptedException {
 		initializeBoskWithBlankValues(Path.just(TestEntity.Fields.catalog));
 		Refs refs = bosk.buildReferences(Refs.class);
 		Reference<TestEntity> ref = refs.catalogEntry(Identifier.unique("e"));
 		autoInitialize(ref);
-		testDiagnosticContextPropagation(() -> bosk.driver().submitConditionalDeletion(ref, refs.rootID(), Identifier.from("root")));
+		testContextPropagation(() -> bosk.driver().submitConditionalDeletion(ref, refs.rootID(), Identifier.from("root")));
 	}
 
-	private void testDiagnosticContextPropagation(Runnable operation) throws IOException, InterruptedException {
-		AtomicBoolean diagnosticsAreReady = new AtomicBoolean(false);
-		Semaphore diagnosticsVerified = new Semaphore(0);
-		bosk.hookRegistrar().registerHook("contextPropagatesToHook", bosk.rootReference(), _1 -> {
+	private void testContextPropagation(Runnable operation) throws IOException, InterruptedException {
+		var expectedTenant = switch (scenario.tenancyModel) {
+			case Transient _ -> Tenant.NOT_ESTABLISHED; // Transient models don't propagate tenant info into hooks
+			case Implicit _ -> scenario.startingTenant;
+		};
+		AtomicBoolean hookEnabled = new AtomicBoolean(false);
+		Semaphore contextVerified = new Semaphore(0);
+		bosk.hookRegistrar().registerHook("contextPropagatesToHook", bosk.rootReference(), _ -> {
 			// Note that this will run as soon as it's registered
-			if (diagnosticsAreReady.get()) {
+			if (hookEnabled.get()) {
 				BoskContext boskContext = bosk.context();
 				LOGGER.debug("Received diagnostic attributes: {}", boskContext.getAttributes());
 				assertEquals("attributeValue", boskContext.getAttribute("attributeName"));
-				diagnosticsVerified.release();
+				assertEquals(expectedTenant, boskContext.getTenant(),
+					"Tenant should be propagated to hooks run in response to updates"); // This is not true for hooks run initially on registration in shared tree mode!
+				contextVerified.release();
 			}
 		});
-		bosk.driver().flush();
-		try (var _ = bosk.context().withAttribute("attributeName", "attributeValue")) {
-			diagnosticsAreReady.set(true);
-			LOGGER.debug("Running operation with diagnostic context");
+		try (
+			var _ = bosk.context().withAttribute("attributeName", "attributeValue")
+		) {
+			bosk.driver().flush();
+			hookEnabled.set(true);
+			LOGGER.debug("Running operation with context");
 			operation.run();
 		}
 		assertCorrectBoskContents();
-		assertTrue(diagnosticsVerified.tryAcquire(5, SECONDS));
-		diagnosticsAreReady.set(false); // Deactivate the hook
+		assertTrue(contextVerified.tryAcquire(5, SECONDS));
+		hookEnabled.set(false); // Deactivate the hook
 	}
 
 	private Reference<TestValues> initializeBoskWithBlankValues(@EnclosingCatalog Path enclosingCatalogPath) throws InvalidTypeException {

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
@@ -36,11 +36,6 @@ import static works.bosk.testing.BoskTestUtils.boskName;
  * Watches the updates entering and leaving a particular {@link BoskDriver} and ensures
  * that they have the same effect on the bosk state. If a mismatch is found, throws
  * {@link AssertionError}.
- *
- * <p>
- * Note: this verifier uses {@link Object#equals} to compare parts of the state tree,
- * expecting value-based equality. If used with state tree nodes having different equality
- * semantics, the resulting verifier could be more or less strict than expected.
  */
 @RequiredArgsConstructor(access = PRIVATE)
 public final class DriverStateVerifier<R extends StateTreeNode> {

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
 import works.bosk.DriverFactory;
 import works.bosk.DriverStack;
@@ -61,28 +62,33 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 	 * @param defaultStateFunction returns the initial state used to set up an internal bosk
 	 *                            that will track the cumulative effect of the updates coming from {@code subject} driver
 	 */
-	public static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject, Type rootType, Bosk.DefaultStateFunction<RR> defaultStateFunction) {
-		Bosk<RR> stateTrackingBosk = new Bosk<>(
-			boskName(),
-			rootType,
-			defaultStateFunction,
-			BoskConfig.simple());
-		DriverStateVerifier<RR> verifier = new DriverStateVerifier<>(
-			stateTrackingBosk,
-			ReplicaSet.redirectingTo(stateTrackingBosk)
-		);
-		return DriverStack.of(
-			// Tag the updates with a thread ID so we can demultiplex them properly after they go through the subject driver
-			ContextScopeDriver.factory(dc -> dc.withAttribute(THREAD_ID, Long.toString(currentThread().threadId()))),
-			// Record the updates as they appear on their way into the subject driver
-			ReportingDriver.factory(verifier::incomingUpdate, _->{}, verifier::postIncomingFlush),
-			// Send to the subject driver
-			subject,
-			// Delay to ensure the subject doesn't depend on immediate downstream propagation of updates
-			BufferingDriver.factory(),
-			// Report the updates as they appear on their way out of the subject driver
-			ReportingDriver.factory(verifier::outgoingUpdate, verifier::preOutgoingFlush, _->{})
-		);
+	static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject, Type rootType, Bosk.DefaultStateFunction<RR> defaultStateFunction) {
+		return (b,d) -> {
+			Bosk<RR> stateTrackingBosk = new Bosk<>(
+				boskName(),
+				rootType,
+				defaultStateFunction,
+				BoskConfig.<RR>builder()
+					.tenancyModel(b.tenancyModel())
+					.build()
+			);
+			DriverStateVerifier<RR> verifier = new DriverStateVerifier<>(
+				stateTrackingBosk,
+				ReplicaSet.redirectingTo(stateTrackingBosk)
+			);
+			return DriverStack.of(
+				// Tag the updates with a thread ID so we can demultiplex them properly after they go through the subject driver
+				ContextScopeDriver.factory(dc -> dc.withAttribute(THREAD_ID, Long.toString(currentThread().threadId()))),
+				// Record the updates as they appear on their way into the subject driver
+				ReportingDriver.factory(verifier::incomingUpdate, _->{}, verifier::postIncomingFlush),
+				// Send to the subject driver
+				subject,
+				// Delay to ensure the subject doesn't depend on immediate downstream propagation of updates
+				BufferingDriver.factory(),
+				// Report the updates as they appear on their way out of the subject driver
+				ReportingDriver.factory(verifier::outgoingUpdate, verifier::preOutgoingFlush, _->{})
+			).build(b,d);
+		};
 	}
 
 	/**
@@ -104,7 +110,10 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 	 */
 	private synchronized void outgoingUpdate(UpdateOperation op) {
 		LOGGER.debug("---> OUT: {}", op);
-		try {
+		if (!(op.boskContext().tenant() instanceof BoskContext.Tenant.Established tenant)) {
+			throw new AssertionError("Missing tenant on update: " + op);
+		}
+		try (var _ = stateTrackingBosk.context().withTenant(tenant)) {
 			Object before = currentStateBefore(op);
 			Object after = hypotheticalStateAfter(op);
 			LOGGER.trace("\t\tbefore: {}", before);
@@ -125,6 +134,12 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 						LOGGER.trace("\t\texpectedAfter: {}", expectedAfter);
 						if (op.matchesIfApplied(expected) && Objects.equals(after, expectedAfter)) {
 							LOGGER.debug("\tConclusion: found match: {}", expected);
+							var expectedTenant = expected.boskContext().tenant();
+							if (!(expectedTenant.equals(tenant))) {
+								throw new AssertionError(
+									"Operation has incorrect tenant " + tenant
+									+ "; expected " + expectedTenant);
+							}
 							UpdateOperation discarded;
 							while ((discarded = q.removeFirst()) != expected) {
 								LOGGER.trace("\t\tdiscard preceding no-op: {}", discarded);
@@ -202,27 +217,31 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 
 	@SuppressWarnings("unchecked")
 	private <T> T currentStateBefore(UpdateOperation op) throws IOException, InterruptedException {
-		Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
-		stateTrackingBosk.driver().flush();
-		try (var _ = stateTrackingBosk.readSession()) {
-			return stateTrackingRef.valueIfExists();
+		try (var _ = stateTrackingBosk.context().withMaybeTenant(op.boskContext().tenant())) {
+			Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
+			stateTrackingBosk.driver().flush();
+			try (var _ = stateTrackingBosk.readSession()) {
+				return stateTrackingRef.valueIfExists();
+			}
 		}
 	}
 
 	@SuppressWarnings("unchecked")
 	private <T> T hypotheticalStateAfter(UpdateOperation op) throws IOException, InterruptedException {
-		R originalState;
-		Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
-		stateTrackingBosk.driver().flush();
-		try (var _ = stateTrackingBosk.readSession()) {
-			originalState = stateTrackingBosk.rootReference().value();
-		}
-		op.submitTo(stateTrackingDriver);
-		stateTrackingBosk.driver().flush();
-		try (var _ = stateTrackingBosk.readSession()) {
-			return stateTrackingRef.valueIfExists();
-		} finally {
-			stateTrackingBosk.driver().submitReplacement(stateTrackingBosk.rootReference(), originalState);
+		try (var _ = stateTrackingBosk.context().withMaybeTenant(op.boskContext().tenant())) {
+			R originalState;
+			Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
+			stateTrackingBosk.driver().flush();
+			try (var _ = stateTrackingBosk.readSession()) {
+				originalState = stateTrackingBosk.rootReference().value();
+			}
+			op.submitTo(stateTrackingDriver);
+			stateTrackingBosk.driver().flush();
+			try (var _ = stateTrackingBosk.readSession()) {
+				return stateTrackingRef.valueIfExists();
+			} finally {
+				stateTrackingBosk.driver().submitReplacement(stateTrackingBosk.rootReference(), originalState);
+			}
 		}
 	}
 
@@ -236,7 +255,7 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 	}
 
 	private static @Nullable String threadId(DriverOperation op) {
-		return op.diagnosticAttributes().get(THREAD_ID);
+		return op.boskContext().diagnosticAttributes().get(THREAD_ID);
 	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DriverStateVerifier.class);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/PolyfillDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/PolyfillDriverConformanceTest.java
@@ -41,7 +41,10 @@ public abstract class PolyfillDriverConformanceTest extends SharedDriverConforma
 			boskName("Upgradeable"),
 			UpgradeableEntity.class,
 			_ -> { throw new AssertionError("upgradeableBosk should use the state from MongoDB"); },
-			BoskConfig.<UpgradeableEntity>builder().driverFactory(upgradeableDriverFactory).build());
+			BoskConfig.<UpgradeableEntity>builder()
+				.tenancyModel(scenario.tenancyModel)
+				.driverFactory(upgradeableDriverFactory)
+				.build());
 
 		LOGGER.debug("Ensure polyfill returns the right value on read");
 		TestValues polyfill;
@@ -59,7 +62,11 @@ public abstract class PolyfillDriverConformanceTest extends SharedDriverConforma
 
 		LOGGER.debug("Perform update inside polyfill");
 		Refs refs = upgradeableBosk.buildReferences(Refs.class);
-		upgradeableBosk.driver().submitReplacement(refs.valuesString(), "new value");
+		try (
+			var _ = upgradeableBosk.context().withMaybeTenant(scenario.startingTenant)
+		) {
+			upgradeableBosk.driver().submitReplacement(refs.valuesString(), "new value");
+		}
 		originalBosk.driver().flush(); // Not the bosk that did the update!
 
 		LOGGER.debug("Check state after");

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/PolyfillDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/PolyfillDriverConformanceTest.java
@@ -1,0 +1,74 @@
+package works.bosk.testing.drivers;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import works.bosk.Bosk;
+import works.bosk.BoskConfig;
+import works.bosk.DriverFactory;
+import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.testing.drivers.state.TestEntity;
+import works.bosk.testing.drivers.state.TestValues;
+import works.bosk.testing.drivers.state.UpgradeableEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.testing.BoskTestUtils.boskName;
+
+/**
+ * Tests that a driver can use {@link works.bosk.annotations.Polyfill @Polyfill}
+ * to share state between two bosks with different but compatible root types.
+ */
+public abstract class PolyfillDriverConformanceTest extends SharedDriverConformanceTest {
+	@Test
+	void updateInsidePolyfill_works() throws IOException, InterruptedException, InvalidTypeException {
+		// We'll use this as an honest observer of the actual state
+		LOGGER.debug("Create Original bosk");
+		Bosk<TestEntity> originalBosk = new Bosk<>(
+			boskName("Original"),
+			TestEntity.class,
+			this::initialState,
+			BoskConfig.<TestEntity>builder()
+				.tenancyModel(scenario.tenancyModel)
+				.driverFactory(driverFactory)
+				.build());
+
+		LOGGER.debug("Create Upgradeable bosk");
+		@SuppressWarnings({"rawtypes","unchecked"})
+		DriverFactory<UpgradeableEntity> upgradeableDriverFactory = (DriverFactory)driverFactory; // Yeehaw! Hope you don't care too much about the root type
+		Bosk<UpgradeableEntity> upgradeableBosk = new Bosk<>(
+			boskName("Upgradeable"),
+			UpgradeableEntity.class,
+			_ -> { throw new AssertionError("upgradeableBosk should use the state from MongoDB"); },
+			BoskConfig.<UpgradeableEntity>builder().driverFactory(upgradeableDriverFactory).build());
+
+		LOGGER.debug("Ensure polyfill returns the right value on read");
+		TestValues polyfill;
+		try (var _ = upgradeableBosk.readSession()) {
+			polyfill = upgradeableBosk.rootReference().value().values();
+		}
+		assertEquals(TestValues.blank(), polyfill);
+
+		LOGGER.debug("Check state before");
+		Optional<TestValues> before;
+		try (var _ = originalBosk.readSession()) {
+			before = originalBosk.rootReference().value().values();
+		}
+		assertEquals(Optional.empty(), before); // Not there yet
+
+		LOGGER.debug("Perform update inside polyfill");
+		Refs refs = upgradeableBosk.buildReferences(Refs.class);
+		upgradeableBosk.driver().submitReplacement(refs.valuesString(), "new value");
+		originalBosk.driver().flush(); // Not the bosk that did the update!
+
+		LOGGER.debug("Check state after");
+		String after;
+		try (var _ = originalBosk.readSession()) {
+			after = originalBosk.rootReference().value().values().get().string();
+		}
+		assertEquals("new value", after); // Now it's there
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PolyfillDriverConformanceTest.class);
+}

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/ReportingDriver.java
@@ -58,42 +58,42 @@ public class ReportingDriver implements BoskDriver {
 
 	@Override
 	public <T> void submitReplacement(Reference<T> target, T newValue) {
-		SubmitReplacement<T> op = new SubmitReplacement<>(target, newValue, context.getAttributes());
+		SubmitReplacement<T> op = new SubmitReplacement<>(target, newValue, context.get());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
-		SubmitConditionalReplacement<T> op = new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue, context.getAttributes());
+		SubmitConditionalReplacement<T> op = new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue, context.get());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
-		ConditionalCreation<T> op = new ConditionalCreation<>(target, newValue, context.getAttributes());
+		ConditionalCreation<T> op = new ConditionalCreation<>(target, newValue, context.get());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitDeletion(Reference<T> target) {
-		SubmitDeletion<T> op = new SubmitDeletion<>(target, context.getAttributes());
+		SubmitDeletion<T> op = new SubmitDeletion<>(target, context.get());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
-		SubmitConditionalDeletion<T> op = new SubmitConditionalDeletion<>(target, precondition, requiredValue, context.getAttributes());
+		SubmitConditionalDeletion<T> op = new SubmitConditionalDeletion<>(target, precondition, requiredValue, context.get());
 		updateListener.accept(op);
 		op.submitTo(downstream);
 	}
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		FlushOperation op = new FlushOperation(context.getAttributes());
+		FlushOperation op = new FlushOperation(context.get());
 		preFlushListener.accept(op);
 		op.submitTo(downstream);
 		postFlushListener.accept(op);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -1,21 +1,11 @@
 package works.bosk.testing.drivers;
 
-import java.io.IOException;
-import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
-import works.bosk.DriverFactory;
-import works.bosk.exceptions.InvalidTypeException;
-import works.bosk.junit.InjectedTest;
 import works.bosk.testing.BoskTestUtils;
 import works.bosk.testing.drivers.state.TestEntity;
-import works.bosk.testing.drivers.state.TestValues;
-import works.bosk.testing.drivers.state.UpgradeableEntity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static works.bosk.testing.BoskTestUtils.boskName;
 
 /**
  * Tests the ability of a driver to share state between two bosks.
@@ -48,51 +38,4 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 		assertEquals(expected, actual);
 	}
 
-	@InjectedTest
-	void updateInsidePolyfill_works() throws IOException, InterruptedException, InvalidTypeException {
-		// We'll use this as an honest observer of the actual state
-		LOGGER.debug("Create Original bosk");
-		Bosk<TestEntity> originalBosk = new Bosk<>(
-			boskName("Original"),
-			TestEntity.class,
-			this::initialState,
-			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
-
-		LOGGER.debug("Create Upgradeable bosk");
-		@SuppressWarnings({"rawtypes","unchecked"})
-		DriverFactory<UpgradeableEntity> upgradeableDriverFactory = (DriverFactory)driverFactory; // Yeehaw! Hope you don't care too much about the root type
-		Bosk<UpgradeableEntity> upgradeableBosk = new Bosk<>(
-			boskName("Upgradeable"),
-			UpgradeableEntity.class,
-			_ -> { throw new AssertionError("upgradeableBosk should use the state from MongoDB"); },
-			BoskConfig.<UpgradeableEntity>builder().driverFactory(upgradeableDriverFactory).build());
-
-		LOGGER.debug("Ensure polyfill returns the right value on read");
-		TestValues polyfill;
-		try (var _ = upgradeableBosk.readSession()) {
-			polyfill = upgradeableBosk.rootReference().value().values();
-		}
-		assertEquals(TestValues.blank(), polyfill);
-
-		LOGGER.debug("Check state before");
-		Optional<TestValues> before;
-		try (var _ = originalBosk.readSession()) {
-			before = originalBosk.rootReference().value().values();
-		}
-		assertEquals(Optional.empty(), before); // Not there yet
-
-		LOGGER.debug("Perform update inside polyfill");
-		Refs refs = upgradeableBosk.buildReferences(Refs.class);
-		upgradeableBosk.driver().submitReplacement(refs.valuesString(), "new value");
-		originalBosk.driver().flush(); // Not the bosk that did the update!
-
-		LOGGER.debug("Check state after");
-		String after;
-		try (var _ = originalBosk.readSession()) {
-			after = originalBosk.rootReference().value().values().get().string();
-		}
-		assertEquals("new value", after); // Now it's there
-	}
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(SharedDriverConformanceTest.class);
 }

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -25,7 +25,14 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 	@Override
 	protected void assertCorrectBoskContents() {
 		super.assertCorrectBoskContents();
-		var latecomer = new Bosk<>(BoskTestUtils.boskName("latecomer"), TestEntity.class, this::initialState, BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+		var latecomer = new Bosk<>(
+			BoskTestUtils.boskName("latecomer"),
+			TestEntity.class,
+			this::initialState,
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(driverFactory)
+				.build()
+		);
 		try {
 			latecomer.driver().flush();
 		} catch (Exception e) {

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -31,8 +31,8 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			this::initialState,
 			BoskConfig.<TestEntity>builder()
 				.driverFactory(driverFactory)
-				.build()
-		);
+				.tenancyModel(scenario.tenancyModel)
+				.build());
 		try {
 			latecomer.driver().flush();
 		} catch (Exception e) {
@@ -64,7 +64,7 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 		Bosk<UpgradeableEntity> upgradeableBosk = new Bosk<>(
 			boskName("Upgradeable"),
 			UpgradeableEntity.class,
-			(b) -> { throw new AssertionError("upgradeableBosk should use the state from MongoDB"); },
+			_ -> { throw new AssertionError("upgradeableBosk should use the state from MongoDB"); },
 			BoskConfig.<UpgradeableEntity>builder().driverFactory(upgradeableDriverFactory).build());
 
 		LOGGER.debug("Ensure polyfill returns the right value on read");

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/ConditionalCreation.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/ConditionalCreation.java
@@ -1,19 +1,18 @@
 package works.bosk.testing.drivers.operations;
 
-import java.util.Collection;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public record ConditionalCreation<T>(
 	Reference<T> target,
 	T newValue,
-	MapValue<String> diagnosticAttributes
+	BoskContext.Context boskContext
 ) implements ReplacementOperation<T> {
 
 	@Override
-	public ConditionalCreation<T> withFilteredAttributes(Collection<String> allowedNames) {
-		return new ConditionalCreation<>(target, newValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	public ConditionalCreation<T> withBoskContext(BoskContext.Context newContext) {
+		return new ConditionalCreation<>(target, newValue, newContext);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/DriverOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/DriverOperation.java
@@ -3,10 +3,9 @@ package works.bosk.testing.drivers.operations;
 import java.io.IOException;
 import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
-import works.bosk.MapValue;
 
 public sealed interface DriverOperation permits UpdateOperation, FlushOperation {
-	MapValue<String> diagnosticAttributes();
+	BoskContext.Context boskContext();
 
 	/**
 	 * Calls the appropriate <code>submit</code> method on the given driver.

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/FlushOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/FlushOperation.java
@@ -1,11 +1,11 @@
 package works.bosk.testing.drivers.operations;
 
 import java.io.IOException;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
-import works.bosk.MapValue;
 
 public record FlushOperation(
-	MapValue<String> diagnosticAttributes
+	BoskContext.Context boskContext
 ) implements DriverOperation {
 	@Override
 	public void submitTo(BoskDriver driver) throws IOException, InterruptedException {

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitConditionalDeletion.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitConditionalDeletion.java
@@ -1,26 +1,25 @@
 package works.bosk.testing.drivers.operations;
 
-import java.util.Collection;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
 import works.bosk.Identifier;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public record SubmitConditionalDeletion<T>(
 	Reference<T> target,
 	Reference<Identifier> precondition,
 	Identifier requiredValue,
-	MapValue<String> diagnosticAttributes
+	BoskContext.Context boskContext
 ) implements DeletionOperation<T>, OperationWithPrecondition {
 
 	@Override
 	public SubmitDeletion<T> unconditional() {
-		return new SubmitDeletion<>(target, diagnosticAttributes);
+		return new SubmitDeletion<>(target, boskContext);
 	}
 
 	@Override
-	public SubmitConditionalDeletion<T> withFilteredAttributes(Collection<String> allowedNames) {
-		return new SubmitConditionalDeletion<>(target, precondition, requiredValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	public SubmitConditionalDeletion<T> withBoskContext(BoskContext.Context newContext) {
+		return new SubmitConditionalDeletion<>(target, precondition, requiredValue, newContext);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitConditionalReplacement.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitConditionalReplacement.java
@@ -1,9 +1,8 @@
 package works.bosk.testing.drivers.operations;
 
-import java.util.Collection;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
 import works.bosk.Identifier;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public record SubmitConditionalReplacement<T>(
@@ -11,17 +10,17 @@ public record SubmitConditionalReplacement<T>(
 	T newValue,
 	Reference<Identifier> precondition,
 	Identifier requiredValue,
-	MapValue<String> diagnosticAttributes
+	BoskContext.Context boskContext
 ) implements ReplacementOperation<T>, OperationWithPrecondition {
 
 	@Override
 	public SubmitReplacement<T> unconditional() {
-		return new SubmitReplacement<>(target, newValue, diagnosticAttributes);
+		return new SubmitReplacement<>(target, newValue, boskContext);
 	}
 
 	@Override
-	public SubmitConditionalReplacement<T> withFilteredAttributes(Collection<String> allowedNames) {
-		return new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	public SubmitConditionalReplacement<T> withBoskContext(BoskContext.Context newContext) {
+		return new SubmitConditionalReplacement<>(target, newValue, precondition, requiredValue, newContext);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitDeletion.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitDeletion.java
@@ -1,18 +1,17 @@
 package works.bosk.testing.drivers.operations;
 
-import java.util.Collection;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public record SubmitDeletion<T>(
 	Reference<T> target,
-	MapValue<String> diagnosticAttributes
+	BoskContext.Context boskContext
 ) implements DeletionOperation<T> {
 
 	@Override
-	public SubmitDeletion<T> withFilteredAttributes(Collection<String> allowedNames) {
-		return new SubmitDeletion<>(target, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	public SubmitDeletion<T> withBoskContext(BoskContext.Context newContext) {
+		return new SubmitDeletion<>(target, newContext);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitReplacement.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/SubmitReplacement.java
@@ -1,19 +1,18 @@
 package works.bosk.testing.drivers.operations;
 
-import java.util.Collection;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public record SubmitReplacement<T>(
 	Reference<T> target,
 	T newValue,
-	MapValue<String> diagnosticAttributes
+	BoskContext.Context boskContext
 ) implements ReplacementOperation<T> {
 
 	@Override
-	public SubmitReplacement<T> withFilteredAttributes(Collection<String> allowedNames) {
-		return new SubmitReplacement<>(target, newValue, MapValue.fromFunction(allowedNames, diagnosticAttributes::get));
+	public SubmitReplacement<T> withBoskContext(BoskContext.Context newContext) {
+		return new SubmitReplacement<>(target, newValue, newContext);
 	}
 
 	@Override

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/UpdateOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/UpdateOperation.java
@@ -1,7 +1,9 @@
 package works.bosk.testing.drivers.operations;
 
 import java.util.Collection;
+import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
+import works.bosk.MapValue;
 import works.bosk.Reference;
 
 public sealed interface UpdateOperation extends DriverOperation permits
@@ -16,7 +18,17 @@ public sealed interface UpdateOperation extends DriverOperation permits
 	 */
 	boolean matchesIfApplied(UpdateOperation other);
 
-	UpdateOperation withFilteredAttributes(Collection<String> allowedNames);
+	default UpdateOperation withFilteredAttributes(Collection<String> allowedNames) {
+		return withBoskContext(
+			boskContext().withOnlyAttributes(MapValue.fromFunction(
+				allowedNames,
+				boskContext().diagnosticAttributes()::get
+			))
+		);
+	}
+
+	UpdateOperation withBoskContext(BoskContext.Context newContext);
 
 	@Override void submitTo(BoskDriver driver); // No checked exceptions
+
 }

--- a/bosk-testing/src/test/java/works/bosk/testing/drivers/ReportingDriverTest.java
+++ b/bosk-testing/src/test/java/works/bosk/testing/drivers/ReportingDriverTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import works.bosk.BoskContext;
 import works.bosk.Identifier;
 import works.bosk.ListingEntry;
-import works.bosk.MapValue;
 import works.bosk.Reference;
 import works.bosk.annotations.ReferencePath;
 import works.bosk.exceptions.InvalidTypeException;
@@ -33,7 +32,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 	AtomicInteger numFlushes;
 	Refs refs;
 	BoskContext.ContextScope contextScope;
-	MapValue<String> expectedAttributes;
+	BoskContext.Context expectedContext;
 	final Identifier id1 = Identifier.from("id1");
 	final Identifier id2 = Identifier.from("id2");
 
@@ -53,7 +52,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		bosk.driver().submitReplacement(refs.entity(id1), emptyEntityAt(refs.entity(id1)));
 		ops.clear();
 		contextScope = bosk.context().withAttribute(ReportingDriverTest.class.getSimpleName(), "expectedValue");
-		expectedAttributes = bosk.context().getAttributes();
+		expectedContext = new BoskContext.Context(bosk.context().getTenant(), bosk.context().getAttributes());
 	}
 
 	@AfterEach
@@ -73,7 +72,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<String> ref = refs.string(id1);
 		String newValue = "submitReplacement";
 		bosk.driver().submitReplacement(ref, newValue);
-		assertExpectedEvents(new SubmitReplacement<>(ref, newValue, expectedAttributes));
+		assertExpectedEvents(new SubmitReplacement<>(ref, newValue, expectedContext));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}
@@ -85,7 +84,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<Identifier> precondition = refs.id();
 		Identifier requiredValue = Identifier.from("root");
 		bosk.driver().submitConditionalReplacement(ref, newValue, precondition, requiredValue);
-		assertExpectedEvents(new SubmitConditionalReplacement<>(ref, newValue, precondition, requiredValue, expectedAttributes));
+		assertExpectedEvents(new SubmitConditionalReplacement<>(ref, newValue, precondition, requiredValue, expectedContext));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}
@@ -95,7 +94,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<TestEntity> ref = refs.entity(id2);
 		TestEntity newValue = emptyEntityAt(ref);
 		bosk.driver().submitConditionalCreation(ref, newValue);
-		assertExpectedEvents(new ConditionalCreation<>(ref, newValue, expectedAttributes));
+		assertExpectedEvents(new ConditionalCreation<>(ref, newValue, expectedContext));
 		assertNodeEquals(newValue, ref);
 		assertCorrectBoskContents();
 	}
@@ -104,13 +103,13 @@ class ReportingDriverTest extends AbstractDriverTest {
 	void submitDeletion() {
 		Reference<ListingEntry> ref = refs.entry(id1);
 		bosk.driver().submitReplacement(ref, LISTING_ENTRY);
-		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY, expectedAttributes));
+		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY, expectedContext));
 		assertNodeEquals(LISTING_ENTRY, ref);
 		assertCorrectBoskContents();
 
 		ops.clear();
 		bosk.driver().submitDeletion(ref);
-		assertExpectedEvents(new SubmitDeletion<>(ref, expectedAttributes));
+		assertExpectedEvents(new SubmitDeletion<>(ref, expectedContext));
 		assertNodeEquals(null, ref);
 		assertCorrectBoskContents();
 	}
@@ -119,7 +118,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 	void submitConditionalDeletion() {
 		Reference<ListingEntry> ref = refs.entry(id1);
 		bosk.driver().submitReplacement(ref, LISTING_ENTRY);
-		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY, expectedAttributes));
+		assertExpectedEvents(new SubmitReplacement<>(ref, LISTING_ENTRY, expectedContext));
 		assertNodeEquals(LISTING_ENTRY, ref);
 		assertCorrectBoskContents();
 
@@ -127,7 +126,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 		Reference<Identifier> precondition = refs.id();
 		Identifier requiredValue = Identifier.from("root");
 		bosk.driver().submitConditionalDeletion(ref, precondition, requiredValue);
-		assertExpectedEvents(new SubmitConditionalDeletion<>(ref, precondition, requiredValue, expectedAttributes));
+		assertExpectedEvents(new SubmitConditionalDeletion<>(ref, precondition, requiredValue, expectedContext));
 		assertNodeEquals(null, ref);
 		assertCorrectBoskContents();
 	}
@@ -143,7 +142,7 @@ class ReportingDriverTest extends AbstractDriverTest {
 			throw new NotYetImplementedException(e);
 		}
 		List<UpdateOperation> actual = ops.stream()
-			.map(op -> op.withFilteredAttributes(expectedAttributes.keySet())) // Unexpected attributes are not grounds for failing the test
+			.map(op -> op.withFilteredAttributes(expectedContext.diagnosticAttributes().keySet())) // Unexpected attributes are not grounds for failing the test
 			.collect(Collectors.toList());
 		assertEquals(asList(expectedOps), actual);
 	}


### PR DESCRIPTION
Rudimentary multitenancy: you can establish a current tenant ID on a thread, and drivers will faithfully propagate it.

This does not support separate state trees per tenant yet. That's coming. This only adds and tests the ability to establish what the current tenant is.

Lots more to be done...

Part of #257 