### PR TITLE
Log replay JUnit extension

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -55,6 +55,7 @@ import static java.util.UUID.randomUUID;
 import static works.bosk.Path.parameterNameFromSegment;
 import static works.bosk.ReferenceUtils.rawClass;
 import static works.bosk.TypeValidation.validateType;
+import static works.bosk.logging.MappedDiagnosticContext.setupMDC;
 
 /**
  * A mutable container for an immutable object tree with cross-tree {@link Reference}s,
@@ -283,57 +284,72 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 
 		@Override
 		public <T> void submitReplacement(Reference<T> target, T newValue) {
-			assertTenantEstablished();
-			assertCorrectBosk(target);
-			downstream.submitReplacement(target, newValue);
+			try (var _ = setupMDC(name(), instanceID())) {
+				assertTenantEstablished();
+				assertCorrectBosk(target);
+				downstream.submitReplacement(target, newValue);
+			}
 		}
 
 		@Override
 		public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
-			assertTenantEstablished();
-			assertCorrectBosk(target);
-			assertCorrectBosk(precondition);
-			downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+			try (var _ = setupMDC(name(), instanceID())) {
+				assertTenantEstablished();
+				assertCorrectBosk(target);
+				assertCorrectBosk(precondition);
+				downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+			}
 		}
 
 		@Override
 		public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
-			assertTenantEstablished();
-			assertCorrectBosk(target);
-			downstream.submitConditionalCreation(target, newValue);
+			try (var _ = setupMDC(name(), instanceID())) {
+				assertTenantEstablished();
+				assertCorrectBosk(target);
+				downstream.submitConditionalCreation(target, newValue);
+			}
 		}
 
 		@Override
 		public <T> void submitDeletion(Reference<T> target) {
-			if (target.path().isEmpty()) {
-				// TODO: Augment dereferencer so it can tell us this for all references, not just the root
-				throw new IllegalArgumentException("Cannot delete root object");
+			try (var _ = setupMDC(name(), instanceID())) {
+				if (target.path().isEmpty()) {
+					// TODO: Augment dereferencer so it can tell us this for all references, not just the root
+					throw new IllegalArgumentException("Cannot delete root object");
+				}
+				assertTenantEstablished();
+				assertCorrectBosk(target);
+				downstream.submitDeletion(target);
 			}
-			assertTenantEstablished();
-			assertCorrectBosk(target);
-			downstream.submitDeletion(target);
 		}
 
 		@Override
 		public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
-			assertTenantEstablished();
-			assertCorrectBosk(target);
-			assertCorrectBosk(precondition);
-			downstream.submitConditionalDeletion(target, precondition, requiredValue);
+			try (var _ = setupMDC(name(), instanceID())) {
+				assertTenantEstablished();
+				assertCorrectBosk(target);
+				assertCorrectBosk(precondition);
+				downstream.submitConditionalDeletion(target, precondition, requiredValue);
+			}
 		}
 
 		@Override
 		public <RR extends StateTreeNode> InitialState<RR> initialState(Class<RR> rootType) throws InvalidTypeException, IOException, InterruptedException {
-			return downstream.initialState(rootType)
-				.cast(rootRef.targetClass())
-				.cast(rootType);
+			try (var _ = setupMDC(name(), instanceID())) {
+				return downstream.initialState(rootType)
+					.cast(rootRef.targetClass())
+					.cast(rootType);
+			}
 		}
 
 		@Override
 		public void flush() throws IOException, InterruptedException {
 			// Flushes can lead to downstream updates against any number of different tenants.
 			// We must clear the tenant context because other drivers have no way to do so.
-			try (var _ = context.withTenantTemporarilyIgnored()) {
+			try (
+				var _ = setupMDC(name(), instanceID());
+				var _ = context.withTenantTemporarilyIgnored()
+			) {
 				downstream.flush();
 			}
 		}

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -95,7 +95,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	private final BoskContext context;
 	private final TenancyModel tenancyModel;
 
-	private final InitialDriver initialDriver;
+	private final IngressDriver ingressDriver;
 	private final LocalDriver localDriver;
 	private final RootRef rootRef;
 	private final ThreadLocal<InitialState<R>> rootSnapshot = new ThreadLocal<>();
@@ -156,11 +156,11 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		// to do such things as create References, so it needs the rest of the
 		// initialization to have completed already.
 		//
-		this.initialDriver = new InitialDriver(requireNonNull(boskConfig.driverFactory().build(boskInfo, this.localDriver)));
+		this.ingressDriver = new IngressDriver(requireNonNull(boskConfig.driverFactory().build(boskInfo, this.localDriver)));
 		this.hookRegistrar = requireNonNull(boskConfig.registrarFactory().build(boskInfo, this::localRegisterHook));
 
 		try {
-			this.currentState = initialDriver
+			this.currentState = ingressDriver
 				.initialState(rootRef.targetClass())
 				.cast(rootRef.targetClass()); // Double check!
 		} catch (InvalidTypeException | IOException | InterruptedException e) {
@@ -236,7 +236,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * @return the {@link BoskDriver} to use for submitting updates to this bosk's state tree.
 	 */
 	public BoskDriver driver() {
-		return initialDriver;
+		return ingressDriver;
 	}
 
 	/**
@@ -262,7 +262,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 */
 	@SuppressWarnings("unchecked")
 	public <D extends BoskDriver> D getDriver(Class<? super D> driverType) {
-		var userSuppliedDriver = initialDriver.downstream;
+		var userSuppliedDriver = ingressDriver.downstream;
 		if (driverType.isInstance(userSuppliedDriver)) {
 			return (D) driverType.cast(userSuppliedDriver);
 		} else {
@@ -274,10 +274,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 * We wrap the user-supplied driver with one of these so we're in control
 	 * of the incoming driver operations.
 	 */
-	final class InitialDriver implements BoskDriver {
+	final class IngressDriver implements BoskDriver {
 		final BoskDriver downstream;
 
-		public InitialDriver(BoskDriver downstream) {
+		public IngressDriver(BoskDriver downstream) {
 			this.downstream = downstream;
 		}
 

--- a/bosk-core/src/main/java/works/bosk/logging/MappedDiagnosticContext.java
+++ b/bosk-core/src/main/java/works/bosk/logging/MappedDiagnosticContext.java
@@ -4,6 +4,7 @@ import org.slf4j.MDC;
 import works.bosk.Identifier;
 
 public final class MappedDiagnosticContext {
+	private MappedDiagnosticContext() {}
 
 	public static MDCScope setupMDC(String boskName, Identifier boskID) {
 		MDCScope result = new MDCScope();
@@ -16,7 +17,6 @@ public final class MappedDiagnosticContext {
 	 * This is like {@link org.slf4j.MDC.MDCCloseable} except instead of
 	 * deleting the MDC entry at the end, it restores it to its prior value,
 	 * which allows us to nest these.
-	 *
 	 * <p>
 	 * You are going to have the urge to use this in an existing
 	 * try block that has catch and finally clauses. Resist that urge.
@@ -25,6 +25,7 @@ public final class MappedDiagnosticContext {
 	 * You really want to use this in a try block that has no catch or finally clause.
 	 */
 	public static final class MDCScope implements AutoCloseable {
+		MDCScope(){}
 		final String oldName = MDC.get(MdcKeys.BOSK_NAME);
 		final String oldID = MDC.get(MdcKeys.BOSK_INSTANCE_ID);
 		@Override public void close() {

--- a/bosk-core/src/main/java/works/bosk/logging/MdcKeys.java
+++ b/bosk-core/src/main/java/works/bosk/logging/MdcKeys.java
@@ -11,11 +11,15 @@ import works.bosk.Bosk;
 public final class MdcKeys {
 	/**
 	 * The value of {@link Bosk#name()}.
+	 * <p>
+	 * Propagated automatically by drivers.
 	 */
 	public static final String BOSK_NAME = "bosk.name";
 
 	/**
 	 * The value of {@link Bosk#instanceID()}.
+	 * <p>
+	 * Propagated automatically by drivers.
 	 */
 	public static final String BOSK_INSTANCE_ID = "bosk.instanceID";
 

--- a/bosk-logback/build.gradle
+++ b/bosk-logback/build.gradle
@@ -2,8 +2,8 @@
 dependencies {
 	api project(":bosk-core")
 	implementation libs.logback.classic
-	implementation platform(libs.junit.bom)
-	implementation libs.junit.api
+	compileOnly platform(libs.junit.bom)
+	compileOnly libs.junit.api
 	testImplementation libs.junit.params
 	testImplementation project(":bosk-junit")
 }

--- a/bosk-logback/build.gradle
+++ b/bosk-logback/build.gradle
@@ -2,4 +2,8 @@
 dependencies {
 	api project(":bosk-core")
 	implementation libs.logback.classic
+	implementation platform(libs.junit.bom)
+	implementation libs.junit.api
+	testImplementation libs.junit.params
+	testImplementation project(":bosk-junit")
 }

--- a/bosk-logback/src/main/java/module-info.java
+++ b/bosk-logback/src/main/java/module-info.java
@@ -7,8 +7,14 @@ module works.bosk.logback {
 	requires transitive ch.qos.logback.core;
 	requires transitive org.slf4j;
 	requires transitive works.bosk.core;
+
+	// We use requires static for JUnit dependencies so that people using
+	// this for logback aren't forced also to include JUnit.
+	// Presumably, everyone wanting this for JUnit will already have it as a dependency anyway.
 	requires static org.junit.platform.commons;
 	requires static org.junit.jupiter.api; // For replay
 
 	exports works.bosk.logback;
+
+	provides org.junit.jupiter.api.extension.Extension with works.bosk.logback.ReplayLogsOnFailureExtension;
 }

--- a/bosk-logback/src/main/java/module-info.java
+++ b/bosk-logback/src/main/java/module-info.java
@@ -7,8 +7,8 @@ module works.bosk.logback {
 	requires transitive ch.qos.logback.core;
 	requires transitive org.slf4j;
 	requires transitive works.bosk.core;
-	requires org.junit.platform.commons;
-	requires transitive org.junit.jupiter.api; // For replay
+	requires static org.junit.platform.commons;
+	requires static org.junit.jupiter.api; // For replay
 
 	exports works.bosk.logback;
 }

--- a/bosk-logback/src/main/java/module-info.java
+++ b/bosk-logback/src/main/java/module-info.java
@@ -1,11 +1,14 @@
 /**
  * Logback-specific logging utilities.
+ * @see works.bosk.logback
  */
 module works.bosk.logback {
 	requires transitive ch.qos.logback.classic;
 	requires transitive ch.qos.logback.core;
 	requires transitive org.slf4j;
 	requires transitive works.bosk.core;
+	requires org.junit.platform.commons;
+	requires transitive org.junit.jupiter.api; // For replay
 
 	exports works.bosk.logback;
 }

--- a/bosk-logback/src/main/java/works/bosk/logback/BoskLogFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/BoskLogFilter.java
@@ -32,8 +32,8 @@ import static works.bosk.logging.MdcKeys.BOSK_INSTANCE_ID;
  * This class infers that a log message is associated with a particular bosk
  * by checking the MDC for the key {@link MdcKeys#BOSK_INSTANCE_ID},
  * which you can set using {@link works.bosk.logging.MappedDiagnosticContext#setupMDC setupMDC}.
- * <p>
- * <em>Note</em>: most bosk drivers don't set this MDC key. TODO: Improve this.
+ * This is part of the driver conformance test,
+ * so all drivers should be propagating this MDC key.
  * <p>
  * Log levels are determined using the following precedence:
  * <ol>

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -6,14 +6,14 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.MDC;
 import org.slf4j.Marker;
-import works.bosk.logback.ReplayLogsOnFailureExtension.Overrides;
-import works.bosk.logback.ReplayLogsOnFailureExtension.QueueContents;
 
 import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
 import static java.util.Objects.requireNonNull;
@@ -291,5 +291,9 @@ public class RecordingTurboFilter extends TurboFilter {
 			queue.offer(event);
 		}
 	}
+
+	record Overrides(@Nullable Boolean enabled, @Nullable Integer capacity) {}
+
+	record QueueContents(Collection<ILoggingEvent> events, long dropped) {}
 
 }

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -131,14 +131,7 @@ public class RecordingTurboFilter extends TurboFilter {
 	// These things are static so the test lifecycle methods don't need to
 	// get their hands on the filter instance.
 
-	/**
-	 * If there's no entry for a given test ID, replay is disabled.
-	 * That is different from an {@link Overrides} where everything is null,
-	 * which means "use the filter's global defaults"
-	 * (which might also mean replay is disabled depending on {@link #enabled}).
-	 */
 	private static final ConcurrentHashMap<String, Overrides> overridesByTestId = new ConcurrentHashMap<>();
-
 	private static final ConcurrentHashMap<String, LogEventBuffer> buffersByTestId = new ConcurrentHashMap<>();
 	private static final ConcurrentHashMap<String, String> testIdsByRoutingKey = new ConcurrentHashMap<>();
 

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -158,7 +158,12 @@ public class RecordingTurboFilter extends TurboFilter {
 	 */
 	public void setRoutingKey(String routingKey) { this.routingKey = routingKey; }
 
-	public void setCapacity(int capacity) { this.capacity = capacity; }
+	public void setCapacity(int capacity) {
+		if (capacity < 0) {
+			throw new IllegalArgumentException("capacity must be non-negative");
+		}
+		this.capacity = capacity;
+	}
 
 	public void setLevel(Level level) { this.level = level; }
 
@@ -226,6 +231,11 @@ public class RecordingTurboFilter extends TurboFilter {
 		int effectiveCapacity = (overrides != null && overrides.capacity() != null)
 			? overrides.capacity()
 			: this.capacity;
+
+		if (effectiveCapacity <= 0) {
+			// Bail out before bothering to instantiate the event object
+			return NEUTRAL;
+		}
 
 		// Capture event for potential replay on failure
 		LoggingEvent event = new LoggingEvent(

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -9,7 +9,7 @@ import ch.qos.logback.core.spi.FilterReply;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.MDC;
 import org.slf4j.Marker;
 import works.bosk.logback.ReplayLogsOnFailureExtension.Overrides;
@@ -52,6 +52,12 @@ import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
  *       The filter only captures events that reach it in the filter chain.
  *       If you have some other filter that drops events before they reach this one,
  *       those events won't be captured and thus won't be replayed on failure.
+ *   </li>
+ *   <li>
+ *       The filter captures the MDC at the time of logging,
+ *       which is necessary to avoid getting the wrong values at replay time,
+ *       but it adds overhead even for events that are ultimately discarded.
+ *       This overhead is O(n) in the number of MDC entries.
  *   </li>
  * </ul>
  * <h2>Configuration properties:</h2>
@@ -231,6 +237,10 @@ public class RecordingTurboFilter extends TurboFilter {
 			params
 		);
 		event.setLoggerContext(logger.getLoggerContext());
+		event.addMarker(marker);
+
+		// We need to capture the current MDC. Can't wait until replay.
+		event.setMDCPropertyMap(MDC.getCopyOfContextMap()); // ew, this is O(n)
 
 		LogEventBuffer buffer = buffersByTestId
 			.computeIfAbsent(testIdValue, _ -> new LogEventBuffer(effectiveCapacity));
@@ -246,7 +256,7 @@ public class RecordingTurboFilter extends TurboFilter {
 			return new QueueContents(List.of(), 0);
 		}
 		// This isn't atomic, but the dropped count isn't really important enough to worry
-		return new QueueContents(buffer.queue, buffer.dropped.get());
+		return new QueueContents(buffer.queue, buffer.count.get() - buffer.queue.size());
 	}
 
 	static void cleanupForTest(String testId) {
@@ -260,17 +270,18 @@ public class RecordingTurboFilter extends TurboFilter {
 
 	static class LogEventBuffer {
 		private final ConcurrentLinkedQueue<ILoggingEvent> queue = new ConcurrentLinkedQueue<>();
-		private final AtomicInteger dropped = new AtomicInteger(0);
 		private final int capacity;
+		private final AtomicLong count = new AtomicLong(0);
 
 		LogEventBuffer(int capacity) {
 			this.capacity = capacity;
 		}
 
 		void offer(ILoggingEvent event) {
-			if (queue.size() >= capacity) {
+			long count = this.count.incrementAndGet();
+			if (count > capacity) {
 				queue.poll();
-				dropped.incrementAndGet();
+			} else {
 			}
 			queue.offer(event);
 		}

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -283,6 +283,7 @@ public class RecordingTurboFilter extends TurboFilter {
 		}
 
 		void offer(ILoggingEvent event) {
+			assert capacity >= 1: "If capacity is not at least 1, you shouldn't have created the event object";
 			if (this.count.incrementAndGet() > capacity) {
 				// Once we're past capacity, remove the oldest event each time to make room for the new one.
 				queue.poll();

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -17,6 +17,7 @@ import org.slf4j.Marker;
 
 import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
 import static java.util.Objects.requireNonNull;
+import static works.bosk.logback.RecordingTurboFilter.Overrides.NONE;
 
 /**
  * Records log events that would otherwise be suppressed so they can be replayed on test failure.
@@ -162,7 +163,12 @@ public class RecordingTurboFilter extends TurboFilter {
 	public void setLevel(Level level) { this.level = level; }
 
 	static void putOverrides(String testId, Overrides overrides) {
-		overridesByTestId.put(testId, overrides);
+		if (overrides == null || NONE.equals(overrides)) {
+			// We want to keep this map tidy so we can tell when it's empty
+			overridesByTestId.remove(testId);
+		} else {
+			overridesByTestId.put(testId, overrides);
+		}
 	}
 
 	static void removeOverrides(String testId) {
@@ -184,6 +190,10 @@ public class RecordingTurboFilter extends TurboFilter {
 			// We don't modify their behaviour.
 			return NEUTRAL;
 		}
+
+		// We could exit early here if !enabled and there are no overrides.
+		// But I think it's best if adding an override to one test doesn't alter
+		// the behaviour of other tests in any way.
 
 		String testIdValue = MDC.get(TEST_ID_KEY);
 		String routingKeyValue = MDC.get(this.routingKey);
@@ -292,7 +302,9 @@ public class RecordingTurboFilter extends TurboFilter {
 		}
 	}
 
-	record Overrides(@Nullable Boolean enabled, @Nullable Integer capacity) {}
+	record Overrides(@Nullable Boolean enabled, @Nullable Integer capacity) {
+		static final Overrides NONE = new Overrides(null, null);
+	}
 
 	record QueueContents(Collection<ILoggingEvent> events, long dropped) {}
 

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -1,0 +1,279 @@
+package works.bosk.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+import works.bosk.logback.ReplayLogsOnFailureExtension.Overrides;
+import works.bosk.logback.ReplayLogsOnFailureExtension.QueueContents;
+
+import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
+
+/**
+ * Records log events that would otherwise be suppressed so they can be replayed on test failure.
+ * <p>
+ * To enable this feature, first add this filter to your {@code logback.xml}:
+ * <pre>
+ *   &lt;turboFilter class="works.bosk.logback.RecordingTurboFilter"/&gt;
+ * </pre>
+ * Then, annotate your test class or method with {@link ReplayLogsOnFailure @ReplayLogsOnFailure}.
+ * <h2>Effect</h2>
+ * This filter offers the illusion that you retroactively turned on debug logging for a failed test,
+ * even if the logs were originally filtered out by logback's normal configuration.
+ * <h3>Caveats</h3>
+ * <ul>
+ *   <li>
+ *       The filter does <em>not</em> cause level queries like {@code isDebugEnabled} to return true.
+ *       This means that if your code is written like this:
+ *       <pre>
+ *       if (logger.isDebugEnabled()) {
+ *           logger.debug(...);
+ *       }
+ *       </pre>
+ *       then this event won't be computed or logged, even if the filter is configured to capture debug events.
+ *   </li>
+ *   <li>
+ *       The filter buffers the events in memory and does not format the messages until replay time.
+ *       This means parameters passed to the logging methods will be stored for some time,
+ *       so if the objects are mutated after the logging event,
+ *       those changes <em>will</em> be reflected in the replayed logs,
+ *       making them differ from what you would have seen if the events were logged normally.
+ *       It can also add to the memory overhead if the objects are large.
+ *   </li>
+ *   <li>
+ *       The filter only captures events that reach it in the filter chain.
+ *       If you have some other filter that drops events before they reach this one,
+ *       those events won't be captured and thus won't be replayed on failure.
+ *   </li>
+ * </ul>
+ * <h2>Configuration properties:</h2>
+ * <ul>
+ *   <li>
+ *       {@code enabled} - Whether to record log events.
+ *       Defaults to {@code false} so that only tests that explicitly
+ *       opt in using {@link ReplayLogsOnFailure @ReplayLogsOnFailure}
+ *       will have the overhead of buffering the logs.
+ *   </li>
+ *   <li>
+ *       {@code level} - Finest-grained log level to record. Defaults to {@code DEBUG}
+ *   </li>
+ *   <li>
+ *       {@code capacity} - Max events to buffer per test, to put a limit on memory consumption.
+ *       If there are more events, the oldest will be dropped. Defaults to 1000.
+ *   </li>
+ *   <li>
+ *       {@code routingKey} - MDC key used to route events to correct test buffer; details below.
+ *       Defaults to {@code bosk.junit.testId}
+ *   </li>
+ * </ul>
+ * <p>
+ * The default configuration is equivalent to:
+ * <pre>
+ *   &lt;turboFilter class="works.bosk.logback.RecordingTurboFilter"&gt;
+ *       &lt;enabled&gt;false&lt;/enabled&gt;
+ *       &lt;level&gt;DEBUG&lt;/level&gt;
+ *       &lt;capacity&gt;1000&lt;/capacity&gt;
+ *       &lt;routingKey&gt;bosk.junit.testId&lt;/routingKey&gt;
+ *   &lt;/turboFilter&gt;
+ * </pre>
+ *
+ * The {@code enabled} and {@code capacity} properties can be overridden on a per-test basis using the {@link ReplayLogsOnFailure @ReplayLogsOnFailure} annotation's properties.
+ * {@code routingKey} cannot be overridden because the routing key is the very thing that tells us which test is running (see below).
+ * {@code level} also cannot be overridden per test because
+ * it is crucial for performance that the filter quickly discards events that are too fine-grained.
+ * <h2>Routing key</h2>
+ *
+ * The filter needs a way to associate log events with the correct test.
+ * For simple single-threaded tests, the JUnit extension will set MDC key {@code bosk.junit.testId}
+ * to the test's unique ID, and the filter can use that directly.
+ * <p>
+ * However, if the code you're testing is multithreaded, it's unlikely to propagate
+ * the test ID to other threads, so the filter won't know which test the events belong to.
+ * In this case, you can specify some other MDC key that your code <em>does</em> propagate across threads.
+ * This is the <em>routing key</em>: the filter will attempt to associate the routing key with
+ * the test ID whenever it sees them together in MDC.
+ * Assuming the first log event for a test has both the test ID and routing key in MDC,
+ * the filter will remember that association
+ * and use it for subsequent events that only have the routing key.
+ * <p>
+ * Concretely, this works well for {@code bosk.instanceID},
+ * which is an MDC key automatically propagated by bosk drivers.
+ *
+ * @see ReplayLogsOnFailure
+ * @see ReplayLogsOnFailureExtension
+ * @see works.bosk.logback
+ */
+public class RecordingTurboFilter extends TurboFilter {
+	public static final String TEST_ID_KEY = "bosk.junit.testId";
+	public static final String DEFAULT_ROUTING_KEY = "bosk.junit.testId";
+	public static final int DEFAULT_CAPACITY = 1000;
+
+	private boolean enabled = false;
+	private int capacity = DEFAULT_CAPACITY;
+	private Level level = Level.DEBUG;
+	private String routingKey = DEFAULT_ROUTING_KEY;
+
+	// These things are static so the test lifecycle methods don't need to
+	// get their hands on the filter instance.
+
+	/**
+	 * If there's no entry for a given test ID, replay is disabled.
+	 * That is different from an {@link Overrides} where everything is null,
+	 * which means "use the filter's global defaults"
+	 * (which might also mean replay is disabled depending on {@link #enabled}).
+	 */
+	private static final ConcurrentHashMap<String, Overrides> overridesByTestId = new ConcurrentHashMap<>();
+
+	private static final ConcurrentHashMap<String, LogEventBuffer> buffersByTestId = new ConcurrentHashMap<>();
+	private static final ConcurrentHashMap<String, String> testIdsByRoutingKey = new ConcurrentHashMap<>();
+
+	// Setters for logback configuration properties
+
+	public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+	/**
+	 * The MDC key to use for routing log events to the correct test's buffer.
+	 * <p>
+	 * For single-threaded tests, "bosk.junit.testId" will work:
+	 * the JUnit extension will set that MDC key as appropriate.
+	 * For tests involving multiple threads, you'll need to pick an MDC key
+	 * that the tested code propagates, and the extension will try to
+	 * associate values of that key with the appropriate test ID.
+	 * <p>
+	 * For bosk tests specifically, "bosk.instanceID" is a good choice for this.
+	 */
+	public void setRoutingKey(String routingKey) { this.routingKey = routingKey; }
+
+	public void setCapacity(int capacity) { this.capacity = capacity; }
+
+	public void setLevel(Level level) { this.level = level; }
+
+	static void putOverrides(String testId, Overrides overrides) {
+		overridesByTestId.put(testId, overrides);
+	}
+
+	static void removeOverrides(String testId) {
+		overridesByTestId.remove(testId);
+		cleanupForTest(testId);
+	}
+
+	@Override
+	public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
+		// Note: Always return NEUTRAL. This lets events flow through the normal appender pipeline.
+
+		// Check level early to quickly discard fine-grained events
+		if (!level.isGreaterOrEqual(this.level)) {
+			return NEUTRAL;
+		}
+
+		if (format == null) {
+			// This happens for a call like isDebugEnabled.
+			// We don't modify their behaviour.
+			return NEUTRAL;
+		}
+
+		String testIdValue = MDC.get(TEST_ID_KEY);
+		String routingKeyValue = MDC.get(this.routingKey);
+		Overrides overrides;
+
+		if (testIdValue == null) {
+			// No test ID in MDC - check for routing key
+			if (routingKeyValue == null) {
+				// No way to associate this event with a test
+				return NEUTRAL;
+			} else {
+				testIdValue = testIdsByRoutingKey.get(routingKeyValue);
+				if (testIdValue == null) {
+					// No test associated with this routing key
+					return NEUTRAL;
+				} else {
+					// Ok, we figured out the test ID from routing key
+					overrides = overridesByTestId.get(testIdValue);
+				}
+			}
+		} else {
+			// We have the test ID directly from MDC
+			overrides = overridesByTestId.get(testIdValue);
+
+			// If there's also a routing key in MDC, remember the association
+			routingKeyValue = MDC.get(this.routingKey);
+			if (routingKeyValue != null) {
+				testIdsByRoutingKey.put(routingKeyValue, testIdValue);
+			}
+		}
+
+		boolean isEnabled = (overrides != null && overrides.enabled() != null)
+			? overrides.enabled()
+			: this.enabled;
+		if (!isEnabled) {
+			return NEUTRAL;
+		}
+
+		int effectiveCapacity = (overrides != null && overrides.capacity() != null)
+			? overrides.capacity()
+			: this.capacity;
+
+		// Capture event for potential replay on failure
+		LoggingEvent event = new LoggingEvent(
+			logger.getName(),
+			logger,
+			level,
+			format,
+			t,
+			params
+		);
+		event.setLoggerContext(logger.getLoggerContext());
+
+		LogEventBuffer buffer = buffersByTestId
+			.computeIfAbsent(testIdValue, _ -> new LogEventBuffer(effectiveCapacity));
+
+		buffer.offer(event);
+
+		return NEUTRAL;
+	}
+
+	QueueContents queueContents(String testId) {
+		LogEventBuffer buffer = buffersByTestId.remove(testId);
+		if (buffer == null) {
+			return new QueueContents(List.of(), 0);
+		}
+		// This isn't atomic, but the dropped count isn't really important enough to worry
+		return new QueueContents(buffer.queue, buffer.dropped.get());
+	}
+
+	static void cleanupForTest(String testId) {
+		testIdsByRoutingKey.forEach((routingKeyValue, associatedTestId) -> {
+			if (testId.equals(associatedTestId)) {
+				testIdsByRoutingKey.remove(routingKeyValue);
+			}
+		});
+		buffersByTestId.remove(testId);
+	}
+
+	static class LogEventBuffer {
+		private final ConcurrentLinkedQueue<ILoggingEvent> queue = new ConcurrentLinkedQueue<>();
+		private final AtomicInteger dropped = new AtomicInteger(0);
+		private final int capacity;
+
+		LogEventBuffer(int capacity) {
+			this.capacity = capacity;
+		}
+
+		void offer(ILoggingEvent event) {
+			if (queue.size() >= capacity) {
+				queue.poll();
+				dropped.incrementAndGet();
+			}
+			queue.offer(event);
+		}
+	}
+
+}

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -16,6 +16,7 @@ import works.bosk.logback.ReplayLogsOnFailureExtension.Overrides;
 import works.bosk.logback.ReplayLogsOnFailureExtension.QueueContents;
 
 import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Records log events that would otherwise be suppressed so they can be replayed on test failure.
@@ -250,7 +251,8 @@ public class RecordingTurboFilter extends TurboFilter {
 		event.addMarker(marker);
 
 		// We need to capture the current MDC. Can't wait until replay.
-		event.setMDCPropertyMap(MDC.getCopyOfContextMap()); // ew, this is O(n)
+		event.setMDCPropertyMap(requireNonNull(MDC.getCopyOfContextMap(), // ew, this is O(n)
+			"MDC can't be absent here!"));
 
 		LogEventBuffer buffer = buffersByTestId
 			.computeIfAbsent(testIdValue, _ -> new LogEventBuffer(effectiveCapacity));

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -278,10 +278,9 @@ public class RecordingTurboFilter extends TurboFilter {
 		}
 
 		void offer(ILoggingEvent event) {
-			long count = this.count.incrementAndGet();
-			if (count > capacity) {
+			if (this.count.incrementAndGet() > capacity) {
+				// Once we're past capacity, remove the oldest event each time to make room for the new one.
 				queue.poll();
-			} else {
 			}
 			queue.offer(event);
 		}

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailure.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailure.java
@@ -11,10 +11,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static works.bosk.logback.ReplayLogsOnFailureExtension.UNSPECIFIED_CAPACITY;
 
 /**
- * Configures log replay on failure for a test class.
+ * Configures log replay on failure for a test.
  * <p>
  * When a test fails, any log events at or above the configured level are captured
  * and printed to the console, helping diagnose test failures.
+ * <p>
+ * Can be applied at the class or method level.
+ * Method-level annotations override class-level settings in their entirety.
  * <p>
  * <em>For a complete how-to guide, see the package documentation for {@link works.bosk.logback}.</em>
  *

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailure.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailure.java
@@ -1,0 +1,41 @@
+package works.bosk.logback;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static works.bosk.logback.ReplayLogsOnFailureExtension.UNSPECIFIED_CAPACITY;
+
+/**
+ * Configures log replay on failure for a test class.
+ * <p>
+ * When a test fails, any log events at or above the configured level are captured
+ * and printed to the console, helping diagnose test failures.
+ * <p>
+ * <em>For a complete how-to guide, see the package documentation for {@link works.bosk.logback}.</em>
+ *
+ * @see ReplayLogsOnFailureExtension
+ * @see RecordingTurboFilter
+ * @see works.bosk.logback
+ */
+@Retention(RUNTIME)
+@Target({TYPE,METHOD})
+@Inherited
+@ExtendWith(ReplayLogsOnFailureExtension.class)
+public @interface ReplayLogsOnFailure {
+	/**
+	 * Whether log replay is enabled for this test class.
+	 * Default is true.
+	 */
+	boolean enabled() default true;
+
+	/**
+	 * Maximum number of log events to buffer per test.
+	 * When capacity is reached, oldest events are dropped.
+	 */
+	int capacity() default UNSPECIFIED_CAPACITY;
+}

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -3,9 +3,7 @@ package works.bosk.logback;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.OutputStreamAppender;
-import java.util.Collection;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -15,6 +13,8 @@ import org.slf4j.MDC;
 
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+import static works.bosk.logback.RecordingTurboFilter.Overrides;
+import static works.bosk.logback.RecordingTurboFilter.QueueContents;
 import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 
 /**
@@ -40,16 +40,6 @@ import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEachCallback {
 
 	static final int UNSPECIFIED_CAPACITY = -1;
-
-	/**
-	 * Per-test config overrides.
-	 * <p>
-	 * Null values mean "nothing is overridden" - the filter will use its global defaults.
-	 */
-	record Overrides(
-		@Nullable Boolean enabled,
-		@Nullable Integer capacity
-	) {}
 
 	@Override
 	public void beforeEach(ExtensionContext context) {
@@ -115,10 +105,8 @@ public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEa
 		return null;
 	}
 
-	record QueueContents(Collection<ILoggingEvent> events, long dropped) {}
-
 	private void replay(QueueContents queueContents) {
-		if (queueContents.events.isEmpty()) {
+		if (queueContents.events().isEmpty()) {
 			// This happens in two cases:
 			// - The test emitted no logs
 			// - Replay is disabled for this test

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -37,9 +37,8 @@ import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
  * @see RecordingTurboFilter
  * @see works.bosk.logback
  */
-	public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEachCallback {
+public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEachCallback {
 
-	static final String UNSPECIFIED_MDC_KEY = "";
 	static final int UNSPECIFIED_CAPACITY = -1;
 
 	/**

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -1,0 +1,191 @@
+package works.bosk.logback;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.OutputStreamAppender;
+import java.util.Collection;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
+
+/**
+ * JUnit 5 extension that implements log replay on failure.
+ * <p>
+ * This class is invoked automatically by {@link ReplayLogsOnFailure} and
+ * coordinates with {@link RecordingTurboFilter}:
+ * <ul>
+ *   <li>
+ *       Before each test, it sets the MDC key {@code bosk.junit.testId} to the test's unique ID,
+ *       allowing the filter to associate log events with this test.
+ *   </li>
+ *   <li>
+ *       After each test, if the test failed, it retrieves the recorded events from the filter
+ *       and prints them to the console.
+ *   </li>
+ * </ul>
+ *
+ * @see ReplayLogsOnFailure
+ * @see RecordingTurboFilter
+ * @see works.bosk.logback
+ */
+	public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEachCallback {
+
+	static final String UNSPECIFIED_MDC_KEY = "";
+	static final int UNSPECIFIED_CAPACITY = -1;
+
+	/**
+	 * Per-test config overrides.
+	 * <p>
+	 * Null values mean "nothing is overridden" - the filter will use its global defaults.
+	 */
+	record Overrides(
+		@Nullable Boolean enabled,
+		@Nullable Integer capacity
+	) {}
+
+	@Override
+	public void beforeEach(ExtensionContext context) {
+		String testId = context.getUniqueId();
+		MDC.put(TEST_ID_KEY, testId);
+		RecordingTurboFilter.putOverrides(testId, resolveOverrides(context));
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) {
+		var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+		String testId = context.getUniqueId();
+
+		if (context.getExecutionException().isPresent()) {
+			if (findFilter(loggerContext) instanceof RecordingTurboFilter filter) {
+				// This is what it's all about
+				replay(filter.queueContents(testId));
+			}
+		}
+
+		RecordingTurboFilter.removeOverrides(testId);
+		MDC.remove(TEST_ID_KEY);
+	}
+
+	private Overrides resolveOverrides(ExtensionContext context) {
+		var element = context.getElement().orElse(null);
+		if (element == null) {
+			// No annotated element, no overrides
+			return new Overrides(null, null);
+		}
+
+		var annotation = findAnnotation(element, ReplayLogsOnFailure.class).orElse(null);
+		if (annotation == null) {
+			var testClass = context.getRequiredTestClass();
+			annotation = testClass.getAnnotation(ReplayLogsOnFailure.class);
+		}
+		if (annotation == null) {
+			// No annotation, no overrides
+			return new Overrides(null, null);
+		}
+
+		// For the enabled flag, the annotation always overrides the global default.
+		// The presence of the annotation is enough to indicate that the user has opted in.
+		boolean enabled = annotation.enabled();
+
+		// For capacity, if unspecified, use the global default from the filter.
+		Integer capacity = (annotation.capacity() == UNSPECIFIED_CAPACITY)
+			? null
+			: annotation.capacity();
+
+		return new Overrides(enabled, capacity);
+	}
+
+	@Nullable
+	private static RecordingTurboFilter findFilter(LoggerContext loggerContext) {
+		for (var f : loggerContext.getTurboFilterList()) {
+			if (f instanceof RecordingTurboFilter) {
+				return (RecordingTurboFilter) f;
+			}
+		}
+		return null;
+	}
+
+	record QueueContents(Collection<ILoggingEvent> events, int dropped) {}
+
+	private void replay(QueueContents queueContents) {
+		if (queueContents.events.isEmpty()) {
+			// This happens in two cases:
+			// - The test emitted no logs
+			// - Replay is disabled for this test
+			// In either case, announcing that we're replaying logs would be confusing.
+			return;
+		}
+		StringBuilder header = new StringBuilder("--- TEST FAILED: REPLAYING LOGS ---");
+		var dropped = queueContents.dropped();
+		if (dropped > 0) {
+			var totalEvents = queueContents.events().size() + dropped;
+			header
+				.append(" (")
+				.append(dropped)
+				.append(" of ")
+				.append(totalEvents)
+				.append(" events dropped due to capacity limit)");
+		}
+		System.out.println(header);
+
+		var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		var rootLogger = loggerContext.getLogger(ROOT_LOGGER_NAME);
+		var patternLayout = findPatternLayout(loggerContext);
+
+		// I tried sending the events to the proper appenders, and that works when a single test
+		// is run in isolation, but when the whole suite is run, this caused bizarre scrambling
+		// of the order of the logs, even within those emitted by a single thread.
+		// I think I've broken some contract of Logback here, but I'm not sure how exactly.
+		// In the meantime, we just print to stdout.
+
+		for (var event : queueContents.events()) {
+			if (false) {
+				var eventLogger = loggerContext.getLogger(event.getLoggerName());
+				var appenderMap = eventLogger.iteratorForAppenders();
+
+				if (!appenderMap.hasNext()) {
+					appenderMap = rootLogger.iteratorForAppenders();
+				}
+
+				while (appenderMap.hasNext()) {
+					var appender = appenderMap.next();
+					appender.doAppend(event);
+				}
+			} else {
+				System.out.print(patternLayout.doLayout(event));
+			}
+		}
+		System.out.println("--- END OF REPLAYED LOGS ---");
+		System.out.flush();
+	}
+
+	private PatternLayout findPatternLayout(LoggerContext loggerContext) {
+		var rootLogger = loggerContext.getLogger(ROOT_LOGGER_NAME);
+		var appenderIt = rootLogger.iteratorForAppenders();
+
+		while (appenderIt.hasNext()) {
+			var appender = appenderIt.next();
+			if (appender instanceof OutputStreamAppender) {
+				var encoder = ((OutputStreamAppender<?>) appender).getEncoder();
+				if (encoder instanceof PatternLayoutEncoder) {
+					var layout = ((PatternLayoutEncoder) encoder).getLayout();
+					if (layout instanceof PatternLayout && layout.isStarted()) {
+						return (PatternLayout) layout;
+					}
+				}
+			}
+		}
+		throw new IllegalStateException("Could not find the PatternLayout in the root logger's appenders");
+	}
+
+}

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -70,7 +70,7 @@ public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEa
 		var element = context.getElement().orElse(null);
 		if (element == null) {
 			// No annotated element, no overrides
-			return new Overrides(null, null);
+			return Overrides.NONE;
 		}
 
 		var annotation = findAnnotation(element, ReplayLogsOnFailure.class).orElse(null);
@@ -80,7 +80,7 @@ public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEa
 		}
 		if (annotation == null) {
 			// No annotation, no overrides
-			return new Overrides(null, null);
+			return Overrides.NONE;
 		}
 
 		// For the enabled flag, the annotation always overrides the global default.

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -116,7 +116,7 @@ import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 		return null;
 	}
 
-	record QueueContents(Collection<ILoggingEvent> events, int dropped) {}
+	record QueueContents(Collection<ILoggingEvent> events, long dropped) {}
 
 	private void replay(QueueContents queueContents) {
 		if (queueContents.events.isEmpty()) {

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -66,7 +66,8 @@ import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 		String testId = context.getUniqueId();
 
 		if (context.getExecutionException().isPresent()) {
-			if (findFilter(loggerContext) instanceof RecordingTurboFilter filter) {
+			RecordingTurboFilter filter = findFilter(loggerContext);
+			if (filter != null) {
 				// This is what it's all about
 				replay(filter.queueContents(testId));
 			}
@@ -139,7 +140,7 @@ import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 		System.out.println(header);
 
 		var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-		var rootLogger = loggerContext.getLogger(ROOT_LOGGER_NAME);
+//		var rootLogger = loggerContext.getLogger(ROOT_LOGGER_NAME);
 		var patternLayout = findPatternLayout(loggerContext);
 
 		// I tried sending the events to the proper appenders, and that works when a single test
@@ -150,17 +151,17 @@ import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 
 		for (var event : queueContents.events()) {
 			if (false) {
-				var eventLogger = loggerContext.getLogger(event.getLoggerName());
-				var appenderMap = eventLogger.iteratorForAppenders();
-
-				if (!appenderMap.hasNext()) {
-					appenderMap = rootLogger.iteratorForAppenders();
-				}
-
-				while (appenderMap.hasNext()) {
-					var appender = appenderMap.next();
-					appender.doAppend(event);
-				}
+//				var eventLogger = loggerContext.getLogger(event.getLoggerName());
+//				var appenderMap = eventLogger.iteratorForAppenders();
+//
+//				if (!appenderMap.hasNext()) {
+//					appenderMap = rootLogger.iteratorForAppenders();
+//				}
+//
+//				while (appenderMap.hasNext()) {
+//					var appender = appenderMap.next();
+//					appender.doAppend(event);
+//				}
 			} else {
 				System.out.print(patternLayout.doLayout(event));
 			}

--- a/bosk-logback/src/main/java/works/bosk/logback/package-info.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/package-info.java
@@ -1,0 +1,74 @@
+/**
+ * Logback-specific logging utilities.
+ * <p>
+ * Provides two features:
+ * <ol>
+ *   <li>
+ *     <b>Per-bosk log control:</b> Suppresses expected warnings during testing.
+ *   </li>
+ *   <li>
+ *     <b>Log replay on failure:</b> Captures log events that would otherwise be filtered out,
+ *     and replays them when a test fails.
+ *   </li>
+ * </ol>
+ *
+ * <h2>Per-bosk log control</h2>
+ * <p>
+ * {@link works.bosk.logback.BoskLogFilter} provides per-bosk logging control, intended to suppress expected warnings
+ * and errors during testing.
+ * <p>
+ * A {@link works.bosk.Bosk Bosk} whose driver stack includes {@link works.bosk.logback.BoskLogFilter#withController}
+ * can set log levels using {@link works.bosk.logback.BoskLogFilter.LogController#setLogging LogController.setLogging} without affecting other logs.
+ * The driver sets the MDC key {@link works.bosk.logging.MdcKeys#BOSK_INSTANCE_ID BOSK_INSTANCE_ID},
+ * and the filter uses that to determine the correct {@code LogController} object to adjust log levels for that bosk.
+ *
+ * <h2>Log replay on failure</h2>
+ * <p>
+ * {@link works.bosk.logback.ReplayLogsOnFailureExtension} is a JUnit extension
+ * that captures and replays log events when a test fails.
+ * <p>
+ * <b>How it works:</b>
+ * <ol>
+ *   <li>
+ *     <b>RecordingTurboFilter</b> sits in the Logback filter chain and records log events
+ *     that match its configured level, storing them in a per-test buffer.
+ *   </li>
+ *   <li>
+ *     <b>ReplayLogsOnFailureExtension</b> coordinates with {@code RecordingTurboFilter}.
+ *     Before each test, it sets an MDC key identifying the test.
+ *     After each test, if the test failed, it retrieves the recorded events and prints them.
+ *   </li>
+ *   <li>
+ *     <b>ReplayLogsOnFailure</b> is the annotation that enables and configures this behavior
+ *     on a test class.
+ *   </li>
+ * </ol>
+ * <p>
+ * <b>Quick start:</b>
+ * <ol>
+ *   <li>
+ *     Add the filter to your logback-test.xml (or logback.xml):
+ *     <pre>
+ *     &lt;turboFilter class="works.bosk.logback.RecordingTurboFilter"/&gt;
+ *     </pre>
+ *   </li>
+ *   <li>
+ *     Add {@code @ReplayLogsOnFailure} to your test class:
+ *     <pre>
+ *     &#64;ReplayLogsOnFailure
+ *     class MyTest { ... }
+ *     </pre>
+ *   </li>
+ * </ol>
+ * <p>
+ * When a test fails, you'll see the captured log events printed to help diagnose the failure.
+ * <p>
+ * <b>For detailed configuration options</b> (level, capacity, routing key for multi-threaded tests),
+ * see {@link works.bosk.logback.RecordingTurboFilter}.
+ *
+ * @see works.bosk.logback.ReplayLogsOnFailure
+ * @see works.bosk.logback.RecordingTurboFilter
+ * @see works.bosk.logback.ReplayLogsOnFailureExtension
+ * @see works.bosk.logback.BoskLogFilter
+ */
+package works.bosk.logback;

--- a/bosk-logback/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/bosk-logback/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,0 @@
-works.bosk.logback.ReplayLogsOnFailureExtension

--- a/bosk-logback/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/bosk-logback/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+works.bosk.logback.ReplayLogsOnFailureExtension

--- a/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
+++ b/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
@@ -10,11 +10,14 @@ import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedElement;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.InjectedTest;
 import works.bosk.junit.Injector;
@@ -159,6 +162,15 @@ class RecordingTurboFilterTest {
 
 		MDC.put(TEST_ID_KEY, TEST_B);
 		testLogger.debug("event for TestB");
+
+		var testAEvents = EventSnapshot.from(filter.queueContents(TEST_A).events());
+		var testBEvents = EventSnapshot.from(filter.queueContents(TEST_B).events());
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "event for TestA", LOGGER_NAME, null)
+		), testAEvents);
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "event for TestB", LOGGER_NAME, null)
+		), testBEvents);
 	}
 
 	@Test
@@ -255,6 +267,39 @@ class RecordingTurboFilterTest {
 		testLogger.debug("should not be buffered");
 
 		assertEquals(List.of(), EventSnapshot.from(filter.queueContents(TEST).events()));
+	}
+
+	@Test
+	void recordedEvent_containsMdcAndMarker() {
+		MDC.put(TEST_ID_KEY, TEST);
+		MDC.put("bosk.name", "test-instance-123");
+		MDC.put("customKey", "customValue");
+
+		testLogger.debug("test message");
+
+		var events = filter.queueContents(TEST).events();
+		assertEquals(1, events.size());
+
+		var event = (ch.qos.logback.classic.spi.LoggingEvent) events.iterator().next();
+		assertEquals(Map.of(
+			"bosk.junit.testId", TEST,
+			"bosk.name", "test-instance-123",
+			"customKey", "customValue"
+		), event.getMDCPropertyMap());
+	}
+
+	@Test
+	void recordedEvent_capturesMarker() {
+		MDC.put(TEST_ID_KEY, TEST);
+		Marker marker = MarkerFactory.getMarker("TEST_MARKER");
+
+		testLogger.debug(marker, "test message with marker");
+
+		var events = filter.queueContents(TEST).events();
+		assertEquals(1, events.size());
+
+		var event = (ch.qos.logback.classic.spi.LoggingEvent) events.iterator().next();
+		assertEquals(marker, event.getMarker());
 	}
 
 	/**

--- a/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
+++ b/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
@@ -123,6 +123,20 @@ class RecordingTurboFilterTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	void capacityZero_retainsNoEvents() {
+		filter.setEnabled(true);
+		filter.setCapacity(0);
+
+		MDC.put(TEST_ID_KEY, TEST);
+		testLogger.debug("event 1");
+		testLogger.debug("event 2");
+
+		var actual = filter.queueContents(TEST).events().size();
+
+		assertEquals(0, actual);
+	}
+
 	@InjectedTest
 	void logLevel_filtering(@FilterLevel Level filterLevel, @LogLevel Level logLevel) {
 		filter.setEnabled(true);

--- a/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
+++ b/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
@@ -1,0 +1,347 @@
+package works.bosk.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.InjectedTest;
+import works.bosk.junit.Injector;
+import works.bosk.logback.ReplayLogsOnFailureExtension.Overrides;
+
+import static ch.qos.logback.classic.Level.DEBUG;
+import static ch.qos.logback.classic.Level.INFO;
+import static ch.qos.logback.classic.Level.TRACE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
+import static works.bosk.logback.RecordingTurboFilter.removeOverrides;
+
+@InjectFrom({
+	RecordingTurboFilterTest.BooleanInjector.class,
+	RecordingTurboFilterTest.NullableBooleanInjector.class,
+	RecordingTurboFilterTest.CapacityInjector.class,
+	RecordingTurboFilterTest.FilterLevelInjector.class,
+	RecordingTurboFilterTest.LogLevelInjector.class
+})
+class RecordingTurboFilterTest {
+	static final String TEST_A = "TestA";
+	static final String TEST_B = "TestB";
+	static final String TEST = "Test";
+	static final String LOGGER_NAME = "Test logger";
+	static final String CONTEXT_NAME = "Test context";
+	public static final String ROUTING_KEY = "testRoutingKey";
+
+	private RecordingTurboFilter filter;
+	private ch.qos.logback.classic.Logger testLogger;
+	private ListAppender<ILoggingEvent> listAppender;
+
+	record EventSnapshot(Level level, String message, String loggerName, String exceptionClassName) {
+		static List<EventSnapshot> from(Collection<ILoggingEvent> events) {
+			return events.stream()
+				.map(e -> new EventSnapshot(
+					e.getLevel(),
+					e.getMessage(),
+					e.getLoggerName(),
+					e.getThrowableProxy() != null ? e.getThrowableProxy().getClassName() : null))
+				.toList();
+		}
+	}
+
+	@BeforeEach
+	void setUp() {
+		var loggerContext = new LoggerContext();
+		loggerContext.setName(CONTEXT_NAME);
+		loggerContext.start();
+
+		filter = new RecordingTurboFilter();
+		filter.setEnabled(true);
+		filter.setRoutingKey(ROUTING_KEY);
+		filter.setCapacity(1000);
+		loggerContext.addTurboFilter(filter);
+
+		testLogger = loggerContext.getLogger(LOGGER_NAME);
+		testLogger.setLevel(DEBUG);
+
+		listAppender = new ListAppender<>();
+		listAppender.start();
+		var root = loggerContext.getLogger(ROOT_LOGGER_NAME);
+		root.addAppender(listAppender);
+	}
+
+	@AfterEach
+	void teardown() {
+		MDC.clear();
+		removeOverrides(TEST_A);
+		removeOverrides(TEST_B);
+		removeOverrides(TEST);
+	}
+
+	@InjectedTest
+	void enabled(boolean globalEnabled, Boolean perTestEnabled) {
+		filter.setEnabled(globalEnabled);
+		RecordingTurboFilter.putOverrides(TEST, new Overrides(perTestEnabled, null));
+
+		MDC.put(TEST_ID_KEY, TEST);
+		testLogger.debug("event");
+
+		boolean expected = (perTestEnabled != null) ? perTestEnabled : globalEnabled;
+		var actual = !filter.queueContents(TEST).events().isEmpty();
+
+		assertEquals(expected, actual);
+	}
+
+	@InjectedTest
+	void capacity(Integer perTestCapacity) {
+		filter.setEnabled(true);
+		filter.setCapacity(2);
+		RecordingTurboFilter.putOverrides(TEST, new Overrides(true, perTestCapacity));
+
+		MDC.put(TEST_ID_KEY, TEST);
+		testLogger.debug("event 1");
+		testLogger.debug("event 2");
+		testLogger.debug("event 3");
+
+		int expected = (perTestCapacity != null) ? perTestCapacity : 2;
+		var actual = filter.queueContents(TEST).events().size();
+
+		assertEquals(expected, actual);
+	}
+
+	@InjectedTest
+	void logLevel_filtering(@FilterLevel Level filterLevel, @LogLevel Level logLevel) {
+		filter.setEnabled(true);
+		filter.setLevel(filterLevel);
+
+		MDC.put(TEST_ID_KEY, TEST);
+		logAt(testLogger, logLevel, "test message");
+
+		boolean shouldCapture = logLevel.levelInt >= filterLevel.levelInt;
+		var actual = !filter.queueContents(TEST).events().isEmpty();
+
+		assertEquals(shouldCapture, actual);
+	}
+
+	@Test
+	void sameTestId_sameQueue() {
+		MDC.put(TEST_ID_KEY, TEST_A);
+
+		testLogger.debug("debug message 1");
+		testLogger.info("info message 1");
+
+		var testAEvents = EventSnapshot.from(filter.queueContents(TEST_A).events());
+		var testBEvents = EventSnapshot.from(filter.queueContents(TEST_B).events());
+
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "debug message 1", LOGGER_NAME, null),
+			new EventSnapshot(INFO, "info message 1", LOGGER_NAME, null)
+		), testAEvents);
+
+		assertEquals(List.of(), testBEvents);
+	}
+
+	@Test
+	void differentTestIds_differentQueues() {
+		MDC.put(TEST_ID_KEY, TEST_A);
+		testLogger.debug("event for TestA");
+
+		MDC.put(TEST_ID_KEY, TEST_B);
+		testLogger.debug("event for TestB");
+	}
+
+	@Test
+	void routingKey_isSticky() {
+		MDC.put(ROUTING_KEY, "instance1");
+		MDC.put(TEST_ID_KEY, TEST_A);
+		testLogger.debug("first event");
+
+		MDC.remove(TEST_ID_KEY);
+		testLogger.debug("second event");
+
+		var testAEvents = EventSnapshot.from(filter.queueContents(TEST_A).events());
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "first event", LOGGER_NAME, null),
+			new EventSnapshot(DEBUG, "second event", LOGGER_NAME, null)
+		), testAEvents);
+	}
+
+	@Test
+	void routingKey_reassociated() {
+		MDC.put(ROUTING_KEY, "same-key");
+		MDC.put(TEST_ID_KEY, TEST_A);
+		testLogger.debug("event for TestA");
+
+		MDC.remove(TEST_ID_KEY);
+		testLogger.debug("event no test ID, should go to TestA");
+
+		MDC.put(TEST_ID_KEY, TEST_B);
+		testLogger.debug("event for TestB");
+
+		MDC.remove(TEST_ID_KEY);
+		testLogger.debug("event no test ID, should go to TestB");
+
+		var testAEvents = EventSnapshot.from(filter.queueContents(TEST_A).events());
+		var testBEvents = EventSnapshot.from(filter.queueContents(TEST_B).events());
+
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "event for TestA", LOGGER_NAME, null),
+			new EventSnapshot(DEBUG, "event no test ID, should go to TestA", LOGGER_NAME, null)
+		), testAEvents);
+
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "event for TestB", LOGGER_NAME, null),
+			new EventSnapshot(DEBUG, "event no test ID, should go to TestB", LOGGER_NAME, null)
+		), testBEvents);
+	}
+
+	@Test
+	void cleanup_removesOnlyAssociated() {
+		MDC.put(ROUTING_KEY, "instance1");
+		MDC.put(TEST_ID_KEY, TEST_A);
+		testLogger.debug("A");
+
+		MDC.put(ROUTING_KEY, "instance2");
+		MDC.put(TEST_ID_KEY, TEST_B);
+		testLogger.debug("B");
+
+		RecordingTurboFilter.cleanupForTest(TEST_A);
+
+		var testAEvents = EventSnapshot.from(filter.queueContents(TEST_A).events());
+		var testBEvents = EventSnapshot.from(filter.queueContents(TEST_B).events());
+
+		assertEquals(List.of(), testAEvents);
+		assertEquals(List.of(
+			new EventSnapshot(DEBUG, "B", LOGGER_NAME, null)
+		), testBEvents);
+	}
+
+	@Test
+	void passThrough_toAppenders() {
+		MDC.put(ROUTING_KEY, "key");
+		MDC.put(TEST_ID_KEY, TEST);
+
+		testLogger.info("info message");
+		testLogger.warn("warn message");
+		testLogger.error("error message");
+
+		var events = EventSnapshot.from(filter.queueContents(TEST).events());
+		var appenderEvents = EventSnapshot.from(listAppender.list);
+
+		assertEquals(List.of(
+			new EventSnapshot(INFO, "info message", LOGGER_NAME, null),
+			new EventSnapshot(Level.WARN, "warn message", LOGGER_NAME, null),
+			new EventSnapshot(Level.ERROR, "error message", LOGGER_NAME, null)
+		), events);
+
+		assertEquals(appenderEvents, events);
+	}
+
+	@Test
+	void noTestId_notBuffered() {
+		MDC.put(ROUTING_KEY, "some-key");
+
+		testLogger.debug("should not be buffered");
+
+		assertEquals(List.of(), EventSnapshot.from(filter.queueContents(TEST).events()));
+	}
+
+	/**
+	 * You might think it would be simpler to call {@code logger.atLevel(level).log(msg, args)},
+	 * but sadly that calls the isXxxEnabled methods which we don't modify, and so the logs wouldn't be recorded.
+	 */
+	private static void logAt(org.slf4j.Logger logger, Level level, String msg, Object... args) {
+		switch (toSlf4jEventLevel(level)) {
+			case TRACE -> logger.trace(msg, args);
+			case DEBUG -> logger.debug(msg, args);
+			case INFO -> logger.info(msg, args);
+			case WARN -> logger.warn(msg, args);
+			case ERROR -> logger.error(msg, args);
+		}
+	}
+
+	private static org.slf4j.event.Level toSlf4jEventLevel(Level level) {
+		return org.slf4j.event.Level.valueOf(level.toString());
+	}
+
+	record BooleanInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement e, Class<?> t) {
+			return t == boolean.class;
+		}
+
+		@Override
+		public List<Boolean> values() {
+			return List.of(true, false);
+		}
+	}
+
+	record NullableBooleanInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement e, Class<?> t) {
+			return t == Boolean.class;
+		}
+
+		@Override
+		public List<Boolean> values() {
+			return Stream.of(null, true, false).toList();
+		}
+	}
+
+	record CapacityInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement e, Class<?> t) {
+			return t == Integer.class;
+		}
+
+		@Override
+		public List<Integer> values() {
+			return Stream.of(null, 1, 2, 3).toList();
+		}
+	}
+
+	record FilterLevelInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement e, Class<?> t) {
+			return e.isAnnotationPresent(FilterLevel.class)
+				&& t == Level.class;
+		}
+
+		@Override
+		public List<Level> values() {
+			return List.of(TRACE, DEBUG, INFO);
+		}
+	}
+
+	record LogLevelInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement e, Class<?> t) {
+			return e.isAnnotationPresent(LogLevel.class)
+				&& t == Level.class;
+		}
+
+		@Override
+		public List<Level> values() {
+			return List.of(TRACE, DEBUG, INFO);
+		}
+	}
+
+	@Target(PARAMETER)
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface FilterLevel {}
+
+	@Target(PARAMETER)
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface LogLevel {}
+}

--- a/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
+++ b/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
@@ -21,7 +21,6 @@ import org.slf4j.MarkerFactory;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.InjectedTest;
 import works.bosk.junit.Injector;
-import works.bosk.logback.ReplayLogsOnFailureExtension.Overrides;
 
 import static ch.qos.logback.classic.Level.DEBUG;
 import static ch.qos.logback.classic.Level.INFO;
@@ -29,6 +28,7 @@ import static ch.qos.logback.classic.Level.TRACE;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+import static works.bosk.logback.RecordingTurboFilter.Overrides;
 import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
 import static works.bosk.logback.RecordingTurboFilter.removeOverrides;
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -214,7 +214,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 	@Override
 	public <RR extends StateTreeNode> InitialState<RR> initialState(Class<RR> rootType) throws InvalidTypeException, InterruptedException, IOException {
-		try (MDCScope _ = beginDriverOperation("initialState({})", rootType)) {
+		try (var _ = beginDriverOperation("initialState({})", rootType)) {
 			// The actual loading of the initial state happens on the ChangeReceiver thread.
 			// Here, we just wait for that to finish and deal with the consequences.
 			var task = listener.taskRef.get();

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
@@ -249,41 +249,39 @@ class SqlDriverImpl implements SqlDriver {
 	@Override
 	public <R extends StateTreeNode> InitialState<R> initialState(Class<R> rootType) throws InvalidTypeException, IOException, InterruptedException {
 		// TODO: Consider a disconnected mode where we delegate downstream if something goes wrong
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			LOGGER.debug("initialState({})", rootType);
-			try (
-				var connection = connectionSource.get()
-			){
-				// TODO: It seems wrong to schedule the listener loop here. It should be in the constructor.
-				ensureTablesExist(connection);
-				InitialState<R> result;
-				var stateAndEpoch = loadStateAndEpoch(connection);
-				if (stateAndEpoch == null) {
-					LOGGER.debug("No current state; initializing {} table from downstream", BOSK);
-					this.epoch = UUID.randomUUID().toString();
-					result = downstream.initialState(rootType);
-					var root = switch (result) {
-						case InitialState.SingleTree(var r) -> r;
-					};
-					String stateJson = mapper.writeValueAsString(root);
+		LOGGER.debug("initialState({})", rootType);
+		try (
+			var connection = connectionSource.get()
+		){
+			// TODO: It seems wrong to schedule the listener loop here. It should be in the constructor.
+			ensureTablesExist(connection);
+			InitialState<R> result;
+			var stateAndEpoch = loadStateAndEpoch(connection);
+			if (stateAndEpoch == null) {
+				LOGGER.debug("No current state; initializing {} table from downstream", BOSK);
+				this.epoch = UUID.randomUUID().toString();
+				result = downstream.initialState(rootType);
+				var root = switch (result) {
+					case InitialState.SingleTree(var r) -> r;
+				};
+				String stateJson = mapper.writeValueAsString(root);
 
-					using(connection)
-						.insertInto(BOSK).columns(ID, STATE, BOSK.EPOCH)
-						.values("current", stateJson, epoch)
-						.onConflictDoNothing()
-						.execute();
-					long changeID = insertChange(connection, rootRef, stateJson);
-					connection.commit();
-					lastChangeSubmittedDownstream.getAndSet(changeID); // Not technically "submitted"
-				} else {
-					LOGGER.debug("Database state exists; initializing downstream from {} table", BOSK);
-					result = resetBoskState(rootType, stateAndEpoch, connection);
-				}
-				listener.scheduleWithFixedDelay(this::listenForChanges, 0, settings.timescaleMS(), MILLISECONDS);
-				return result;
-			} catch (SQLException e) {
-				throw new NotYetImplementedException(e);
+				using(connection)
+					.insertInto(BOSK).columns(ID, STATE, BOSK.EPOCH)
+					.values("current", stateJson, epoch)
+					.onConflictDoNothing()
+					.execute();
+				long changeID = insertChange(connection, rootRef, stateJson);
+				connection.commit();
+				lastChangeSubmittedDownstream.getAndSet(changeID); // Not technically "submitted"
+			} else {
+				LOGGER.debug("Database state exists; initializing downstream from {} table", BOSK);
+				result = resetBoskState(rootType, stateAndEpoch, connection);
 			}
+			listener.scheduleWithFixedDelay(this::listenForChanges, 0, settings.timescaleMS(), MILLISECONDS);
+			return result;
+		} catch (SQLException e) {
+			throw new NotYetImplementedException(e);
 		}
 	}
 
@@ -333,82 +331,72 @@ class SqlDriverImpl implements SqlDriver {
 
 	@Override
 	public <T> void submitReplacement(Reference<T> target, T newValue) {
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			LOGGER.debug("submitReplacement({}, {})", target, newValue);
-			try (
-				var connection = connectionSource.get()
-			) {
-				// TODO optimization: no need to read the current state for root
-				replaceAndCommit(readState(connection), target, newValue, connection);
-			} catch (SQLException e) {
-				throw new NotYetImplementedException(e);
-			}
+		LOGGER.debug("submitReplacement({}, {})", target, newValue);
+		try (
+			var connection = connectionSource.get()
+		) {
+			// TODO optimization: no need to read the current state for root
+			replaceAndCommit(readState(connection), target, newValue, connection);
+		} catch (SQLException e) {
+			throw new NotYetImplementedException(e);
 		}
 	}
 
 	@Override
 	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			LOGGER.debug("submitConditionalReplacement({}, {}, {}, {})", target, newValue, precondition, requiredValue);
-			try (
-				var connection = connectionSource.get()
-			) {
-				JsonNode state = readState(connection);
-				if (isMatchingTextNode(precondition, requiredValue, state)) {
-					replaceAndCommit(state, target, newValue, connection);
-				}
-			} catch (SQLException e) {
-				throw new NotYetImplementedException(e);
+		LOGGER.debug("submitConditionalReplacement({}, {}, {}, {})", target, newValue, precondition, requiredValue);
+		try (
+			var connection = connectionSource.get()
+		) {
+			JsonNode state = readState(connection);
+			if (isMatchingTextNode(precondition, requiredValue, state)) {
+				replaceAndCommit(state, target, newValue, connection);
 			}
+		} catch (SQLException e) {
+			throw new NotYetImplementedException(e);
 		}
 	}
 
 	@Override
 	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			LOGGER.debug("submitConditionalCreation({}, {})", target, newValue);
-			try (
-				var connection = connectionSource.get()
-			) {
-				JsonNode state = readState(connection);
-				NodeInfo node = surgeon.nodeInfo(state, target);
-				if (surgeon.node(node.valueLocation(), state) == null) {
-					replaceAndCommit(state, target, newValue, connection);
-				}
-			} catch (SQLException e) {
-				throw new NotYetImplementedException(e);
+		LOGGER.debug("submitConditionalCreation({}, {})", target, newValue);
+		try (
+			var connection = connectionSource.get()
+		) {
+			JsonNode state = readState(connection);
+			NodeInfo node = surgeon.nodeInfo(state, target);
+			if (surgeon.node(node.valueLocation(), state) == null) {
+				replaceAndCommit(state, target, newValue, connection);
 			}
+		} catch (SQLException e) {
+			throw new NotYetImplementedException(e);
 		}
 	}
 
 	@Override
 	public <T> void submitDeletion(Reference<T> target) {
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			LOGGER.debug("submitDeletion({})", target);
-			try (
-				var connection = connectionSource.get()
-			) {
-				replaceAndCommit(readState(connection), target, null, connection);
-			} catch (SQLException e) {
-				throw new NotYetImplementedException(e);
-			}
+		LOGGER.debug("submitDeletion({})", target);
+		try (
+			var connection = connectionSource.get()
+		) {
+			replaceAndCommit(readState(connection), target, null, connection);
+		} catch (SQLException e) {
+			throw new NotYetImplementedException(e);
 		}
 	}
 
 	@Override
 	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			LOGGER.debug("submitConditionalDeletion({}, {}, {})", target, precondition, requiredValue);
-			try (
-				var connection = connectionSource.get()
-			) {
-				JsonNode state = readState(connection);
-				if (isMatchingTextNode(precondition, requiredValue, state)) {
-					replaceAndCommit(state, target, null, connection);
-				}
-			} catch (SQLException e) {
-				throw new NotYetImplementedException(e);
+		LOGGER.debug("submitConditionalDeletion({}, {}, {})", target, precondition, requiredValue);
+		try (
+			var connection = connectionSource.get()
+		) {
+			JsonNode state = readState(connection);
+			if (isMatchingTextNode(precondition, requiredValue, state)) {
+				replaceAndCommit(state, target, null, connection);
 			}
+		} catch (SQLException e) {
+			throw new NotYetImplementedException(e);
 		}
 	}
 
@@ -419,39 +407,37 @@ class SqlDriverImpl implements SqlDriver {
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		try (MDCScope _ = setupMDC(boskName, boskID)) {
-			try (
-				var connection = connectionSource.get()
-			) {
-				long currentChangeID = latestChangeID(connection);
-				LOGGER.debug("flush({})", currentChangeID);
+		try (
+			var connection = connectionSource.get()
+		) {
+			long currentChangeID = latestChangeID(connection);
+			LOGGER.debug("flush({})", currentChangeID);
 
-				// Exponential backoff starting from timescaleMS
-				long sleepTime = settings.timescaleMS();
-				long sleepDeadline = currentTimeMillis() + multiplyExact(sleepTime, settings.patienceFactor());
-				while (lastChangeSubmittedDownstream.get() < currentChangeID) {
-					long sleepBudget = sleepDeadline - currentTimeMillis();
-					if (sleepBudget <= 0) {
-						throw new FlushFailureException("Timed out waiting for change #" + currentChangeID);
-					}
-					LOGGER.debug("Will retry");
-					Thread.sleep(min(sleepBudget, sleepTime));
-					sleepTime *= 2;
+			// Exponential backoff starting from timescaleMS
+			long sleepTime = settings.timescaleMS();
+			long sleepDeadline = currentTimeMillis() + multiplyExact(sleepTime, settings.patienceFactor());
+			while (lastChangeSubmittedDownstream.get() < currentChangeID) {
+				long sleepBudget = sleepDeadline - currentTimeMillis();
+				if (sleepBudget <= 0) {
+					throw new FlushFailureException("Timed out waiting for change #" + currentChangeID);
 				}
-			} catch (SQLException e) {
-				throw new FlushFailureException(e);
-			} catch (EpochMismatchException e) {
-				LOGGER.debug("Epoch mismatch: reload state from database");
-				try (var c = connectionSource.get()) {
-					resetBoskState(rootRef.targetType(), loadStateAndEpoch(c), c);
-				} catch (SQLException | RuntimeException ex) {
-					throw new FlushFailureException(ex);
-				}
-			} catch (RuntimeException e) {
-				throw new FlushFailureException("Unexpected error while flushing", e);
+				LOGGER.debug("Will retry");
+				Thread.sleep(min(sleepBudget, sleepTime));
+				sleepTime *= 2;
 			}
-			downstream.flush();
+		} catch (SQLException e) {
+			throw new FlushFailureException(e);
+		} catch (EpochMismatchException e) {
+			LOGGER.debug("Epoch mismatch: reload state from database");
+			try (var c = connectionSource.get()) {
+				resetBoskState(rootRef.targetType(), loadStateAndEpoch(c), c);
+			} catch (SQLException | RuntimeException ex) {
+				throw new FlushFailureException(ex);
+			}
+		} catch (RuntimeException e) {
+			throw new FlushFailureException("Unexpected error while flushing", e);
 		}
+		downstream.flush();
 	}
 
 	/**

--- a/bosk-testing/build.gradle
+++ b/bosk-testing/build.gradle
@@ -2,6 +2,7 @@
 dependencies {
 	api project(":bosk-core")
 	api project(":bosk-junit")
+	api project(":bosk-logback")
 
 	// The main build.gradle brings these in as test dependencies,
 	// but we need them as main dependencies.

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/AsyncDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/AsyncDriver.java
@@ -16,6 +16,7 @@ import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static lombok.AccessLevel.PRIVATE;
+import static works.bosk.logging.MappedDiagnosticContext.setupMDC;
 
 @RequiredArgsConstructor(access = PRIVATE)
 public class AsyncDriver implements BoskDriver {
@@ -80,12 +81,15 @@ public class AsyncDriver implements BoskDriver {
 		var tenant = bosk.context().getTenant();
 		var diagnosticAttributes = bosk.context().getAttributes();
 		executor.submit(()->{
-			LOGGER.debug("Run {}", description);
 			try (
+				var _ = setupMDC(bosk.name(), bosk.instanceID());
 				var _ = bosk.context().withMaybeTenant(tenant);
 				var _ = bosk.context().withOnly(diagnosticAttributes)
 			) {
 				task.run();
+			} catch (Throwable t) {
+				LOGGER.error("Error during {}", description, t);
+				throw t;
 			} finally {
 				LOGGER.debug("Proceeding after {}", description);
 			}

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
@@ -20,7 +20,6 @@ import works.bosk.DriverFactory;
 import works.bosk.DriverStack;
 import works.bosk.Reference;
 import works.bosk.StateTreeNode;
-import works.bosk.drivers.BufferingDriver;
 import works.bosk.drivers.ContextScopeDriver;
 import works.bosk.drivers.ReplicaSet;
 import works.bosk.exceptions.InvalidTypeException;
@@ -84,7 +83,8 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 				// Send to the subject driver
 				subject,
 				// Delay to ensure the subject doesn't depend on immediate downstream propagation of updates
-				BufferingDriver.factory(),
+				// Note: this can actually cause some bad drivers to pass because it runs actions reliably in the context of the subsequent flush
+//				BufferingDriver.factory(),
 				// Report the updates as they appear on their way out of the subject driver
 				ReportingDriver.factory(verifier::outgoingUpdate, verifier::preOutgoingFlush, _->{})
 			).build(b,d);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
@@ -12,9 +12,10 @@ import java.util.concurrent.LinkedBlockingDeque;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
-import works.bosk.BoskContext;
+import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.DriverFactory;
 import works.bosk.DriverStack;
@@ -30,6 +31,8 @@ import works.bosk.testing.drivers.operations.UpdateOperation;
 
 import static java.lang.Thread.currentThread;
 import static lombok.AccessLevel.PRIVATE;
+import static works.bosk.logging.MdcKeys.BOSK_INSTANCE_ID;
+import static works.bosk.logging.MdcKeys.BOSK_NAME;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 /**
@@ -39,6 +42,9 @@ import static works.bosk.testing.BoskTestUtils.boskName;
  */
 @RequiredArgsConstructor(access = PRIVATE)
 public final class DriverStateVerifier<R extends StateTreeNode> {
+	final String boskName;
+	final String boskInstanceID;
+
 	/**
 	 * Used to model the effect of each operation on the bosk state
 	 */
@@ -72,6 +78,8 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 					.build()
 			);
 			DriverStateVerifier<RR> verifier = new DriverStateVerifier<>(
+				b.name(),
+				b.instanceID().toString(),
 				stateTrackingBosk,
 				ReplicaSet.redirectingTo(stateTrackingBosk)
 			);
@@ -97,6 +105,7 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 	 */
 	private void incomingUpdate(UpdateOperation updateOperation) {
 		LOGGER.debug("---> IN: {}", updateOperation);
+		checkMDC();
 		// Note: because we have a separate queue for each thread, this isn't actually blocking
 		pendingOperationsByThreadID
 			.computeIfAbsent(threadId(updateOperation), _ -> new LinkedBlockingDeque<>())
@@ -110,7 +119,8 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 	 */
 	private synchronized void outgoingUpdate(UpdateOperation op) {
 		LOGGER.debug("---> OUT: {}", op);
-		if (!(op.boskContext().tenant() instanceof BoskContext.Tenant.Established tenant)) {
+		checkMDC();
+		if (!(op.boskContext().tenant() instanceof Tenant.Established tenant)) {
 			throw new AssertionError("Missing tenant on update: " + op);
 		}
 		try (var _ = stateTrackingBosk.context().withTenant(tenant)) {
@@ -256,6 +266,15 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 
 	private static @Nullable String threadId(DriverOperation op) {
 		return op.boskContext().diagnosticAttributes().get(THREAD_ID);
+	}
+
+	private void checkMDC() {
+		if (!boskName.equals(MDC.get(BOSK_NAME))) {
+			throw new AssertionError("MDC bosk name must be " + boskName + " but was " + MDC.get(BOSK_NAME));
+		}
+		if (!boskInstanceID.equals(MDC.get(BOSK_INSTANCE_ID))) {
+			throw new AssertionError("MDC bosk instance ID must be " + boskInstanceID + " but was " + MDC.get(BOSK_INSTANCE_ID));
+		}
 	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DriverStateVerifier.class);

--- a/lib-testing/src/main/resources/junit-platform.properties
+++ b/lib-testing/src/main/resources/junit-platform.properties
@@ -4,3 +4,5 @@ junit.jupiter.execution.parallel.mode.classes.default = concurrent
 # If we parallelize at the method level, we seem to end up overloading databases
 # and causing timeouts due to our deliberately short timeout settings.
 junit.jupiter.execution.parallel.mode.default = same_thread
+
+junit.jupiter.execution.timeout.default=1m

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -1,5 +1,11 @@
 <configuration>
 	<turboFilter class="works.bosk.logback.BoskLogFilter"/>
+	<turboFilter class="works.bosk.logback.RecordingTurboFilter">
+		<!-- To enable globally, rather than per-test -->
+<!--		<enabled>true</enabled>-->
+		<capacity>10</capacity>
+		<routingKey>bosk.instanceID</routingKey>
+	</turboFilter>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d %-5level [%thread] [%X{bosk.name}]%X{bosk.MongoDriver.transaction}%X{bosk.MongoDriver.event} %logger{25}: %msg%n</pattern>

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -1,9 +1,6 @@
 <configuration>
 	<turboFilter class="works.bosk.logback.BoskLogFilter"/>
 	<turboFilter class="works.bosk.logback.RecordingTurboFilter">
-		<!-- To enable globally, rather than per-test -->
-<!--		<enabled>true</enabled>-->
-		<capacity>10</capacity>
 		<routingKey>bosk.instanceID</routingKey>
 	</turboFilter>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Adds a JUnit extension that replays log events when a test fails, kind of providing the illusion that we retroactively turned on debug logging. The illusion is imperfect and has several flaws and caveats, but hopefully still very useful.

The motivation here is to catch some odd failures I'm seeing when I try to make certain changes to the code.

Also adds a 1-minute timeout for all tests, because I've seen some tests hand for 30+ minutes.