### PR TITLE
Rename bosk-mongo manifest "!Manifest"

### DIFF
--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -3,11 +3,17 @@ package works.bosk.drivers.mongo;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Value;
+import org.bson.BsonString;
 import works.bosk.Bosk;
 import works.bosk.BoskDriver;
 
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
+import static works.bosk.drivers.mongo.MongoDriverSettings.InitialDatabaseUnavailableMode.DISCONNECT;
+import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestDocumentIdMode.STANDARD;
 import static works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode.EARNEST;
+import static works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode.HASTY;
+import static works.bosk.drivers.mongo.internal.MainDriver.LEGACY_MANIFEST_ID;
+import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 
 @Value
 @Builder(toBuilder = true)
@@ -47,6 +53,8 @@ public class MongoDriverSettings {
 	 */
 	@Default int timescaleMS = 10_000;
 
+	@Default ManifestDocumentIdMode manifestDocumentIdMode = STANDARD;
+
 	/**
 	 * @see DatabaseFormat#SEQUOIA
 	 * @see PandoFormat
@@ -58,7 +66,7 @@ public class MongoDriverSettings {
 	 * because it simplifies production deployments and repairs,
 	 * but these very fault-tolerance features can be confusing during development.
 	 */
-	@Default InitialDatabaseUnavailableMode initialDatabaseUnavailableMode = InitialDatabaseUnavailableMode.DISCONNECT;
+	@Default InitialDatabaseUnavailableMode initialDatabaseUnavailableMode = DISCONNECT;
 
 	@Default Experimental experimental = Experimental.builder().build();
 	@Default Testing testing = Testing.builder().build();
@@ -70,7 +78,7 @@ public class MongoDriverSettings {
 	@Builder
 	public static class Experimental {
 		@Default long changeStreamInitialWaitMS = 20;
-		@Default OrphanDocumentMode orphanDocumentMode = OrphanDocumentMode.HASTY;
+		@Default OrphanDocumentMode orphanDocumentMode = HASTY;
 	}
 
 	/**
@@ -90,7 +98,7 @@ public class MongoDriverSettings {
 	public sealed interface DatabaseFormat
 		permits SequoiaFormat, PandoFormat
 	{
-		public String name();
+		String name();
 
 		/**
 		 * Simple format that stores the entire bosk state in a single document,
@@ -141,6 +149,23 @@ public class MongoDriverSettings {
 		 * Unused documents may be left behind, to be cleaned up later.
 		 */
 		HASTY,
+	}
+
+	public enum ManifestDocumentIdMode {
+		/**
+		 * Use {@code manifest}
+		 */
+		LEGACY,
+
+		/**
+		 * Use {@code !manifest}
+		 */
+		STANDARD,
+		;
+
+		public BsonString manifestDocumentId() {
+			return this == LEGACY ? LEGACY_MANIFEST_ID : MANIFEST_ID;
+		}
 	}
 
 	public void validate() {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -158,7 +158,7 @@ public class MongoDriverSettings {
 		LEGACY,
 
 		/**
-		 * Use {@code !manifest}
+		 * Use {@code !Manifest}
 		 */
 		STANDARD,
 		;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -35,7 +35,6 @@ import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
-import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_IDS;
 
 @RequiredArgsConstructor
@@ -166,6 +165,8 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 			// deletes the old manifest and creates a new one with a different ID.
 			// We'll already be handling this when the manifest we care about changes;
 			// no need to react to the other one.
+			// Note that it actually doesn't matter which one we watch, as long
+			// as we watch just one.
 			LOGGER.debug("Ignoring event for different manifest document with ID {}", event.getDocumentKey().get("_id"));
 			return;
 		} else if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
@@ -203,9 +204,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	protected void writeManifest(Manifest manifest) {
-		BsonDocument doc = new BsonDocument("_id", MANIFEST_ID);
+		BsonDocument doc = new BsonDocument("_id", requireNonNull(manifestId));
 		doc.putAll((BsonDocument) formatter.object2bsonValue(manifest, Manifest.class));
-		BsonDocument filter = new BsonDocument("_id", MANIFEST_ID);
+		BsonDocument filter = new BsonDocument("_id", manifestId);
 		LOGGER.debug("| Initial manifest: {}", doc);
 		ReplaceOptions options = new ReplaceOptions().upsert(true);
 		UpdateResult result = collection.replaceOne(filter, doc, options);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -1,6 +1,7 @@
 package works.bosk.drivers.mongo.internal;
 
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
 import java.io.IOException;
 import java.util.Set;
@@ -26,7 +27,10 @@ import works.bosk.drivers.mongo.status.StateStatus;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 
+import static com.mongodb.client.model.changestream.OperationType.INSERT;
+import static com.mongodb.client.model.changestream.OperationType.REPLACE;
 import static java.util.Collections.newSetFromMap;
+import static java.util.Objects.requireNonNull;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
 
@@ -143,6 +147,32 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		LOGGER.debug("+ onRevisionToSkip({})", revision.longValue());
 		revisionToSkip = revision;
 		flushLock.finishedRevision(revision);
+	}
+
+	/**
+	 * We're required to cope with anything we might ourselves do in {@link #initializeCollection},
+	 * but outside that, we want to be as strict as possible
+	 * so incompatible database changes don't go unnoticed.
+	 */
+	protected void validateManifestEvent(ChangeStreamDocument<BsonDocument> event, Manifest effectiveManifest) throws UnprocessableEventException {
+		LOGGER.debug("onManifestEvent({})", event.getOperationType().name());
+		if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
+			BsonDocument manifestDoc = requireNonNull(event.getFullDocument());
+			Manifest manifest;
+			try {
+				manifest = formatter.decodeManifest(manifestDoc);
+			} catch (UnrecognizedFormatException e) {
+				throw new UnprocessableEventException("Invalid manifest", e, event.getOperationType());
+			}
+			if (!manifest.equals(effectiveManifest)) {
+				throw new UnprocessableEventException("Manifest indicates format has changed", event.getOperationType());
+			}
+		} else {
+			// We always use INSERT/REPLACE to update the manifest;
+			// anything else is unexpected.
+			throw new UnprocessableEventException("Unexpected change to manifest document", event.getOperationType());
+		}
+		LOGGER.debug("Ignoring benign manifest change event");
 	}
 
 	protected abstract BsonInt64 readRevisionNumber() throws FlushFailureException;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -3,7 +3,9 @@ package works.bosk.drivers.mongo.internal;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,8 @@ import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
+import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
+import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_IDS;
 
 @RequiredArgsConstructor
 abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implements FormatDriver<R> {
@@ -42,6 +46,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	final TransactionalCollection collection;
 	final BoskDriver downstream;
 	final FlushLock flushLock;
+	@Nullable final BsonString manifestId;
 
 	@Override
 	public MongoStatus readStatus() {
@@ -156,7 +161,14 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 */
 	protected void validateManifestEvent(ChangeStreamDocument<BsonDocument> event, Manifest effectiveManifest) throws UnprocessableEventException {
 		LOGGER.debug("onManifestEvent({})", event.getOperationType().name());
-		if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
+		if (!Objects.equals(manifestId, event.getDocumentKey().get("_id"))) {
+			// This is important to avoid additional disconnect churn when a refurbish
+			// deletes the old manifest and creates a new one with a different ID.
+			// We'll already be handling this when the manifest we care about changes;
+			// no need to react to the other one.
+			LOGGER.debug("Ignoring event for different manifest document with ID {}", event.getDocumentKey().get("_id"));
+			return;
+		} else if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
 			BsonDocument manifestDoc = requireNonNull(event.getFullDocument());
 			Manifest manifest;
 			try {
@@ -191,9 +203,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	protected void writeManifest(Manifest manifest) {
-		BsonDocument doc = new BsonDocument("_id", MainDriver.MANIFEST_ID);
+		BsonDocument doc = new BsonDocument("_id", MANIFEST_ID);
 		doc.putAll((BsonDocument) formatter.object2bsonValue(manifest, Manifest.class));
-		BsonDocument filter = new BsonDocument("_id", MainDriver.MANIFEST_ID);
+		BsonDocument filter = new BsonDocument("_id", MANIFEST_ID);
 		LOGGER.debug("| Initial manifest: {}", doc);
 		ReplaceOptions options = new ReplaceOptions().upsert(true);
 		UpdateResult result = collection.replaceOne(filter, doc, options);
@@ -210,6 +222,10 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		fieldValues.put(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(context.getAttributes()));
 
 		return fieldValues;
+	}
+
+	protected boolean isManifestID(BsonValue documentId) {
+		return MANIFEST_IDS.contains(documentId);
 	}
 
 	/**

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
@@ -82,7 +82,7 @@ final class Formatter extends BsonFormatter {
 	 */
 	static final BsonInt64 REVISION_ONE = new BsonInt64(1);
 
-	private final BsonInt32 SUPPORTED_MANIFEST_VERSION = new BsonInt32(1);
+	private static final Set<BsonInt32> SUPPORTED_MANIFEST_VERSIONS = Set.of(new BsonInt32(1));
 
 	//
 	// Helpers to translate Bosk <-> MongoDB
@@ -125,8 +125,8 @@ final class Formatter extends BsonFormatter {
 					throw new UnrecognizedFormatException("Unrecognized keys in manifest: " + keys);
 				}
 			}
-			if (!SUPPORTED_MANIFEST_VERSION.equals(manifest.getInt32("version"))) {
-				throw new UnrecognizedFormatException("Manifest version " + manifest.getInt32("version") + " not suppoted");
+			if (!SUPPORTED_MANIFEST_VERSIONS.contains(manifest.getInt32("version"))) {
+				throw new UnrecognizedFormatException("Manifest version " + manifest.getInt32("version") + " not supported");
 			}
 		} catch (ClassCastException e) {
 			throw new UnrecognizedFormatException("Manifest field has unexpected type", e);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -1,6 +1,7 @@
 package works.bosk.drivers.mongo.internal;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoClientSettings.Builder;
 import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
 import com.mongodb.WriteConcern;
@@ -35,6 +36,7 @@ import org.bson.BsonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.BoskDriver;
+import works.bosk.BoskDriver.InitialState.SingleTree;
 import works.bosk.BoskInfo;
 import works.bosk.Identifier;
 import works.bosk.Reference;
@@ -160,7 +162,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 					+ driverSettings.timescaleMS() // Extra buffer
 			;
 
-			MongoClientSettings.Builder commonSettingsBuilder = MongoClientSettings
+			Builder commonSettingsBuilder = MongoClientSettings
 				.builder(clientSettings)
 				.applyToServerSettings(s ->
 					// If timescaleMS is shorter than the default min heartbeat,
@@ -315,7 +317,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
 				var root = switch (initialState) {
-					case InitialState.SingleTree(var r) -> r;
+					case SingleTree(var r) -> r;
 				};
 				preferredDriver.initializeCollection(new StateAndMetadata<>(root, REVISION_ZERO, boskInfo.context().getAttributes()));
 				session.commitTransactionIfAny();
@@ -375,8 +377,9 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// FormatDriver must cope with deletions of the manifest document
 			// to avoid disconnection during refurbish operations,
 			// which is a burden. Let's just not.
-			// Note that this does delete LEGACY_MANIFEST_ID if it exists, which is deliberate.
-			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
+			// Note that this does delete the other manifest if it exists,
+			// which is deliberate.
+			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", driverSettings.manifestDocumentIdMode().manifestDocumentId()));
 			LOGGER.trace("Deleting state documents: {}", deletionFilter);
 			queryCollection.deleteMany(deletionFilter);
 
@@ -616,9 +619,11 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	private FormatDriver<R> newPreferredFormatDriver() {
 		DatabaseFormat preferred = driverSettings.preferredDatabaseFormat();
 		if (preferred.equals(SEQUOIA) || preferred instanceof PandoFormat) {
-			// TODO: We might want to offer a way to make new manifests
-			//  with the legacy ID
-			return newFormatDriver(REVISION_ZERO.longValue(), preferred, MANIFEST_ID);
+			return newFormatDriver(
+				REVISION_ZERO.longValue(),
+				preferred,
+				driverSettings.manifestDocumentIdMode().manifestDocumentId()
+			);
 		}
 		throw new AssertionError("Unknown database format setting: " + preferred);
 	}
@@ -685,6 +690,15 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				LOGGER.debug("Manifest is missing; checking for Sequoia format in {}", driverSettings.database());
 				return new ManifestInfo(Manifest.forSequoia(), null);
 			}
+		}
+	}
+
+	/**
+	 * Meant for tests
+	 */
+	ManifestInfo loadManifestInfo() throws UnrecognizedFormatException, FailedMongoClientSessionException {
+		try (var _ = queryCollection.newReadOnlySession()) {
+			return loadManifest();
 		}
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -874,7 +874,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	}
 
 	public static final String COLLECTION_NAME = "boskCollection";
-	public static final BsonString MANIFEST_ID = new BsonString("!manifest");
+	public static final BsonString MANIFEST_ID = new BsonString("!Manifest");
 	public static final BsonString LEGACY_MANIFEST_ID = new BsonString("manifest");
 	public static final Set<BsonValue> MANIFEST_IDS = Set.of(MANIFEST_ID, LEGACY_MANIFEST_ID);
 	private static final Exception FAILURE_TO_COMPUTE_INITIAL_STATE = new InitialStateFailureException("Failure to compute initial state");

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -10,11 +10,14 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import jakarta.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeoutException;
@@ -24,6 +27,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
@@ -362,14 +366,16 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		try {
 			// Design note: this operation shouldn't do any special coordination with
 			// the receiver/listener system, because other replicas won't.
-			// That system needs to cope with a refurbish operations without any help.
+			// That system needs to cope with refurbish operations without any help.
 			StateAndMetadata<R> result = formatDriver.loadAllState();
 			FormatDriver<R> newFormatDriver = newPreferredFormatDriver();
 
 			// initializeCollection is required to replace the manifest anyway,
 			// so deleting it has no value; and if we do delete it, then every
-			// FormatDriver must cope with deletions of the manifest document,
+			// FormatDriver must cope with deletions of the manifest document
+			// to avoid disconnection during refurbish operations,
 			// which is a burden. Let's just not.
+			// Note that this does delete LEGACY_MANIFEST_ID if it exists, which is deliberate.
 			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
 			LOGGER.trace("Deleting state documents: {}", deletionFilter);
 			queryCollection.deleteMany(deletionFilter);
@@ -451,7 +457,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			var _ = queryCollection.newReadOnlySession()
 		) {
 			MongoStatus partialResult = detectFormat().readStatus();
-			Manifest manifest = loadManifest(); // TODO: Avoid loading the manifest again
+			Manifest manifest = loadManifest().manifest(); // TODO: Avoid loading the manifest again
 			return partialResult.with(driverSettings.preferredDatabaseFormat(), manifest);
 		}
 	}
@@ -610,14 +616,17 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	private FormatDriver<R> newPreferredFormatDriver() {
 		DatabaseFormat preferred = driverSettings.preferredDatabaseFormat();
 		if (preferred.equals(SEQUOIA) || preferred instanceof PandoFormat) {
-			return newFormatDriver(REVISION_ZERO.longValue(), preferred);
+			// TODO: We might want to offer a way to make new manifests
+			//  with the legacy ID
+			return newFormatDriver(REVISION_ZERO.longValue(), preferred, MANIFEST_ID);
 		}
 		throw new AssertionError("Unknown database format setting: " + preferred);
 	}
 
 	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException {
 		LOGGER.debug("Detecting format");
-		Manifest manifest = loadManifest();
+		var manifestInfo = loadManifest();
+		Manifest manifest = manifestInfo.manifest();
 		DatabaseFormat format = manifest.pando().isPresent()? manifest.pando().get() : SEQUOIA;
 		BsonString documentId = (format == SEQUOIA)
 			? SequoiaFormatDriver.DOCUMENT_ID
@@ -638,7 +647,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				// TODO: We really need a better way to deal with revision numbers
 				long revisionAlreadySeen = revision.longValue()-1;
 
-				return newFormatDriver(revisionAlreadySeen, format);
+				return newFormatDriver(revisionAlreadySeen, format, manifestInfo.manifestId());
 			} else {
 				// Note that this message is confusing if the user specified
 				// a preference for Pando but no manifest file exists, because
@@ -653,20 +662,33 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		}
 	}
 
-	private Manifest loadManifest() throws UnrecognizedFormatException {
-		try (MongoCursor<BsonDocument> cursor = queryCollection.find(new BsonDocument("_id", MANIFEST_ID)).cursor()) {
+	record ManifestInfo(Manifest manifest, @Nullable BsonString manifestId) {}
+
+	private ManifestInfo loadManifest() throws UnrecognizedFormatException {
+		try (MongoCursor<BsonDocument> cursor = queryCollection.find(new BsonDocument("_id",
+			new BsonDocument("$in", new BsonArray(List.of(MANIFEST_ID, LEGACY_MANIFEST_ID)))
+		)).cursor()) {
 			if (cursor.hasNext()) {
-				LOGGER.debug("Found manifest");
-				return formatter.decodeManifest(cursor.next());
+				BsonDocument doc = cursor.next();
+				if (doc.get("_id").equals(LEGACY_MANIFEST_ID)) {
+					LOGGER.info("Found legacy manifest");
+				} else {
+					LOGGER.debug("Found manifest");
+				}
+				Manifest result = formatter.decodeManifest(doc);
+				if (cursor.hasNext()) {
+					throw new UnrecognizedFormatException("Multiple manifest documents found");
+				}
+				return new ManifestInfo(result, doc.getString("_id"));
 			} else {
 				// For legacy databases with no manifest
 				LOGGER.debug("Manifest is missing; checking for Sequoia format in {}", driverSettings.database());
-				return Manifest.forSequoia();
+				return new ManifestInfo(Manifest.forSequoia(), null);
 			}
 		}
 	}
 
-	private FormatDriver<R> newFormatDriver(long revisionAlreadySeen, DatabaseFormat format) {
+	private FormatDriver<R> newFormatDriver(long revisionAlreadySeen, DatabaseFormat format, @Nullable BsonString manifestId) {
 		if (format.equals(SEQUOIA)) {
 			return new SequoiaFormatDriver<>(
 				boskInfo,
@@ -674,6 +696,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				driverSettings,
 				bsonSerializer,
 				new FlushLock(revisionAlreadySeen, flushTimeout),
+				manifestId,
 				downstream);
 		} else if (format instanceof PandoFormat pandoFormat) {
 			return new PandoFormatDriver<>(
@@ -683,6 +706,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				pandoFormat,
 				bsonSerializer,
 				new FlushLock(revisionAlreadySeen, flushTimeout),
+				manifestId,
 				downstream);
 		}
 		throw new IllegalArgumentException("Unexpected database format: " + format);
@@ -836,7 +860,9 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	}
 
 	public static final String COLLECTION_NAME = "boskCollection";
-	public static final BsonString MANIFEST_ID = new BsonString("manifest");
+	public static final BsonString MANIFEST_ID = new BsonString("!manifest");
+	public static final BsonString LEGACY_MANIFEST_ID = new BsonString("manifest");
+	public static final Set<BsonValue> MANIFEST_IDS = Set.of(MANIFEST_ID, LEGACY_MANIFEST_ID);
 	private static final Exception FAILURE_TO_COMPUTE_INITIAL_STATE = new InitialStateFailureException("Failure to compute initial state");
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainDriver.class);
 	private static final Logger UNINITIALIZED_COLLECTION_LOGGER = LoggerFactory.getLogger(UNINITIALIZED_COLLECTION_LOGGER_NAME);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Manifest.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Manifest.java
@@ -10,7 +10,7 @@ import works.bosk.drivers.mongo.PandoFormat;
  * Defines the format of the manifest document, which is stored in the database
  * to describe the database contents.
  *
- * @param version the version of the format of the manifest itself; currently always 1
+ * @param version the version of the format of the manifest itself; currently must be 1
  * @param sequoia if present, indicates that the database is in the Sequoia format
  * @param pando if present, indicates that the database is in the Pando format and describes how it's configured
  */

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -78,9 +78,10 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		MongoDriverSettings driverSettings,
 		PandoFormat format, BsonSerializer bsonSerializer,
 		FlushLock flushLock,
+		BsonString manifestId,
 		BoskDriver downstream
 	) {
-		super(boskInfo.rootReference(), boskInfo.context(), new Formatter(boskInfo, bsonSerializer), collection, downstream, flushLock);
+		super(boskInfo.rootReference(), boskInfo.context(), new Formatter(boskInfo, bsonSerializer), collection, downstream, flushLock, manifestId);
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 		this.settings = driverSettings;
 		this.format = format;
@@ -200,7 +201,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		assert event.getDocumentKey() != null;
 		BsonValue bsonDocumentID = event.getDocumentKey().get("_id");
-		if (MainDriver.MANIFEST_ID.equals(bsonDocumentID)) {
+		if (isManifestID(bsonDocumentID)) {
 			onManifestEvent(event);
 			return;
 		}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -50,10 +50,8 @@ import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.changestream.OperationType.INSERT;
-import static com.mongodb.client.model.changestream.OperationType.REPLACE;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.bson.BsonBoolean.TRUE;
@@ -396,30 +394,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 	}
 
-	/**
-	 * We're required to cope with anything we might ourselves do in {@link #initializeCollection},
-	 * but outside that, we want to be as strict as possible
-	 * so incompatible database changes don't go unnoticed.
-	 */
 	private void onManifestEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
-		LOGGER.debug("onManifestEvent({})", event.getOperationType().name());
-		if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
-			BsonDocument manifestDoc = requireNonNull(event.getFullDocument());
-			Manifest manifest;
-			try {
-				manifest = formatter.decodeManifest(manifestDoc);
-			} catch (UnrecognizedFormatException e) {
-				throw new UnprocessableEventException("Invalid manifest", e, event.getOperationType());
-			}
-			if (!manifest.equals(Manifest.forPando(format))) {
-				throw new UnprocessableEventException("Manifest indicates format has changed", event.getOperationType());
-			}
-		} else {
-			// PandoFormatDriver always uses INSERT/REPLACE to update the manifest;
-			// anything else is unexpected.
-			throw new UnprocessableEventException("Unexpected change to manifest document", event.getOperationType());
-		}
-		LOGGER.debug("Ignoring benign manifest change event");
+		validateManifestEvent(event, Manifest.forPando(format));
 	}
 
 	private static boolean updateEventHasField(ChangeStreamDocument<BsonDocument> event, DocumentFields field) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -32,9 +32,6 @@ import works.bosk.exceptions.InvalidTypeException;
 import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
-import static com.mongodb.client.model.changestream.OperationType.INSERT;
-import static com.mongodb.client.model.changestream.OperationType.REPLACE;
-import static java.util.Objects.requireNonNull;
 import static org.bson.BsonBoolean.FALSE;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.referenceTo;
@@ -221,24 +218,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	 * so incompatible database changes don't go unnoticed.
 	 */
 	private void onManifestEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
-		LOGGER.debug("onManifestEvent({})", event.getOperationType().name());
-		if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
-			BsonDocument manifest = requireNonNull(event.getFullDocument());
-			manifest.remove("_id");
-			try {
-				formatter.validateManifest(manifest);
-			} catch (UnrecognizedFormatException e) {
-				throw new UnprocessableEventException("Invalid manifest", e, event.getOperationType());
-			}
-			if (!new BsonDocument().equals(manifest.get("sequoia"))) {
-				throw new UnprocessableEventException("Unexpected value in manifest \"sequoia\" field: " + manifest.get("sequoia"), event.getOperationType());
-			}
-		} else {
-			// SequoiaFormatDriver always uses INSERT/REPLACE to update the manifest;
-			// anything else is unexpected.
-			throw new UnprocessableEventException("Unexpected change to manifest document", event.getOperationType());
-		}
-		LOGGER.debug("Ignoring benign manifest change event");
+		validateManifestEvent(event, Manifest.forSequoia());
 	}
 
 	//

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -36,7 +36,6 @@ import static org.bson.BsonBoolean.FALSE;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.referenceTo;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
-import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 
 /**
  * Implements the {@link MongoDriverSettings.DatabaseFormat#SEQUOIA Sequoia} format.
@@ -52,9 +51,10 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 		MongoDriverSettings driverSettings,
 		BsonSerializer bsonSerializer,
 		FlushLock flushLock,
+		@Nullable BsonString manifestId,
 		BoskDriver downstream
 	) {
-		super(boskInfo.rootReference(), boskInfo.context(), new Formatter(boskInfo, bsonSerializer), collection, downstream, flushLock);
+		super(boskInfo.rootReference(), boskInfo.context(), new Formatter(boskInfo, bsonSerializer), collection, downstream, flushLock, manifestId);
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 	}
 
@@ -142,7 +142,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	@Override
 	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		assert event.getDocumentKey() != null;
-		if (MANIFEST_ID.equals(event.getDocumentKey().get("_id"))) {
+		if (isManifestID(event.getDocumentKey().get("_id"))) {
 			onManifestEvent(event);
 			return;
 		}
@@ -255,7 +255,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			}
 		} catch (NoSuchElementException e) {
 			LOGGER.debug("Document is missing", e);
-			throw new RevisionFieldDisruptedException(e);
+			throw new RevisionFieldDisruptedException("State document is missing", e);
 		} catch (RuntimeException e) {
 			LOGGER.debug("readRevisionNumber failed", e);
 			throw new FlushFailureException(e);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/AbstractMongoDriverTest.java
@@ -1,13 +1,10 @@
 package works.bosk.drivers.mongo.internal;
 
 import ch.qos.logback.classic.Level;
-import com.mongodb.client.MongoCollection;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,21 +91,6 @@ abstract class AbstractMongoDriverTest {
 	void runTearDown(TestInfo testInfo) {
 		tearDownActions.forEach(Runnable::run);
 		logTest("\\=== Done", testInfo);
-	}
-
-	public void changeManifestToLegacyFormat() {
-		MongoCollection<BsonDocument> collection = mongoService.client()
-			.getDatabase(driverSettings.database())
-			.getCollection(COLLECTION_NAME, BsonDocument.class);
-		BsonDocument modernManifestFilter = new BsonDocument("_id", MainDriver.MANIFEST_ID);
-		var existingManifest = collection
-			.find(modernManifestFilter)
-			.first();
-		var legacyManifest = existingManifest.clone()
-			.append("_id", MainDriver.LEGACY_MANIFEST_ID)
-			.append("version", new BsonInt32(1));
-		collection.deleteOne(modernManifestFilter);
-		collection.insertOne(legacyManifest);
 	}
 
 	public static void logTest(String verb, TestInfo testInfo) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/AbstractMongoDriverTest.java
@@ -1,10 +1,13 @@
 package works.bosk.drivers.mongo.internal;
 
 import ch.qos.logback.classic.Level;
+import com.mongodb.client.MongoCollection;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,6 +94,21 @@ abstract class AbstractMongoDriverTest {
 	void runTearDown(TestInfo testInfo) {
 		tearDownActions.forEach(Runnable::run);
 		logTest("\\=== Done", testInfo);
+	}
+
+	public void changeManifestToLegacyFormat() {
+		MongoCollection<BsonDocument> collection = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		BsonDocument modernManifestFilter = new BsonDocument("_id", MainDriver.MANIFEST_ID);
+		var existingManifest = collection
+			.find(modernManifestFilter)
+			.first();
+		var legacyManifest = existingManifest.clone()
+			.append("_id", MainDriver.LEGACY_MANIFEST_ID)
+			.append("version", new BsonInt32(1));
+		collection.deleteOne(modernManifestFilter);
+		collection.insertOne(legacyManifest);
 	}
 
 	public static void logTest(String verb, TestInfo testInfo) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -74,6 +74,13 @@ import static works.bosk.testing.BoskTestUtils.boskName;
 @ParameterizedClass
 @MethodSource("parameterSets")
 class MongoDriverSpecialTest extends AbstractMongoDriverTest {
+	/**
+	 * We deliberately don't reference {@link MainDriver#MANIFEST_ID} here
+	 * because if we change the manifest ID then that's a breaking change,
+	 * and we want this test to fail.
+	 */
+	public static final String MANIFEST_ID = "manifest";
+
 	ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
 
 	@BeforeEach
