### PR TITLE
Add enum support to @InjectedFrom

### DIFF
--- a/bosk-junit/src/main/java/works/bosk/junit/InjectFrom.java
+++ b/bosk-junit/src/main/java/works/bosk/junit/InjectFrom.java
@@ -28,6 +28,24 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Injectors can, themselves, have constructor parameters injected by earlier injectors.
  * In that case, multiple instances of the same injector class will be created,
  * one for each distinct set of constructor parameters.
+ * <p>
+ * Injecting an {@code enum} class is equivalent to using a class like the one below.
+ * <pre>{@code
+ * public record MyEnumInjector() implements Injector {
+ *     @Override
+ *     public boolean supports(AnnotatedElement element, Class<?> elementType) {
+ *         return elementType == MyEnum.class;
+ *     }
+ *
+ *     @Override
+ *     public List<?> values() { return Arrays.asList(MyEnum.values()); }
+ * }
+ * }</pre>
+ *
+ * If you want to customize the injection (say, by
+ * injecting only a subset of the enum values),
+ * then you can begin by replacing the enum class with an injector like this,
+ * and then you can customize it.
  *
  * @see InjectedTest
  * @see Injected

--- a/bosk-junit/src/main/java/works/bosk/junit/InjectFrom.java
+++ b/bosk-junit/src/main/java/works/bosk/junit/InjectFrom.java
@@ -35,5 +35,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface InjectFrom {
-	Class<? extends Injector>[] value();
+	/**
+	 * The injectors to use. They can be:
+	 * <ul>
+	 * <li>
+	 *     An {@code enum}, to inject each of the enum's values, or
+	 * </li>
+	 * <li>
+	 *     An {@link Injector}, to customize exactly what gets injected.
+	 * </li>
+	 * </ul>
+	 */
+	Class<?>[] value();
 }

