### PR TITLE
Mongo client factory

### DIFF
--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -90,6 +90,8 @@ public class MongoDriverSettings {
 	public sealed interface DatabaseFormat
 		permits SequoiaFormat, PandoFormat
 	{
+		public String name();
+
 		/**
 		 * Simple format that stores the entire bosk state in a single document,
 		 * and (except for {@link MongoDriver#refurbish() refirbish})
@@ -103,6 +105,7 @@ public class MongoDriverSettings {
 
 	public static final class SequoiaFormat implements DatabaseFormat {
 		SequoiaFormat() { }
+		@Override public String name() { return "Sequoia"; }
 		@Override public String toString() { return "SequoiaFormat"; }
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
@@ -30,6 +30,8 @@ public record PandoFormat(
 	// TODO: Since this is used for updates and not reads, it should probably be called prunePoints or something
 	ListValue<String> graftPoints
 ) implements StateTreeNode, MongoDriverSettings.DatabaseFormat {
+	@Override public String name() { return "Pando"; }
+
 	/**
 	 * Differs from Sequoia in that (1) the root document has a different ID, rendering the formats incompatible;
 	 * and (2) Sequoia is designed not to need multi-document transactions.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeListener.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeListener.java
@@ -21,7 +21,7 @@ interface ChangeListener {
 		InterruptedException,
 		IOException,
 		InitialStateActionException,
-		TimeoutException, FailedSessionException;
+		TimeoutException, FailedMongoClientSessionException;
 
 	/**
 	 * @param event is a document-specific event, with a non-null {@link ChangeStreamDocument#getDocumentKey() document key}.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
@@ -178,7 +178,7 @@ class ChangeReceiver implements Closeable {
 						} catch (InterruptedException e) {
 							disconnect("Interrupted while processing MongoDB change events", REMEDY_CONTINUE, e);
 							continue;
-						} catch (IOException | FailedSessionException e) {
+						} catch (IOException | FailedMongoClientSessionException e) {
 							disconnect("Unexpected exception while processing MongoDB change events", REMEDY_RETURN, e);
 							return;
 						} catch (UnrecognizedFormatException e) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FailedMongoClientSessionException.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FailedMongoClientSessionException.java
@@ -7,16 +7,16 @@ import com.mongodb.client.MongoClient;
  * leaving us unable to interact with the database. This is often a transient
  * failure that could be remedied by retrying.
  */
-public class FailedSessionException extends Exception {
-	FailedSessionException(String message) {
+public class FailedMongoClientSessionException extends Exception {
+	FailedMongoClientSessionException(String message) {
 		super(message);
 	}
 
-	FailedSessionException(String message, Throwable cause) {
+	FailedMongoClientSessionException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	FailedSessionException(Throwable cause) {
+	FailedMongoClientSessionException(Throwable cause) {
 		super(cause);
 	}
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -296,11 +296,11 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				// We can now publish the driver knowing that the transaction, if there is one, has committed
 				publishFormatDriver(preferredDriver);
 				preferredDriver.onRevisionToSkip(REVISION_ONE); // initialState handles REVISION_ONE; downstream only needs to know about changes after that
-			} catch (RuntimeException | FailedSessionException e2) {
+			} catch (RuntimeException | FailedMongoClientSessionException e2) {
 				LOGGER.warn("Failed to initialize database; disconnecting", e2);
 				setDisconnectedDriver(e2);
 			}
-		} catch (RuntimeException | UnrecognizedFormatException | IOException | FailedSessionException e) {
+		} catch (RuntimeException | UnrecognizedFormatException | IOException | FailedMongoClientSessionException e) {
 			switch (driverSettings.initialDatabaseUnavailableMode()) {
 				case FAIL_FAST:
 					LOGGER.debug("Unable to load initial state from database; aborting initialization", e);
@@ -471,7 +471,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		public void onConnectionSucceeded() throws
 			UnrecognizedFormatException,
 			UninitializedCollectionException,
-			FailedSessionException,
+			FailedMongoClientSessionException,
 			InterruptedException,
 			IOException,
 			InitialStateActionException,
@@ -697,7 +697,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				try (var session = queryCollection.newSession()) {
 					operation.run();
 					session.commitTransactionIfAny();
-				} catch (FailedSessionException e) {
+				} catch (FailedMongoClientSessionException e) {
 					setDisconnectedDriver(e);
 					throw new DisconnectedException(e);
 				} catch (MongoException e) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
@@ -108,6 +109,21 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	 */
 	static final ThreadLocal<UnaryOperator<ChangeListener>> LISTENER_FACTORY = new ThreadLocal<>();
 
+	/**
+	 * Allows tests to control creation of {@link MongoClient}s.
+	 * Tests create clients at a furious rate and can overwhelm
+	 * the operating system's management of ephemeral ports.
+	 * This provides a way that they can use the same client across tests.
+	 */
+	static final ThreadLocal<MongoClientFactory> MONGO_CLIENT_FACTORY = ThreadLocal.withInitial(()-> MongoClientFactory.ALWAYS_CREATE);
+
+	record MongoClientFactory(
+		Function<MongoClientSettings, MongoClient> function,
+		boolean shouldClose
+	) {
+		static MongoClientFactory ALWAYS_CREATE = new MongoClientFactory(MongoClients::create, true);
+	}
+
 	public MainDriver(
 		BoskInfo<R> boskInfo,
 		MongoClientSettings clientSettings,
@@ -178,16 +194,22 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 						.readTimeout(0, MILLISECONDS))
 				;
 
-			var changeStreamClient = MongoClients.create(changeStreamSettingsBuilder.build());
-			closeables.addFirst(changeStreamClient);
+			var clientFactory = MONGO_CLIENT_FACTORY.get();
+
+			var changeStreamClient = clientFactory.function.apply(changeStreamSettingsBuilder.build());
+			if (clientFactory.shouldClose) {
+				closeables.addFirst(changeStreamClient);
+			}
 
 			// Override timeouts to make them compatible with driverSettings.timescaleMS()
 			var querySettingsBuilder = MongoClientSettings.builder(commonSettingsBuilder.build());
 			querySettingsBuilder
 				.timeout(flushTimeout, MILLISECONDS);
 
-			var queryClient = MongoClients.create(querySettingsBuilder.build());
-			closeables.addFirst(queryClient);
+			var queryClient = clientFactory.function.apply(querySettingsBuilder.build());
+			if (clientFactory.shouldClose) {
+				closeables.addFirst(queryClient);
+			}
 
 			this.queryCollection = TransactionalCollection.of(queryClient
 				.getDatabase(driverSettings.database())

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -121,7 +121,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		Function<MongoClientSettings, MongoClient> function,
 		boolean shouldClose
 	) {
-		static MongoClientFactory ALWAYS_CREATE = new MongoClientFactory(MongoClients::create, true);
+		private static final MongoClientFactory ALWAYS_CREATE = new MongoClientFactory(MongoClients::create, true);
 	}
 
 	public MainDriver(

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
@@ -38,11 +38,11 @@ class TransactionalCollection {
 	private final ThreadLocal<Session> currentSession = new ThreadLocal<>();
 	private static final AtomicLong identityCounter = new AtomicLong(1);
 
-	public Session newSession() throws FailedSessionException {
+	public Session newSession() throws FailedMongoClientSessionException {
 		return new Session(false);
 	}
 
-	public Session newReadOnlySession() throws FailedSessionException {
+	public Session newReadOnlySession() throws FailedMongoClientSessionException {
 		return new Session(true);
 	}
 
@@ -58,15 +58,15 @@ class TransactionalCollection {
 		final String name;
 		final String oldMDC;
 
-		public Session(boolean isReadOnly) throws FailedSessionException {
+		public Session(boolean isReadOnly) throws FailedMongoClientSessionException {
 			this.isReadOnly = isReadOnly;
 			name = (isReadOnly? "r":"s") + identityCounter.getAndIncrement();
 			oldMDC = MDC.get(MdcKeys.TRANSACTION);
 			if (currentSession.get() != null) {
-				// Note: we don't throw FailedSessionException because this
+				// Note: we don't throw FailedMongoClientSessionException because this
 				// is not a transient exception that can be remedied by waiting
 				// and retrying (which is what callers typically do when they
-				// catch FailedSessionException). This isn't a "failure" so much
+				// catch FailedMongoClientSessionException). This isn't a "failure" so much
 				// as a bosk bug!
 				throw new IllegalStateException("Cannot start nested session");
 			}
@@ -81,7 +81,7 @@ class TransactionalCollection {
 			try {
 				this.clientSession = mongoClient.startSession(sessionOptions);
 			} catch (RuntimeException | Error e) {
-				throw new FailedSessionException(e);
+				throw new FailedMongoClientSessionException(e);
 			}
 			currentSession.set(this);
 			MDC.put(MdcKeys.TRANSACTION, name);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/ForwardingChangeListener.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/ForwardingChangeListener.java
@@ -13,7 +13,7 @@ class ForwardingChangeListener implements ChangeListener {
 	}
 
 	@Override
-	public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException, InterruptedException, IOException, InitialStateActionException, TimeoutException, FailedSessionException {
+	public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException, InterruptedException, IOException, InitialStateActionException, TimeoutException, FailedMongoClientSessionException {
 		downstream.onConnectionSucceeded();
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,11 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 		MainDriver.MONGO_CLIENT_FACTORY.remove();
 		errorRecorder.assertAllClear("after test");
 		MainDriver.LISTENER_FACTORY.remove();
+	}
+
+	@AfterAll
+	static void closeClients() {
+		SHARED_CLIENTS.values().forEach(MongoClient::close);
 	}
 
 	static List<ParameterSet> parameterSets() {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
@@ -1,9 +1,13 @@
 package works.bosk.drivers.mongo.internal;
 
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -18,6 +22,7 @@ import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.drivers.mongo.internal.MainDriver.MongoClientFactory;
 import works.bosk.drivers.mongo.internal.MongoDriverConformanceTest.ParameterSetInjector;
 import works.bosk.drivers.mongo.internal.TestParameters.EventTiming;
 import works.bosk.drivers.mongo.internal.TestParameters.ParameterSet;
@@ -45,10 +50,18 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 	void setupErrorRecording() {
 		errorRecorder = new ErrorRecordingChangeListener.ErrorRecorder();
 		MainDriver.LISTENER_FACTORY.set(downstream -> new ErrorRecordingChangeListener(errorRecorder, downstream));
+
+		// This guy uses a literal bazillion TCP ports if we don't share clients
+		var defaultFactory = MainDriver.MONGO_CLIENT_FACTORY.get();
+		MainDriver.MONGO_CLIENT_FACTORY.set(new MongoClientFactory(
+			settings -> SHARED_CLIENTS.computeIfAbsent(settings, defaultFactory.function()),
+			false
+		));
 	}
 
 	@AfterEach
 	void teardownErrorRecording() {
+		MainDriver.MONGO_CLIENT_FACTORY.remove();
 		errorRecorder.assertAllClear("after test");
 		MainDriver.LISTENER_FACTORY.remove();
 	}
@@ -113,6 +126,8 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 			return driver;
 		};
 	}
+
+	private static final Map<MongoClientSettings, MongoClient> SHARED_CLIENTS = new ConcurrentHashMap<>();
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MongoDriverConformanceTest.class);
 }

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -507,7 +507,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 	@Test
 	void updateNonexistentField_ignored(TestInfo testInfo) throws InvalidTypeException, IOException, InterruptedException {
-		setLogging(ERROR, SequoiaFormatDriver.class, PandoFormatDriver.class, StateTreeSerializer.class);
+		setLogging(ERROR, AbstractFormatDriver.class, StateTreeSerializer.class);
 
 		Bosk<TestEntity> bosk = new Bosk<>(
 			boskName("Newer"),

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoService.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoService.java
@@ -4,6 +4,12 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import com.mongodb.event.ConnectionCheckOutFailedEvent;
+import com.mongodb.event.ConnectionCheckOutStartedEvent;
+import com.mongodb.event.ConnectionCheckedOutEvent;
+import com.mongodb.event.ConnectionClosedEvent;
+import com.mongodb.event.ConnectionCreatedEvent;
+import com.mongodb.event.ConnectionPoolListener;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import java.io.Closeable;
@@ -43,6 +49,35 @@ public class MongoService implements Closeable {
 	// We do logging in some static initializers, so this needs to be initialized first
 	private static final Logger LOGGER = LoggerFactory.getLogger(MongoService.class);
 	private final MongoClient mongoClient = MongoClients.create(normalClientSettings);
+
+	// We need this in static initializers too
+	private static final ConnectionPoolListener CONNECTION_POOL_LOGGER = new ConnectionPoolListener() {
+		@Override
+		public void connectionCheckOutStarted(ConnectionCheckOutStartedEvent event) {
+			LOGGER.debug("Pool checkout started: {}", event.getServerId());
+		}
+
+		@Override
+		public void connectionCheckedOut(ConnectionCheckedOutEvent event) {
+			LOGGER.debug("Pool checkout: {}", event.getConnectionId());
+		}
+
+		@Override
+		public void connectionCheckOutFailed(ConnectionCheckOutFailedEvent event) {
+			LOGGER.debug("Pool checkout FAILED: {} reason={}", event.getServerId(), event.getReason());
+		}
+
+		@Override
+		public void connectionCreated(ConnectionCreatedEvent event) {
+			LOGGER.debug("Connection created: {}", event.getConnectionId());
+		}
+
+		@Override
+		public void connectionClosed(ConnectionClosedEvent event) {
+			LOGGER.debug("Connection closed: {} reason={}", event.getConnectionId(), event.getReason());
+		}
+	};
+
 
 	// Expensive stuff shared among instances as much as possible, hence static
 	private static final Network NETWORK = Network.newNetwork();
@@ -161,6 +196,9 @@ public class MongoService implements Closeable {
 			.applyToClusterSettings(builder ->
 				builder.hosts(singletonList(serverAddress))
 			)
+			.applyToConnectionPoolSettings(builder ->
+				builder.addConnectionPoolListener(CONNECTION_POOL_LOGGER))
 			.build();
 	}
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ configure(subprojects.findAll {
 
 	tasks.withType(JavaCompile).configureEach {
 		options.encoding = 'UTF-8'
+
+		// Gradle is in control. We don't need javac meddling.
+		options.compilerArgs << '-implicit:none'
+
+		// Suppress some lint warnings
 		options.compilerArgs << '-Xlint'
 		options.compilerArgs << '-Xlint:-serial'     // Don't care about Java serialization
 		options.compilerArgs << '-Xlint:-try'        // Really annoying bogus "auto-closeable never used" warnings

--- a/lib-testing/src/main/resources/junit-platform.properties
+++ b/lib-testing/src/main/resources/junit-platform.properties
@@ -5,4 +5,5 @@ junit.jupiter.execution.parallel.mode.classes.default = concurrent
 # and causing timeouts due to our deliberately short timeout settings.
 junit.jupiter.execution.parallel.mode.default = same_thread
 
+# Way longer than tests should actually take; 5s would probably work
 junit.jupiter.execution.timeout.default=1m


### PR DESCRIPTION
We're now running so many MongoDriver tests so quickly that it exhausts ephemeral ports and causes spurious failures, at least on Windows.

I've added MONGO_CLIENT_FACTORY as a way for tests to make MainDriver reuse MongoClient objects, and now it needs just two `MongoClient` objects for the 1400+ tests in `MongoDriverConformanceTest`.

Perhaps we ought to generaize this into something the production driver does too; after all, if your app has two bosks, why should it need twice as many MongoClients?

### Other goodies
For tests, adds logging of Mongo connection pool events. Handy when `ReplayLogsOnFailure` kicks in because it will include these logs.