@@ -735,7 +742,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			.getDatabase(driverSettings.database())
 			.getCollection(MainDriver.COLLECTION_NAME);
 		collection.updateOne(
-			new BsonDocument("_id", new BsonString("manifest")),
+			new BsonDocument("_id", new BsonString(MANIFEST_ID)),
 			new BsonDocument("$inc", new BsonDocument("version", new BsonInt32(1)))
 		);
 		// Must also bump the revision number or else flush rightly does nothing

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -83,7 +83,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	 * because if we change the manifest ID then that's a breaking change,
 	 * and we want this test to fail.
 	 */
-	public static final String MANIFEST_ID = "!manifest";
+	public static final String MANIFEST_ID = "!Manifest";
 	public static final String LEGACY_MANIFEST_ID = "manifest"; // Ditto
 
 	ErrorRecordingChangeListener.ErrorRecorder errorRecorder;

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import lombok.With;
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
@@ -18,8 +19,10 @@ import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -61,6 +64,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,7 +83,8 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	 * because if we change the manifest ID then that's a breaking change,
 	 * and we want this test to fail.
 	 */
-	public static final String MANIFEST_ID = "manifest";
+	public static final String MANIFEST_ID = "!manifest";
+	public static final String LEGACY_MANIFEST_ID = "manifest"; // Ditto
 
 	ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
 
