### PR TITLE
MongoDB: remove support for collections with no manifest

### DIFF
--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeListener.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeListener.java
@@ -21,7 +21,7 @@ interface ChangeListener {
 		InterruptedException,
 		IOException,
 		InitialStateActionException,
-		TimeoutException, FailedMongoClientSessionException;
+		TimeoutException, FailedMongoClientSessionException, InvalidCollectionContentsException;
 
 	/**
 	 * @param event is a document-specific event, with a non-null {@link ChangeStreamDocument#getDocumentKey() document key}.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
@@ -187,6 +187,9 @@ class ChangeReceiver implements Closeable {
 						} catch (UninitializedCollectionException e) {
 							disconnect("MongoDB collection is not initialized", REMEDY_RETURN, e);
 							return;
+						} catch (InvalidCollectionContentsException e) {
+							disconnect("MongoDB collection contents are invalid", REMEDY_RETURN, e);
+							return;
 						} catch (InitialStateActionException e) {
 							disconnect("Unable to initialize bosk state", REMEDY_RETURN, e);
 							return;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/InvalidCollectionContentsException.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/InvalidCollectionContentsException.java
@@ -1,0 +1,20 @@
+package works.bosk.drivers.mongo.internal;
+
+import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
+
+/**
+ * The collection contents don't obey the rules of the format declared by the manifest document.
+ */
+public class InvalidCollectionContentsException extends Exception {
+	InvalidCollectionContentsException(DatabaseFormat format, String details) {
+		super(message(format, details));
+	}
+
+	InvalidCollectionContentsException(DatabaseFormat format, String details, Throwable cause) {
+		super(message(format, details), cause);
+	}
+
+	private static String message(DatabaseFormat format, String details) {
+		return "Collection contents don't match " + format.name() + " format: " + details;
+	}
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -322,7 +322,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				LOGGER.warn("Failed to initialize database; disconnecting", e2);
 				setDisconnectedDriver(e2);
 			}
-		} catch (RuntimeException | UnrecognizedFormatException | IOException | FailedMongoClientSessionException e) {
+		} catch (RuntimeException | UnrecognizedFormatException | InvalidCollectionContentsException | IOException | FailedMongoClientSessionException e) {
 			switch (driverSettings.initialDatabaseUnavailableMode()) {
 				case FAIL_FAST:
 					LOGGER.debug("Unable to load initial state from database; aborting initialization", e);
@@ -497,7 +497,8 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			InterruptedException,
 			IOException,
 			InitialStateActionException,
-			TimeoutException
+			TimeoutException,
+			InvalidCollectionContentsException
 		{
 			LOGGER.debug("onConnectionSucceeded");
 			FutureTask<InitialState<R>> initialStateAction = this.taskRef.get();
@@ -615,7 +616,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		throw new AssertionError("Unknown database format setting: " + preferred);
 	}
 
-	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException {
+	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException, InvalidCollectionContentsException {
 		LOGGER.debug("Detecting format");
 		Manifest manifest = loadManifest();
 		DatabaseFormat format = manifest.pando().isPresent()? manifest.pando().get() : SEQUOIA;
@@ -640,12 +641,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 				return newFormatDriver(revisionAlreadySeen, format);
 			} else {
-				// Note that this message is confusing if the user specified
-				// a preference for Pando but no manifest file exists, because
-				// the message will say it couldn't find the Sequoia document.
-				// One day when we drop support for collections with no
-				// manifest, we can eliminate this confusion.
-				throw new UninitializedCollectionException("Document doesn't exist: "
+				throw new InvalidCollectionContentsException(format, "Document doesn't exist: "
 					+ "collection=" + driverSettings.database()
 					+ "." + COLLECTION_NAME
 					+ " id=" + documentId.getValue());
@@ -653,15 +649,16 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		}
 	}
 
-	private Manifest loadManifest() throws UnrecognizedFormatException {
+	private Manifest loadManifest() throws UnrecognizedFormatException, UninitializedCollectionException {
 		try (MongoCursor<BsonDocument> cursor = queryCollection.find(new BsonDocument("_id", MANIFEST_ID)).cursor()) {
 			if (cursor.hasNext()) {
 				LOGGER.debug("Found manifest");
 				return formatter.decodeManifest(cursor.next());
 			} else {
-				// For legacy databases with no manifest
-				LOGGER.debug("Manifest is missing; checking for Sequoia format in {}", driverSettings.database());
-				return Manifest.forSequoia();
+				throw new UninitializedCollectionException("No manifest document: "
+					+ "collection=" + driverSettings.database()
+					+ "." + COLLECTION_NAME
+					+ " id=" + MANIFEST_ID);
 			}
 		}
 	}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/ForwardingChangeListener.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/ForwardingChangeListener.java
@@ -13,7 +13,7 @@ class ForwardingChangeListener implements ChangeListener {
 	}
 
 	@Override
-	public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException, InterruptedException, IOException, InitialStateActionException, TimeoutException, FailedMongoClientSessionException {
+	public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException, InterruptedException, IOException, InitialStateActionException, TimeoutException, FailedMongoClientSessionException, InvalidCollectionContentsException {
 		downstream.onConnectionSucceeded();
 	}
 


### PR DESCRIPTION
This is a speed bump for multitenancy. I don't think there are any bosk collections in the known universe now that have no manifest.