--- a/bosk-junit/src/main/java/works/bosk/junit/InjectionSupport.java
+++ b/bosk-junit/src/main/java/works/bosk/junit/InjectionSupport.java
@@ -56,7 +56,7 @@ class InjectionSupport {
 	 * <p>
 	 * This is done in two phases.
 	 * First, we compute all possible branches by instantiating all injector classes.
-	 * Once we have the injectors, we can use {@link Injector#supportsParameter}
+	 * Once we have the injectors, we can use {@link Injector#supports}
 	 * to determine which ones are needed,
 	 * and do a second pass to compute the branches for just those injectors.
 	 * <p>
@@ -155,14 +155,17 @@ class InjectionSupport {
 	}
 
 	/**
+	 * Note that "injector classes" in this context doesn't necessarily
+	 * mean {@link Injector}, but rather any class supported by {@link Injected#value()}.
+	 *
 	 * @return the injector classes in the order they should be instantiated
 	 */
-	static List<Class<? extends Injector>> getAllInjectorClasses(ExtensionContext context) {
+	static List<Class<?>> getAllInjectorClasses(ExtensionContext context) {
 		List<Class<?>> bottomUp = new ArrayList<>();
 		for (var c = context.getRequiredTestClass(); c != Object.class; c = c.getSuperclass()) {
 			bottomUp.add(c);
 		}
-		List<Class<? extends Injector>> allInjectors = new ArrayList<>();
+		List<Class<?>> allInjectors = new ArrayList<>();
 		for (var c : bottomUp.reversed()) {
 			for (var a: c.getAnnotationsByType(InjectFrom.class)) {
 				allInjectors.addAll(asList(a.value()));
@@ -174,7 +177,7 @@ class InjectionSupport {
 	/**
 	 * A version of {@link Branch#expandedFor(Class, String)} that operates on a list.
 	 */
-	private static List<Branch> expandedBranches(List<Branch> currentBranches, Class<? extends Injector> injectorType, String qualifier) {
+	private static List<Branch> expandedBranches(List<Branch> currentBranches, Class<?> injectorType, String qualifier) {
 		List<Branch> expanded = new ArrayList<>();
 		for (Branch branch : currentBranches) {
 			expanded.addAll(branch.expandedFor(injectorType, qualifier));
@@ -221,7 +224,7 @@ class InjectionSupport {
 		 * The resulting branches all have {@link InjectionKey}s suitable to inject
 		 * values for the given {@code injectorType} and {@code qualifier}.
 		 */
-		List<Branch> expandedFor(Class<? extends Injector> injectorType, String qualifier) {
+		List<Branch> expandedFor(Class<?> injectorType, String qualifier) {
 			Dependency dependency = new Dependency(injectorType, qualifier);
 
 			boolean alreadyExists = toInject.values().stream() // TODO: A more efficient data structure
@@ -230,6 +233,10 @@ class InjectionSupport {
 				// The branch has already been expanded for this dependency.
 				// If we expand it again, we risk introducing combinations that aren't supposed to be there.
 				return List.of(this);
+			}
+
+			if (Enum.class.isAssignableFrom(injectorType)) {
+				return expandedForEnum(injectorType, qualifier);
 			}
 
 			// Determine the injection requirements of injectorType's constructor
@@ -290,6 +297,46 @@ class InjectionSupport {
 				}
 			}
 			return result;
+		}
+
+		/**
+		 * Enum injectors much simpler than general {@link Injector}s.
+		 * They have no constructor arguments, support only their own class,
+		 * and return all the enum values.
+		 * They're orthogonal to other injectors, so they combine as a
+		 * cartesian product, so "expansion" actually just returns one {@link Branch}.
+		 */
+		private @NonNull List<Branch> expandedForEnum(Class<?> enumClass, String qualifier) {
+			List<?> enumValues = List.of((Object[]) enumClass.getEnumConstants());
+			var enumInjector = new Injector() {
+				@Override
+				public Class<?> injectorClass() {
+					// An enum injector is represented by the enum class
+					return enumClass;
+				}
+
+				@Override
+				public boolean supports(AnnotatedElement element, Class<?> elementType) {
+					return elementType == enumClass;
+				}
+
+				@Override
+				public List<?> values() {
+					return enumValues;
+				}
+
+				@Override
+				public String toString() {
+					return enumClass.getSimpleName();
+				}
+			};
+
+			var toInject = new LinkedHashMap<>(this.toInject);
+			toInject.put(
+				new InjectionKey(enumInjector, qualifier),
+				new Superposition(enumValues, Set.of(new Dependency(enumClass, qualifier)))
+			);
+			return List.of(new Branch(unmodifiableMap(toInject)));
 		}
 
 		/**
@@ -385,7 +432,7 @@ class InjectionSupport {
 	 */
 	record InjectionKey(Injector injector, String qualifier) {
 		Dependency dependency() {
-			return new Dependency(injector.getClass(), qualifier);
+			return new Dependency(injector.injectorClass(), qualifier);
 		}
 
 		@Override
@@ -430,7 +477,7 @@ class InjectionSupport {
 	 * and then rename this guy to {@link InjectionKey}.
 	 * That does move us a step away from injecting enums though.
 	 */
-	record Dependency(Class<? extends Injector> injectorClass, String qualifier) {}
+	record Dependency(Class<?> injectorClass, String qualifier) {}
 
 	@SuppressForbidden("Only for testing code; we have few other options here")
 	static void setAccessible(AccessibleObject accessibleObject) {

--- a/bosk-junit/src/main/java/works/bosk/junit/InjectionSupport.java
+++ b/bosk-junit/src/main/java/works/bosk/junit/InjectionSupport.java
@@ -156,7 +156,7 @@ class InjectionSupport {
 
 	/**
 	 * Note that "injector classes" in this context doesn't necessarily
-	 * mean {@link Injector}, but rather any class supported by {@link Injected#value()}.
+	 * mean {@link Injector}, but rather any class supported by {@link InjectFrom}.
 	 *
 	 * @return the injector classes in the order they should be instantiated
 	 */
@@ -235,8 +235,13 @@ class InjectionSupport {
 				return List.of(this);
 			}
 
-			if (Enum.class.isAssignableFrom(injectorType)) {
+			if (injectorType.isEnum()) {
 				return expandedForEnum(injectorType, qualifier);
+			} else if (!Injector.class.isAssignableFrom(injectorType)) {
+				throw new ParameterResolutionException(
+					"Unsupported injector class: "
+						+ injectorType
+						+ "; accepted injector types are enum or Injector");
 			}
 
 			// Determine the injection requirements of injectorType's constructor
@@ -300,7 +305,7 @@ class InjectionSupport {
 		}
 
 		/**
-		 * Enum injectors much simpler than general {@link Injector}s.
+		 * Enum injectors are much simpler than general {@link Injector}s.
 		 * They have no constructor arguments, support only their own class,
 		 * and return all the enum values.
 		 * They're orthogonal to other injectors, so they combine as a

--- a/bosk-junit/src/main/java/works/bosk/junit/Injector.java
+++ b/bosk-junit/src/main/java/works/bosk/junit/Injector.java
@@ -1,8 +1,6 @@
 package works.bosk.junit;
 
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
 import java.util.HashSet;
 import java.util.List;
 
@@ -21,8 +19,13 @@ import java.util.List;
  * @see InjectFrom
  */
 public interface Injector {
-	default boolean supportsParameter(Parameter parameter) { return supports(parameter, parameter.getType()); }
-	default boolean supportsField(Field field) { return supports(field, field.getType()); }
+	/**
+	 * @return the class as reported to {@link InjectFrom}.
+	 * For most injectors, that's just the object's class,
+	 * but for other kinds of supported injectors,
+	 * like enums, it can be something else.
+	 */
+	default Class<?> injectorClass() { return getClass(); }
 
 	/**
 	 * Note: if this method returns different results for the same element

--- a/bosk-junit/src/test/java/works/bosk/junit/InjectFromHappyPathTests.java
+++ b/bosk-junit/src/test/java/works/bosk/junit/InjectFromHappyPathTests.java
@@ -40,7 +40,6 @@ import static works.bosk.junit.InjectFromHappyPathTests.IndependentValue.Y;
  * so we need to take some care to make those thread-safe;
  */
 class InjectFromHappyPathTests {
-
 	enum BaseValue { FIRST, SECOND }
 	record DependentValue(BaseValue base) { @Override public String toString() { return "based-on-" + base; } }
 	record Dependent2Value(DependentValue base) { @Override public String toString() { return "based-on-" + base; } }
@@ -385,6 +384,41 @@ class InjectFromHappyPathTests {
 				"SECOND:X:X",
 				"SECOND:Y:Y"
 			), observations);
+		}
+	}
+
+	@Nested
+	@InjectFields
+	@InjectFrom({BaseValue.class})
+	class EnumFieldTest {
+		static List<BaseValue> observations = new ArrayList<>();
+
+		@Injected BaseValue value;
+
+		@Test
+		void enumFieldInjection_works() {
+			observations.add(value);
+		}
+
+		@AfterAll
+		static void checkObservations() {
+			assertEquals(List.of(FIRST, SECOND), observations);
+		}
+	}
+
+	@Nested
+	@InjectFrom({BaseValue.class})
+	class EnumParameterTest {
+		static List<BaseValue> observations = new ArrayList<>();
+
+		@InjectedTest
+		void enumParameterInjection_works(BaseValue value) {
+			observations.add(value);
+		}
+
+		@AfterAll
+		static void checkObservations() {
+			assertEquals(List.of(FIRST, SECOND), observations);
 		}
 	}
 

--- a/bosk-junit/src/test/java/works/bosk/junit/QualifiedInjectionTests.java
+++ b/bosk-junit/src/test/java/works/bosk/junit/QualifiedInjectionTests.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import works.bosk.junit.InjectFromHappyPathTests.BaseValue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -45,6 +46,29 @@ class QualifiedInjectionTests {
 		static void check() {
 			assertEquals(Set.of("A:A", "B:B"), sameQualifierObservations);
 			assertEquals(Set.of("A:A", "A:B", "B:A", "B:B"), differentQualifierObservations);
+		}
+	}
+
+	@Nested
+	@InjectFrom({BaseValue.class})
+	class EnumQualifierParameterTest {
+		static Set<String> differentQualifierObservations = new HashSet<>();
+		static Set<String> sameQualifierObservations = new HashSet<>();
+
+		@InjectedTest
+		void sameQualifier(@Injected("x") BaseValue a, @Injected("x") BaseValue b) {
+			sameQualifierObservations.add(a + ":" + b);
+		}
+
+		@InjectedTest
+		void differentQualifier(@Injected("x") BaseValue a, @Injected("y") BaseValue b) {
+			differentQualifierObservations.add(a + ":" + b);
+		}
+
+		@AfterAll
+		static void check() {
+			assertEquals(Set.of("FIRST:FIRST", "SECOND:SECOND"), sameQualifierObservations);
+			assertEquals(Set.of("FIRST:FIRST", "FIRST:SECOND", "SECOND:FIRST", "SECOND:SECOND"), differentQualifierObservations);
 		}
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/AbstractDriverTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/AbstractDriverTest.java
@@ -3,7 +3,6 @@ package works.bosk.testing.drivers;
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +35,7 @@ import works.bosk.junit.InjectFields;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
 import works.bosk.junit.Injector;
-import works.bosk.testing.drivers.AbstractDriverTest.ScenarioInjector;
+import works.bosk.testing.drivers.AbstractDriverTest.Scenario;
 import works.bosk.testing.drivers.state.TestEntity;
 import works.bosk.testing.drivers.state.TestEntity.Fields;
 import works.bosk.util.Classes;
@@ -46,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 @InjectFields
-@InjectFrom(ScenarioInjector.class)
+@InjectFrom(Scenario.class)
 public abstract class AbstractDriverTest {
 	public static final Identifier TENANT1 = Identifier.from("tenant1");
 	public static final Identifier TENANT2 = Identifier.from("tenant2");
@@ -94,18 +93,6 @@ public abstract class AbstractDriverTest {
 			this.startingTenant = startingTenant;
 		}
 
-	}
-
-	record ScenarioInjector() implements Injector {
-		@Override
-		public boolean supports(AnnotatedElement element, Class<?> elementType) {
-			return elementType.equals(Scenario.class);
-		}
-
-		@Override
-		public List<?> values() {
-			return Arrays.asList(Scenario.values());
-		}
 	}
 
 	/**


### PR DESCRIPTION
Enums are a convenient way to parameterize tests. They can have methods and fields that supply all kinds of information as a package.

This change adds direct support for enums to the injection extension, allowing users to avoid the boilerplate..