@@ -809,6 +814,131 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			assertEquals(1L, doc.getLong(Formatter.DocumentFields.revision.name()));
 		}
 
+	}
+
+	/**
+	 * Note that we don't test upgrading the manifest and also changing the format at the same time.
+	 * That should work in theory, but it's not recommended.
+	 */
+	@Disabled("Leads to expected errors. This is a good test but it doesn't really belong in this class.")
+	@Test
+	void manifestUpgrade_works() throws InvalidTypeException, IOException, InterruptedException {
+		TestValues distinctiveValues = TestValues.blank().withString("distinctive value");
+
+		LOGGER.debug("Initialize the database");
+		{
+			Bosk<TestEntity> initializeBosk = new Bosk<>(
+				boskName("Initialize"),
+				TestEntity.class,
+				AbstractMongoDriverTest::initialState,
+				BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+			var initializeRefs = initializeBosk.buildReferences(Refs.class);
+
+			BoskDriver driver = initializeBosk.driver();
+			driver.submitReplacement(initializeRefs.values(), distinctiveValues);
+			driver.flush();
+			initializeBosk.getDriver(MongoDriver.class).close();
+		}
+
+		LOGGER.debug("Use the legacy ID for the manifest");
+		MongoCollection<BsonDocument> collection = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(MainDriver.COLLECTION_NAME, BsonDocument.class);
+		BsonDocument newManifest;
+		try (var cursor = findManifestDocs(collection)) {
+			newManifest = cursor.next();
+		}
+		collection.deleteOne(new BsonDocument("_id", new BsonString(MANIFEST_ID)));
+		newManifest.put("_id", new BsonString(LEGACY_MANIFEST_ID));
+		newManifest.put("version", new BsonInt32(1));
+		collection.insertOne(newManifest);
+
+		LOGGER.debug("Connect bosk for refurbishing and verify contents");
+		Bosk<TestEntity> refurbishBosk = new Bosk<>(
+			boskName("Main"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+
+		TestEntity expected = initialRoot(refurbishBosk).withValues(Optional.of(distinctiveValues));
+		TestEntity actual;
+		try (var _ = refurbishBosk.readSession()) {
+			actual = refurbishBosk.rootReference().value();
+		}
+		assertEquals(expected, actual);
+
+		LOGGER.debug("Verify manifest document still has legacy ID");
+		var legacyManifest = assertUniqueManifest(collection, LEGACY_MANIFEST_ID);
+		assertEquals(new BsonInt32(1), legacyManifest.getInt32("version"), "Legacy manifest should have version 1");
+
+		LOGGER.debug("Create bystander bosk");
+		Bosk<TestEntity> bystanderBosk = new Bosk<>(
+			boskName("Bystander"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+
+		LOGGER.debug("Refurbish");
+		MongoDriver refurbishDriver = refurbishBosk.getDriver(MongoDriver.class);
+		refurbishDriver.refurbish();
+
+		LOGGER.debug("Verify manifest ID has been updated and state is intact");
+		var refurbishedManifest = assertUniqueManifest(collection, MANIFEST_ID);
+		assertEquals(new BsonInt32(2), refurbishedManifest.getInt32("version"), "Manifest version should have been bumped to 2");
+		for (String format: List.of("sequoia", "pando")) {
+			// Note: technically this is not the contract here:
+			// refurbish should change the format to be the preferred format, not leave it unchanged.
+			// However, since initializeBosk uses the same preferred format, the format is in fact unchanged.
+			assertEquals(
+				legacyManifest.get(format),
+				refurbishedManifest.get(format),
+				"Refurbish should not have changed the " + format + " field");
+		}
+
+		LOGGER.debug("Refurbish again to verify drivers can consume their own manifest update events");
+		refurbishBosk.driver().flush(); // Make sure we've already seen the first update
+		refurbishDriver.refurbish();
+		refurbishBosk.driver().flush(); // Make sure we've seen the second update
+		errorRecorder.assertAllClear("after second refurbish");
+
+		LOGGER.debug("Verify bystander's state");
+		try (var _ = bystanderBosk.readSession()) {
+			actual = bystanderBosk.rootReference().value();
+			assertEquals(expected, actual);
+		}
+
+		LOGGER.debug("Update state to make sure both bosks are still live");
+		var refurbishRefs = refurbishBosk.buildReferences(Refs.class);
+		refurbishBosk.driver().submitReplacement(refurbishRefs.valuesString(), "new string");
+		refurbishBosk.driver().flush();
+		var expected2 = expected.withValues(Optional.of(expected.values().get().withString("new string")));
+		try (var _ = refurbishBosk.readSession()) {
+			assertEquals(expected2, refurbishBosk.rootReference().value(), "Refurbish bosk should see the change");
+		}
+		bystanderBosk.driver().flush();
+		try (var _ = bystanderBosk.readSession()) {
+			assertEquals(expected2, bystanderBosk.rootReference().value(), "Bystander bosk should see the change");
+		}
+		errorRecorder.assertAllClear("after update");
+
+	}
+
+	private static BsonDocument assertUniqueManifest(MongoCollection<BsonDocument> collection, String expectedID) {
+		try (MongoCursor<BsonDocument> cursor = findManifestDocs(collection)) {
+			assertTrue(cursor.hasNext(), "Manifest document must exist");
+			BsonDocument manifestDoc = cursor.next();
+			assertEquals(expectedID, manifestDoc.getString("_id").getValue(),
+				"Manifest document must still have legacy ID");
+			assertFalse(cursor.hasNext(), "Must be just one manifest");
+			return manifestDoc;
+		}
+	}
+
+	private static @NonNull MongoCursor<BsonDocument> findManifestDocs(MongoCollection<BsonDocument> collection) {
+		List<BsonString> manifestIDs = Stream.of(MANIFEST_ID, LEGACY_MANIFEST_ID).map(BsonString::new).toList();
+		return collection.find(new BsonDocument("_id",
+			new BsonDocument("$in", new BsonArray(manifestIDs))
+		)).cursor();
 	}
 
 	private void deleteFields(MongoCollection<Document> collection, Formatter.DocumentFields... fields) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
@@ -2,10 +2,13 @@ package works.bosk.drivers.mongo.internal;
 
 import ch.qos.logback.classic.Level;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +36,11 @@ import static works.bosk.testing.BoskTestUtils.boskName;
 
 @Slow
 @InjectFields
-@InjectFrom({SchemaEvolutionTest.FromConfigInjector.class, SchemaEvolutionTest.ToConfigInjector.class})
+@InjectFrom({
+	SchemaEvolutionTest.FromConfigInjector.class,
+	SchemaEvolutionTest.ToConfigInjector.class,
+	SchemaEvolutionTest.ManifestScenarioInjector.class
+})
 public class SchemaEvolutionTest {
 
 	@Injected
@@ -43,6 +50,27 @@ public class SchemaEvolutionTest {
 	@Injected
 	@To
 	Configuration toConfig;
+
+	@Injected ManifestScenario manifestScenario;
+
+	enum ManifestScenario {
+		LEGACY(1, "manifest"),
+		NEW(2, "!manifest");
+
+		final BsonInt32 manifestVersion;
+		final BsonString documentId;
+
+		ManifestScenario(int manifestVersion, String documentId) {
+			this.manifestVersion = new BsonInt32(manifestVersion);
+			this.documentId = new BsonString(documentId);
+		}
+
+		public void fixupManifestIfNecessary(Helper fromHelper) {
+			if (this == LEGACY) {
+				fromHelper.changeManifestToLegacyFormat();
+			}
+		}
+	}
 
 	private Helper fromHelper;
 	private Helper toHelper;
@@ -84,6 +112,8 @@ public class SchemaEvolutionTest {
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);
 		Refs fromRefs = fromBosk.buildReferences(Refs.class);
 
+		manifestScenario.fixupManifestIfNecessary(fromHelper);
+
 		// TODO: Make this test less lame
 		LOGGER.debug("Set distinctive string");
 		fromBosk.driver().submitReplacement(fromRefs.string(), "Distinctive String");
@@ -101,6 +131,16 @@ public class SchemaEvolutionTest {
 		LOGGER.debug("Refurbish");
 		MongoDriver driver = toBosk.getDriver(MongoDriver.class);
 		driver.refurbish();
+
+
+		LOGGER.debug("Verify that the manifest prescribes the preferred format");
+		try (var _ = toBosk.readSession()) {
+			var status = driver.readStatus();
+			assertEquals(
+				Manifest.forFormat(toConfig.preferredFormat),
+				status.manifest().actual()
+			);
+		}
 
 		LOGGER.debug("Perform fromBosk read");
 		try (var _ = fromBosk.readSession()) {
@@ -121,6 +161,8 @@ public class SchemaEvolutionTest {
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);
 		Refs fromRefs = fromBosk.buildReferences(Refs.class);
 
+		manifestScenario.fixupManifestIfNecessary(fromHelper);
+
 		LOGGER.debug("Create toBosk [{}]", toHelper.name);
 		Bosk<TestEntity> toBosk = newBosk(toHelper);
 		Refs toRefs = toBosk.buildReferences(Refs.class);
@@ -130,6 +172,15 @@ public class SchemaEvolutionTest {
 		driver.refurbish();
 
 		flushIfLiveRefurbishIsNotSupported(fromBosk, fromHelper, toHelper);
+
+		LOGGER.debug("Verify that the manifest prescribes the preferred format");
+		try (var _ = toBosk.readSession()) {
+			var status = driver.readStatus();
+			assertEquals(
+				Manifest.forFormat(toConfig.preferredFormat),
+				status.manifest().actual()
+			);
+		}
 
 		LOGGER.debug("Set distinctive string using fromBosk ({})", fromBosk.name());
 		fromBosk.driver().submitReplacement(fromRefs.string(), "Distinctive String");
@@ -200,9 +251,9 @@ public class SchemaEvolutionTest {
 	}
 
 	static abstract class ConfigInjector implements Injector {
-		private final Class<? extends java.lang.annotation.Annotation> annotationType;
+		private final Class<? extends Annotation> annotationType;
 
-		ConfigInjector(Class<? extends java.lang.annotation.Annotation> annotationType) {
+		ConfigInjector(Class<? extends Annotation> annotationType) {
 			this.annotationType = annotationType;
 		}
 
@@ -235,6 +286,18 @@ public class SchemaEvolutionTest {
 		new Configuration(PandoFormat.oneBigDocument()),
 		new Configuration(PandoFormat.withGraftPoints("/catalog", "/sideTable"))
 	);
+
+	record ManifestScenarioInjector() implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType == SchemaEvolutionTest.ManifestScenario.class;
+		}
+
+		@Override
+		public List<ManifestScenario> values() {
+			return List.of(ManifestScenario.values());
+		}
+	}
 
 	static final class Helper extends AbstractMongoDriverTest {
 		final String name;

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,6 @@ import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.junit.InjectFields;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
-import works.bosk.junit.InjectedTest;
 import works.bosk.junit.Injector;
 import works.bosk.testing.drivers.state.TestEntity;
 import works.bosk.testing.junit.Slow;
@@ -77,7 +77,7 @@ public class SchemaEvolutionTest {
 		toHelper  .runTearDown(testInfo);
 	}
 
-	@InjectedTest
+	@Test
 	void pairwise_readCompatible() throws Exception {
 		LOGGER.debug("Create fromBosk [{}]", fromHelper.name);
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);
@@ -113,7 +113,7 @@ public class SchemaEvolutionTest {
 //		System.out.println("Status: " + ((MongoDriver<?>)toBosk.driver()).readStatus());
 	}
 
-	@InjectedTest
+	@Test
 	void pairwise_writeCompatible() throws Exception {
 		LOGGER.debug("Create fromBosk [{}]", fromHelper.name);
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
@@ -28,6 +28,7 @@ import works.bosk.testing.drivers.state.TestEntity;
 import works.bosk.testing.junit.Slow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 @Slow
@@ -83,6 +84,7 @@ public class SchemaEvolutionTest {
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);
 		Refs fromRefs = fromBosk.buildReferences(Refs.class);
 
+		// TODO: Make this test less lame
 		LOGGER.debug("Set distinctive string");
 		fromBosk.driver().submitReplacement(fromRefs.string(), "Distinctive String");
 		fromBosk.driver().flush();
@@ -160,8 +162,8 @@ public class SchemaEvolutionTest {
 		Helper helperForUpdate,
 		Helper helperForRefurbish
 	) throws IOException, InterruptedException {
-		if (helperForUpdate.driverSettings.preferredDatabaseFormat() == MongoDriverSettings.DatabaseFormat.SEQUOIA
-			&& helperForRefurbish.driverSettings.preferredDatabaseFormat() != MongoDriverSettings.DatabaseFormat.SEQUOIA) {
+		if (SEQUOIA == helperForUpdate.driverSettings.preferredDatabaseFormat()
+			&& SEQUOIA != helperForRefurbish.driverSettings.preferredDatabaseFormat()) {
 			// When switching format classes, the old format's state documents
 			// disappear.
 			//
@@ -229,7 +231,7 @@ public class SchemaEvolutionTest {
 	}
 
 	private static final List<Configuration> CONFIGURATIONS = List.of(
-		new Configuration(MongoDriverSettings.DatabaseFormat.SEQUOIA),
+		new Configuration(SEQUOIA),
 		new Configuration(PandoFormat.oneBigDocument()),
 		new Configuration(PandoFormat.withGraftPoints("/catalog", "/sideTable"))
 	);
@@ -241,8 +243,7 @@ public class SchemaEvolutionTest {
 			super(MongoDriverSettings.builder()
 				.database(SchemaEvolutionTest.class.getSimpleName() + "_" + dbCounter)
 				.preferredDatabaseFormat(config.preferredFormat())
-				.experimental(MongoDriverSettings.Experimental.builder()
-					.build()));
+			);
 			this.name = config.preferredFormat().toString().toLowerCase(Locale.ROOT);
 		}
 
@@ -253,8 +254,7 @@ public class SchemaEvolutionTest {
 	}
 
 	public interface Refs {
-		@ReferencePath("/string")
-		Reference<String> string();
+		@ReferencePath("/string") Reference<String> string();
 	}
 
 	private static final AtomicInteger DB_COUNTER = new AtomicInteger(0);

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
@@ -7,8 +7,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.bson.BsonInt32;
-import org.bson.BsonString;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +22,7 @@ import works.bosk.annotations.ReferencePath;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.drivers.mongo.internal.MainDriver.ManifestInfo;
 import works.bosk.junit.InjectFields;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
@@ -32,6 +32,10 @@ import works.bosk.testing.junit.Slow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
+import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestDocumentIdMode.LEGACY;
+import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestDocumentIdMode.STANDARD;
+import static works.bosk.drivers.mongo.internal.MainDriver.LEGACY_MANIFEST_ID;
+import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 @Slow
@@ -39,7 +43,6 @@ import static works.bosk.testing.BoskTestUtils.boskName;
 @InjectFrom({
 	SchemaEvolutionTest.FromConfigInjector.class,
 	SchemaEvolutionTest.ToConfigInjector.class,
-	SchemaEvolutionTest.ManifestScenarioInjector.class
 })
 public class SchemaEvolutionTest {
 
@@ -50,27 +53,6 @@ public class SchemaEvolutionTest {
 	@Injected
 	@To
 	Configuration toConfig;
-
-	@Injected ManifestScenario manifestScenario;
-
-	enum ManifestScenario {
-		LEGACY(1, "manifest"),
-		NEW(2, "!manifest");
-
-		final BsonInt32 manifestVersion;
-		final BsonString documentId;
-
-		ManifestScenario(int manifestVersion, String documentId) {
-			this.manifestVersion = new BsonInt32(manifestVersion);
-			this.documentId = new BsonString(documentId);
-		}
-
-		public void fixupManifestIfNecessary(Helper fromHelper) {
-			if (this == LEGACY) {
-				fromHelper.changeManifestToLegacyFormat();
-			}
-		}
-	}
 
 	private Helper fromHelper;
 	private Helper toHelper;
@@ -112,7 +94,16 @@ public class SchemaEvolutionTest {
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);
 		Refs fromRefs = fromBosk.buildReferences(Refs.class);
 
-		manifestScenario.fixupManifestIfNecessary(fromHelper);
+		try (var _ = fromBosk.readSession()) {
+			ManifestInfo expected = fromConfig.expectedManifestInfo();
+			LOGGER.debug("Confirm starting manifest is {}", expected);
+			assertEquals(
+				expected,
+				fromBosk.getDriver(MainDriver.class).loadManifestInfo()
+			);
+		}
+
+		LOGGER.debug("Confirm starting manifest ID");
 
 		// TODO: Make this test less lame
 		LOGGER.debug("Set distinctive string");
@@ -133,12 +124,12 @@ public class SchemaEvolutionTest {
 		driver.refurbish();
 
 
-		LOGGER.debug("Verify that the manifest prescribes the preferred format");
 		try (var _ = toBosk.readSession()) {
-			var status = driver.readStatus();
+			ManifestInfo expected = toConfig.expectedManifestInfo();
+			LOGGER.debug("Confirm ending manifest is {}", expected);
 			assertEquals(
-				Manifest.forFormat(toConfig.preferredFormat),
-				status.manifest().actual()
+				expected,
+				toBosk.getDriver(MainDriver.class).loadManifestInfo()
 			);
 		}
 
@@ -160,8 +151,6 @@ public class SchemaEvolutionTest {
 		LOGGER.debug("Create fromBosk [{}]", fromHelper.name);
 		Bosk<TestEntity> fromBosk = newBosk(fromHelper);
 		Refs fromRefs = fromBosk.buildReferences(Refs.class);
-
-		manifestScenario.fixupManifestIfNecessary(fromHelper);
 
 		LOGGER.debug("Create toBosk [{}]", toHelper.name);
 		Bosk<TestEntity> toBosk = newBosk(toHelper);
@@ -238,15 +227,33 @@ public class SchemaEvolutionTest {
 	}
 
 	private static Bosk<TestEntity> newBosk(Helper helper) {
-		return new Bosk<>(boskName(helper.toString()), TestEntity.class, AbstractMongoDriverTest::initialState, BoskConfig.<TestEntity>builder().driverFactory(helper.driverFactory).build());
+		return new Bosk<>(
+			boskName(helper.toString()),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(helper.driverFactory)
+				.build()
+		);
 	}
 
 	record Configuration(
-		MongoDriverSettings.DatabaseFormat preferredFormat
+		MongoDriverSettings.DatabaseFormat preferredFormat,
+		MongoDriverSettings.ManifestDocumentIdMode manifestDocumentIdMode
 	) {
+		public ManifestInfo expectedManifestInfo() {
+			return new ManifestInfo(
+				Manifest.forFormat(preferredFormat),
+				switch (manifestDocumentIdMode) {
+					case LEGACY -> LEGACY_MANIFEST_ID;
+					case STANDARD -> MANIFEST_ID;
+				}
+			);
+		}
+
 		@Override
 		public String toString() {
-			return preferredFormat.toString();
+			return manifestDocumentIdMode.toString() + "+" + preferredFormat.toString();
 		}
 	}
 
@@ -281,23 +288,14 @@ public class SchemaEvolutionTest {
 		}
 	}
 
-	private static final List<Configuration> CONFIGURATIONS = List.of(
-		new Configuration(SEQUOIA),
-		new Configuration(PandoFormat.oneBigDocument()),
-		new Configuration(PandoFormat.withGraftPoints("/catalog", "/sideTable"))
-	);
-
-	record ManifestScenarioInjector() implements Injector {
-		@Override
-		public boolean supports(AnnotatedElement element, Class<?> elementType) {
-			return elementType == SchemaEvolutionTest.ManifestScenario.class;
-		}
-
-		@Override
-		public List<ManifestScenario> values() {
-			return List.of(ManifestScenario.values());
-		}
-	}
+	private static final List<Configuration> CONFIGURATIONS = Stream.of(
+		SEQUOIA,
+		PandoFormat.oneBigDocument(),
+		PandoFormat.withGraftPoints("/catalog", "/sideTable")
+	).flatMap(format -> Stream.of(
+		new Configuration(format, LEGACY),
+		new Configuration(format, STANDARD)
+	)).toList();
 
 	static final class Helper extends AbstractMongoDriverTest {
 		final String name;
@@ -306,6 +304,7 @@ public class SchemaEvolutionTest {
 			super(MongoDriverSettings.builder()
 				.database(SchemaEvolutionTest.class.getSimpleName() + "_" + dbCounter)
 				.preferredDatabaseFormat(config.preferredFormat())
+				.manifestDocumentIdMode(config.manifestDocumentIdMode())
 			);
 			this.name = config.preferredFormat().toString().toLowerCase(Locale.ROOT);
 		}

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -1,8 +1,8 @@
 <configuration>
-	<turboFilter class="works.bosk.logback.BoskLogFilter"/>
 	<turboFilter class="works.bosk.logback.RecordingTurboFilter">
 		<routingKey>bosk.instanceID</routingKey>
 	</turboFilter>
+	<turboFilter class="works.bosk.logback.BoskLogFilter"/>
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%d %-5level [%thread] [%X{bosk.name}]%X{bosk.MongoDriver.transaction}%X{bosk.MongoDriver.event} %logger{25}: %msg%n</pattern>


### PR DESCRIPTION
I wish I had named it `!Manifest` in the first place, so it would sort alphabetically first.

Renaming the manifest file is a schema evolution I never anticipated, but we can make it work.