### PR TITLE
Add permissions to Sync Docs workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,5 +1,8 @@
 name: Sync Docs
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/boskworks/bosk/security/code-scanning/4](https://github.com/boskworks/bosk/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block either at the workflow root (so it applies to all jobs) or under the specific job, granting only what is needed. This workflow only needs to read repository contents for `actions/checkout`; it does not push changes, create releases, or modify issues/PRs. Therefore, `contents: read` is sufficient and aligns with the minimal permissions suggested by CodeQL.

The single best fix with minimal behavioral change is to add a root-level `permissions` block just under the `name:` (or under `on:`), specifying `contents: read`. This will apply to the `sync-docs` job and any future jobs that don’t override permissions. Concretely, in `.github/workflows/sync-docs.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Sync Docs` line and the `on:` block. No imports or additional definitions are needed because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
