### PR TITLE
MongoDB: Change manifest document ID so it sorts first

### DIFF
--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -836,7 +836,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	}
 
 	public static final String COLLECTION_NAME = "boskCollection";
-	public static final BsonString MANIFEST_ID = new BsonString("manifest");
+	public static final BsonString MANIFEST_ID = new BsonString("!manifest");
 	private static final Exception FAILURE_TO_COMPUTE_INITIAL_STATE = new InitialStateFailureException("Failure to compute initial state");
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainDriver.class);
 	private static final Logger UNINITIALIZED_COLLECTION_LOGGER = LoggerFactory.getLogger(UNINITIALIZED_COLLECTION_LOGGER_NAME);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -74,6 +74,13 @@ import static works.bosk.testing.BoskTestUtils.boskName;
 @ParameterizedClass
 @MethodSource("parameterSets")
 class MongoDriverSpecialTest extends AbstractMongoDriverTest {
+	/**
+	 * We deliberately don't reference {@link MainDriver#MANIFEST_ID} here
+	 * because if we change the manifest ID then that's a breaking change,
+	 * and we want this test to fail.
+	 */
+	public static final String MANIFEST_ID = "manifest";
+
 	ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
 
 	@BeforeEach
@@ -735,7 +742,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			.getDatabase(driverSettings.database())
 			.getCollection(MainDriver.COLLECTION_NAME);
 		collection.updateOne(
-			new BsonDocument("_id", new BsonString("manifest")),
+			new BsonDocument("_id", new BsonString(MANIFEST_ID)),
 			new BsonDocument("$inc", new BsonDocument("version", new BsonInt32(1)))
 		);
 		// Must also bump the revision number or else flush rightly does nothing

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -79,7 +79,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	 * because if we change the manifest ID then that's a breaking change,
 	 * and we want this test to fail.
 	 */
-	public static final String MANIFEST_ID = "manifest";
+	public static final String MANIFEST_ID = "!manifest";
 
 	ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
 


### PR DESCRIPTION
**_THIS IS A BREAKING CHANGE_**. There's no built-in support for migrating an existing bosk collection to account for this change. Operators would need to move the existing `manifest` document manually into a new file called `!manifest` while the application shut down.

We could have handled this more gracefully, but given that the latest version of bosk has no users, it didn't seem worth the effort.