### PR TITLE
Support for implicit references in bosk-boson

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
 - Prefer building the entire expected data structure and using `assertEquals` over checking individual fields one-by-one. Tests with per-field assertions get stale when the object acquires new fields.
 - Assertion message strings should state what was expected (e.g. `"Should have no errors"`), not describe the error.
 - Use `./gradlew <task> --rerun` (not `--rerun-tasks`) to force Gradle to re-execute a task when cached results exist.
+- Java assertions (-ea) are enabled for tests
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,3 +179,4 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
   - Some other projects perceive a symmetry between these two operations
   - The bosk philosophy is that they have nothing in common and are handled by entirely separate mechanisms. (This is almost a corollary of representing data with immutable structures.)
 - Even when the bosk state is persisted (say, in MongoDB), the in-memory state tree is a _replica_, not a cache, and is always available.
+- Prefer `if (x) { ... } else { ... }` over `if (!x) { ... } else { ... }` (avoid double-negative conditions).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,10 @@ Put less formal things, like references to the `example-hello` project, in the R
 
 We use Lombok sparingly. Most of its features are disabled in lombok.config.
 
+### Wrangler interfaces
+
+Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) must have **more than one abstract method**. Single-method (SAM) wranglers would allow lambda usage, but lambdas don't preserve generic type parameters at runtime, breaking the reflection-based `DataType.of(wrangler.getClass())` type extraction used in factory methods. Always make wranglers multi-method to force anonymous-class instantiation.
+
 ### Commits
 
 - Commits in a PR should ideally be rebased and massaged to follow these guidelines prior to committing, to give a clean history:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
 ### Testing
 
 - Prefer building the entire expected data structure and using `assertEquals` over checking individual fields one-by-one. Tests with per-field assertions get stale when the object acquires new fields.
-- Assertion message strings should state what was expected (e.g. `"Should have no errors"`), not describe the error.
+- Assertion message strings should state what was expected (e.g. `"Set must have the new item"`), not describe the error (e.g. `"Set does not contain the new item"`).
 - Use `./gradlew <task> --rerun` (not `--rerun-tasks`) to force Gradle to re-execute a task when cached results exist.
 - Java assertions (-ea) are enabled for tests
 
@@ -180,4 +180,4 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
   - Some other projects perceive a symmetry between these two operations
   - The bosk philosophy is that they have nothing in common and are handled by entirely separate mechanisms. (This is almost a corollary of representing data with immutable structures.)
 - Even when the bosk state is persisted (say, in MongoDB), the in-memory state tree is a _replica_, not a cache, and is always available.
-- Prefer `if (x) { ... } else { ... }` over `if (!x) { ... } else { ... }` (avoid double-negative conditions).
+- Prefer `if (x) { ... } else { ... }` over `if (!x) { ... } else { ... }` to avoid the double-negative `else` branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The usual Gradle commands, plus:
 
 ### General
 - We take warnings seriously. If a build issues a warning, it should be fixed at the earliest convenience.
-- Code in each file is ordered use-before-definition so it can be read and understood by a human from start to end, to the extent possible.
+- Code in each file is ordered use-before-definition so it can be read and understood by a human from start to end.
 - To the extent possible, we separate complex logic from side effects to facilitate unit testing.
 - When something can't always work, we prefer it _never_ to work rather than _sometimes_ to work.
   - The overarching goal of Bosk is to reduce the behaviour gap between local development and production. If your code works, you probably did things right.
@@ -71,12 +71,21 @@ Also, some methods (like `BoskDriver.initialState`) throw checked exceptions
 because those methods are typically called in initialization code that is invoked by a dependency injection framework,
 where `throws` clauses have no real downside.
 
+We put exceptions for a module into a sub-package that ends with `.exceptions`
+so they don't clutter up other packages.
+
 ### Javadocs
 
 We use javadocs extensively, including in `module-info.java` and `package-info.java` files.
 Avoid documenting words using themselves, like `@param settings  the settings`;
 instead, consider someone who has seen the name but still has a question,
 and try to answer that question in the javadocs.
+
+Javadocs contain most of the info.
+They focus on conveying design principles, navigating concepts in a hierarchical manner (module, package, class, method),
+and giving practical usage advice and best practices.
+They are concise but complete; do not assume the reader has access to the README.md file.
+Put less formal things, like references to the `example-hello` project, in the README.md file instead.
 
 ### Lombok
 
@@ -116,7 +125,20 @@ We use Lombok sparingly. Most of its features are disabled in lombok.config.
 - Subclasses of `DriverConformanceTest` in `bosk-testing` verify driver implementations; all drivers ought to pass these tests
   - Use `SharedDriverConformanceTest` for drivers that do replication between bosks
 - Aim for readability in test code.
-  - A good test does not merely fail if something goes wrong: it also serves to document examples of intended usage
+  - A good test does not merely fail if something goes wrong: it also serves to document examples of intended usage.
+    Write tests that *demonstrate* the intended usage, not just exercise code paths.
+    - Names given to test artifacts (classes, fields, methods etc.) should guide the reader to the correct generalization, rather than suggesting real-world meaning.
+      - Good: `String field1`, `int field2`: convey that this test is expected to work on any field
+      - Good: Country/City: concept that is clearly from another domain, clearly conveys a whole/part relationship, if that's what the test is demonstrating
+      - Bad: `String name`, `int version`: might be framework concepts or meaningful domain properties; generalization is unclear.
+      - Good: bosk jargon used in the right context, like "reference", "driver", "path".
+      - Bad: Bosk jargon used outside its Bosk meaning.
+      - Good: names that convey the relationship between the artifacts (`Catalog<T> parts`, `TaggedUnion<X> variant`).
+    - Things that are the same should look the same; things that are different should look different.
+      - Example: `field1`, `field2` suggests the test treats these fields the same way
+      - Example: `date`, `name` suggests the test might treat dates and names differently
+    - Test values should be transparently arbitrary. `Identifier.from("w1")` is better than `Identifier.from("alice")`
+      because `w1` makes no claim about what it is beyond "widget ID 1".
   - With few exceptions, tests should use `assertEquals` rather than complex Hamcrest matchers; the latter is taken as an indication that the API being tested is too complicated
   - Mocks are avoided not because they're inherently bad, but because our components should be designed in a way that doesn't need them, since we favour immutable components and data structures
 - Tests should be parallelizable, and they should be self-contained in that a failing test can be re-run on its own
@@ -126,11 +148,24 @@ We use Lombok sparingly. Most of its features are disabled in lombok.config.
 - Tests should be deterministic, and they should not rely on timing except in rare cases where there is no alternative, or where timeout behaviour is specifically being tested
   - Where components have timeout settings, tests should adjust those settings to be very short or very long as appropriate to make spurious failures vanishingly rare
 
+## Hints
+
+### General
+
+- Keep entries in `gradle/libs.versions.toml` alphabetized within each section.
+- Consider `RuntimeException` to be abstract and throw the appropriate subtype: often `IllegalStateException` but consider whether others are more appropriate
+
+### Testing
+
+- Prefer building the entire expected data structure and using `assertEquals` over checking individual fields one-by-one. Tests with per-field assertions get stale when the object acquires new fields.
+- Assertion message strings should state what was expected (e.g. `"Should have no errors"`), not describe the error.
+- Use `./gradlew <task> --rerun` (not `--rerun-tasks`) to force Gradle to re-execute a task when cached results exist.
+
 ## Notes
 
 - We use spotbugs for shipped code
 - Published to Maven Central via GitHub actions, by creating a new release in GitHub
-- We use GitHub Dependabot to keep dependencies very up-to-date
+- We use GitHub Dependabot to keep dependencies up to date
 - We separate setup from execution. Prefer designs where work is described once (at construction/configuration time) and executed many times efficiently.
   - `Reference` is an example: path parsing and validation happen once when the `Reference` is built, and then reads are fast.
     Apply this pattern when designing new abstractions — avoid doing expensive setup work inside hot paths.

--- a/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
+++ b/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
@@ -1,7 +1,10 @@
 package works.bosk.bosonSerializer;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Array;
+import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedMap;
+import org.jetbrains.annotations.NotNull;
 import works.bosk.BoskInfo;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
@@ -37,13 +41,16 @@ import works.bosk.boson.mapping.spec.ComputedSpec;
 import works.bosk.boson.mapping.spec.FixedObjectNode;
 import works.bosk.boson.mapping.spec.FixedObjectNode.TwoMemberWrangler;
 import works.bosk.boson.mapping.spec.MaybeAbsentSpec;
+import works.bosk.boson.mapping.spec.ParseCallbackSpec;
 import works.bosk.boson.mapping.spec.RecognizedMember;
 import works.bosk.boson.mapping.spec.RepresentAsSpec;
 import works.bosk.boson.mapping.spec.StringNode;
 import works.bosk.boson.mapping.spec.TypeRefNode;
 import works.bosk.boson.mapping.spec.UniformMapNode;
+import works.bosk.boson.mapping.spec.UniformMapNode.MemberValueWrangler;
 import works.bosk.boson.mapping.spec.UniformMapNode.OneMemberWrangler;
 import works.bosk.boson.mapping.spec.handles.MemberPresenceCondition;
+import works.bosk.boson.mapping.spec.handles.TypedHandle;
 import works.bosk.boson.mapping.spec.handles.TypedHandles;
 import works.bosk.boson.types.BoundType;
 import works.bosk.boson.types.DataType;
@@ -52,7 +59,10 @@ import works.bosk.boson.types.TypeReference;
 import works.bosk.boson.types.TypeVariable;
 import works.bosk.exceptions.InvalidTypeException;
 
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 import static works.bosk.boson.mapping.spec.handles.MemberPresenceCondition.memberValue;
 import static works.bosk.boson.mapping.spec.handles.TypedHandles.canonicalConstructor;
@@ -161,24 +171,25 @@ public class BosonSerializer extends StateTreeSerializer {
 			})
 		));
 
-		directives.add(Directive.fixed(
-			UniformMapNode.singleton(new OneMemberWrangler<MapEntry<T>, Identifier, T>(){
-				@Override
-				public Identifier getKey(MapEntry<T> value) {
-					return value.id();
+		// For MapEntry, we need a MemberValueWrangler to open and close a DeserializationScope
+		directives.add(Directive.fixed(UniformMapNode.oneMember(
+			new OneMemberWrangler<MapEntry<T>, Identifier, T>() {
+				@Override public Identifier getKey(MapEntry<T> v) { return v.id(); }
+				@Override public T getValue(MapEntry<T> v) { return v.value(); }
+				@Override public MapEntry<T> finish(Identifier key, T value) { return new MapEntry<>(key, value); }
+			},
+			new MemberValueWrangler<Identifier, T, DeserializationScope>() {
+				@Override public DeserializationScope beforeValue(Identifier key) {
+					return BosonSerializer.this.entryDeserializationScope(key);
 				}
-
-				@Override
-				public T getValue(MapEntry<T> value) {
-					return value.value();
+				@Override public void afterValue(Identifier key, T value, DeserializationScope scope) {
+					// This won't get called if there's an exception after the scope is opened,
+					// but there's a top-level try-finally around the parsing process that
+					// will reset things properly in that case anyway.
+					scope.close();
 				}
-
-				@Override
-				public MapEntry<T> finish(Identifier id, T value) {
-					return new MapEntry<>(id, value);
-				}
-			})
-		));
+			}
+		)));
 
 		// It's remarkable how cumbersome this one is
 		directives.add(new Directive(
@@ -305,10 +316,23 @@ public class BosonSerializer extends StateTreeSerializer {
 									Phantom::empty)),
 								componentAccessor(rc, lookup)
 							));
-						} else {
-							// A simple TypeRefNode will do
+						} else if (isImplicitParameter(recordClass, rc)) {
 							componentsByName.put(rc.getName(), new RecognizedMember(
-								new TypeRefNode(DataType.known(rc.getGenericType())),
+								new ComputedSpec(supplier(DataType.known(rc.getGenericType()),
+									() -> implicitReference(recordClass, rc, bosk))),
+								componentAccessor(rc, lookup)
+							));
+						} else {
+							// This would be just a TypeRefNode, except we also need a DeserializationScope.
+							// The close won't get called if there's an exception while parsing the record component,
+							// but there's a top-level try-finally around the parsing process that
+							// will reset things properly in that case anyway.
+							componentsByName.put(rc.getName(), new RecognizedMember(
+								new ParseCallbackSpec(
+									openRecordComponentDeserializationScope(rc, recordClass, lookup),
+									new TypeRefNode(DataType.known(rc.getGenericType())),
+									closeRecordComponentDeserializationScope(rc, lookup)
+								),
 								componentAccessor(rc, lookup)
 							));
 						}
@@ -416,6 +440,47 @@ public class BosonSerializer extends StateTreeSerializer {
 			List.of(lookup),
 			List.copyOf(directives)
 		);
+	}
+
+	/**
+	 * @return nullary callback that opens a {@link DeserializationScope} for a given record component.
+	 */
+	private @NotNull TypedHandle openRecordComponentDeserializationScope(RecordComponent rc, Class<? extends Record> recordClass, Lookup lookup) {
+		try {
+			MethodHandle nodeFieldDeserializationScope = lookup.findVirtual(StateTreeSerializer.class,
+				"nodeFieldDeserializationScope",
+				methodType(DeserializationScope.class, Class.class, String.class));
+			return new TypedHandle(
+				insertArguments(nodeFieldDeserializationScope, 0,
+					this, recordClass, rc.getName()
+				),
+				DataType.known(DeserializationScope.class), List.of());
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new IllegalArgumentException("Failed to create scope callback for " + rc.getName(), e);
+		}
+	}
+
+	/**
+	 * @return callback that closes a {@link DeserializationScope}
+	 * opened by {@link #openRecordComponentDeserializationScope(RecordComponent, Class, Lookup)}.
+	 */
+	private static @NotNull TypedHandle closeRecordComponentDeserializationScope(RecordComponent rc, Lookup lookup) {
+		try {
+			MethodHandle close = lookup.findVirtual(DeserializationScope.class, "close",
+				methodType(void.class));
+
+			// The callback receives the parsed record component value, but we don't use it
+			MethodHandle mh = dropArguments(close, 1, rc.getType());
+
+			return new TypedHandle(mh,
+				DataType.VOID,
+				List.of(
+					DataType.known(DeserializationScope.class),
+					DataType.known(rc.getGenericType())
+				));
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new IllegalArgumentException("Failed to create scope callback for " + rc.getName(), e);
+		}
 	}
 
 }

--- a/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
+++ b/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
@@ -296,8 +296,24 @@ public class BosonSerializer extends StateTreeSerializer {
 							// This is remarkably cumbersome
 							var valueType = ReferenceUtils.parameterType(rc.getGenericType(), Optional.class, 0);
 							var elementType = new TypeRefNode(DataType.known(valueType));
-							var ifPresent = RepresentAsSpec.<Optional<?>, Object>as(
+							// The element needs an appropriate scope for @Self to resolve inside it
+							TypedHandle closeScope;
+							try {
+								MethodHandle close = lookup.findVirtual(DeserializationScope.class, "close",
+									methodType(void.class));
+								MethodHandle closeMh = dropArguments(close, 1, ReferenceUtils.rawClass(valueType));
+								closeScope = new TypedHandle(closeMh,
+									DataType.VOID,
+									List.of(DataType.known(DeserializationScope.class), DataType.known(valueType)));
+							} catch (NoSuchMethodException | IllegalAccessException e) {
+								throw new IllegalArgumentException("Failed to create scope callback for " + rc.getName(), e);
+							}
+							var scopedElement = new ParseCallbackSpec(
+								openRecordComponentDeserializationScope(rc, recordClass, lookup),
 								elementType,
+								closeScope);
+							var ifPresent = RepresentAsSpec.<Optional<?>, Object>as(
+								scopedElement,
 								DataType.known(rc.getGenericType()),
 								Optional::get,
 								Optional::of

--- a/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
+++ b/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
@@ -91,6 +91,10 @@ public class BosonSerializer extends StateTreeSerializer {
 			)
 		));
 
+		/*
+		 * Both {@link Catalog} and {@link SideTable} serialize as a list of key-value pairs
+		 * to maintain the order of the entries. This type represents that structure.
+		 */
 		record MapEntry<V>(Identifier id, V value) {}
 
 		// This probably should be a SequencedCollection, but pcollections doesn't have that
@@ -266,7 +270,7 @@ public class BosonSerializer extends StateTreeSerializer {
 			})));
 
 		directives.add(new Directive(
-			new TypeVariable("X", StateTreeNode.class),
+			new TypeVariable("X", StateTreeNode.class), // Any subtype of StateTreeNode
 			stateTreeNodeType -> switch (stateTreeNodeType) {
 				case BoundType bt -> {
 					// StateTreeNode offers some features that only work in the context of a StateTreeNode,

--- a/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
+++ b/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
@@ -35,12 +35,14 @@ import works.bosk.boson.mapping.TypeScanner.Directive;
 import works.bosk.boson.mapping.spec.BooleanNode;
 import works.bosk.boson.mapping.spec.ComputedSpec;
 import works.bosk.boson.mapping.spec.FixedObjectNode;
+import works.bosk.boson.mapping.spec.FixedObjectNode.TwoMemberWrangler;
 import works.bosk.boson.mapping.spec.MaybeAbsentSpec;
 import works.bosk.boson.mapping.spec.RecognizedMember;
 import works.bosk.boson.mapping.spec.RepresentAsSpec;
 import works.bosk.boson.mapping.spec.StringNode;
 import works.bosk.boson.mapping.spec.TypeRefNode;
 import works.bosk.boson.mapping.spec.UniformMapNode;
+import works.bosk.boson.mapping.spec.UniformMapNode.OneMemberWrangler;
 import works.bosk.boson.mapping.spec.handles.MemberPresenceCondition;
 import works.bosk.boson.mapping.spec.handles.TypedHandles;
 import works.bosk.boson.types.BoundType;
@@ -50,6 +52,7 @@ import works.bosk.boson.types.TypeReference;
 import works.bosk.boson.types.TypeVariable;
 import works.bosk.exceptions.InvalidTypeException;
 
+import static java.lang.invoke.MethodHandles.lookup;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 import static works.bosk.boson.mapping.spec.handles.MemberPresenceCondition.memberValue;
 import static works.bosk.boson.mapping.spec.handles.TypedHandles.canonicalConstructor;
@@ -64,7 +67,7 @@ public class BosonSerializer extends StateTreeSerializer {
 		E extends Entity,
 		V extends VariantCase
 	> TypeScanner.Bundle bundleFor(BoskInfo<?> bosk) {
-		MethodHandles.Lookup lookup = MethodHandles.lookup();
+		MethodHandles.Lookup lookup = lookup();
 
 		var directives = new ArrayList<Directive>();
 
@@ -107,7 +110,7 @@ public class BosonSerializer extends StateTreeSerializer {
 		));
 
 		directives.add(Directive.fixed(
-			FixedObjectNode.of(new FixedObjectNode.Wrangler2<Listing<E>, CatalogReference<E>, List<Identifier>>(
+			FixedObjectNode.of(new TwoMemberWrangler<Listing<E>, CatalogReference<E>, List<Identifier>>(
 				"domain",
 				"ids"
 			) {
@@ -155,7 +158,7 @@ public class BosonSerializer extends StateTreeSerializer {
 		));
 
 		directives.add(Directive.fixed(
-			UniformMapNode.singleton(new UniformMapNode.SingletonWrangler<MapEntry<T>, Identifier, T>(){
+			UniformMapNode.singleton(new OneMemberWrangler<MapEntry<T>, Identifier, T>(){
 				@Override
 				public Identifier getKey(MapEntry<T> value) {
 					return value.id();

--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonRoundTripConformanceTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonRoundTripConformanceTest.java
@@ -56,6 +56,7 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 
 	public static class BosonRoundTripDriver extends AbstractRoundTripTest.PreprocessingDriver {
 		private final BosonSerializer bosonSerializer;
+		private final JacksonSerializer jacksonSerializer;
 		private final TypeMap typeMap;
 		private final Codec codec;
 		private final Variant variant;
@@ -73,11 +74,12 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 				.scan(rootType)
 				.build();
 			this.codec = CodecBuilder.using(typeMap).build();
+			this.jacksonSerializer = new JacksonSerializer();
 			this.jackson = JsonMapper.builder()
 				.enable(INCLUDE_SOURCE_IN_LOCATION)
 				.disable(READ_ENUMS_USING_TO_STRING)
 				.disable(WRITE_ENUMS_USING_TO_STRING)
-				.addModule(new JacksonSerializer().moduleFor(b))
+				.addModule(jacksonSerializer.moduleFor(b))
 				.build();
 		}
 
@@ -108,7 +110,9 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 			LOGGER.debug("Intermediate JSON:\n{}", jsonString);
 
 			if (variant == Variant.B2J) {
-				return jackson.readerFor(referenceType).readValue(jsonString);
+				try (var _ = jacksonSerializer.newDeserializationScope(reference)) {
+					return jackson.readerFor(referenceType).readValue(jsonString);
+				}
 			} else {
 				JsonReader json = CharArrayJsonReader.forString(jsonString);
 				if (variant == Variant.VALIDATING) {

--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonRoundTripConformanceTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonRoundTripConformanceTest.java
@@ -55,6 +55,7 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 	}
 
 	public static class BosonRoundTripDriver extends AbstractRoundTripTest.PreprocessingDriver {
+		private final BosonSerializer bosonSerializer;
 		private final TypeMap typeMap;
 		private final Codec codec;
 		private final Variant variant;
@@ -64,7 +65,8 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 			super(d);
 			this.variant = variant;
 			var rootType = DataType.of(b.rootReference().targetType());
-			TypeScanner.Bundle bundle = new BosonSerializer().bundleFor(b);
+			this.bosonSerializer = new BosonSerializer();
+			TypeScanner.Bundle bundle = bosonSerializer.bundleFor(b);
 			LOGGER.debug("Creating the real TypeScanner now for root type {}", rootType);
 			this.typeMap = new TypeScanner(TypeMap.Settings.DEFAULT.withCompiled(false))
 				.addBundle(bundle)
@@ -112,11 +114,13 @@ class BosonRoundTripConformanceTest extends DriverConformanceTest {
 				if (variant == Variant.VALIDATING) {
 					json = json.withValidation();
 				}
-				try {
-					Object parsed = parser.parse(json);
-					return reference.targetClass().cast(parsed);
-				} catch (IOException e) {
-					throw new AssertionError("Unexpected exception", e);
+				try (var _ = bosonSerializer.newDeserializationScope(reference)) {
+					try {
+						Object parsed = parser.parse(json);
+						return reference.targetClass().cast(parsed);
+					} catch (IOException e) {
+						throw new AssertionError("Unexpected exception", e);
+					}
 				}
 			}
 		}

--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
@@ -3,19 +3,23 @@ package works.bosk.bosonSerializer;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
+import works.bosk.BoskDriver;
 import works.bosk.BoskDriver.EntireState;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
 import works.bosk.Entity;
 import works.bosk.Identifier;
+import works.bosk.Reference;
 import works.bosk.SideTable;
 import works.bosk.SideTableReference;
 import works.bosk.StateTreeNode;
 import works.bosk.annotations.ReferencePath;
+import works.bosk.annotations.Self;
 import works.bosk.boson.codec.Codec;
 import works.bosk.boson.codec.CodecBuilder;
 import works.bosk.boson.codec.io.CharArrayJsonReader;
@@ -29,18 +33,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BosonSerializerTest {
 
-
 	public record Root(
 		Catalog<Key> keys,
-		SideTable<Key, String> sideTable
+		Catalog<Item> items,
+		SideTable<Key, String> sideTable,
+		@Self Reference<Root> self
 	) implements StateTreeNode {}
 
 	public record Key(
 		Identifier id
 	) implements Entity {}
 
+	public record Item(
+		Identifier id,
+		@Self Reference<Item> self
+	) implements Entity {}
+
 	public interface Refs {
 		@ReferencePath("/keys") CatalogReference<Key> keys();
+		@ReferencePath("/items") CatalogReference<Item> items();
 		@ReferencePath("/sideTable") SideTableReference<Key, String> sideTable();
 	}
 
@@ -54,13 +65,7 @@ public class BosonSerializerTest {
 		bosk = new Bosk<>(
 			"test",
 			Root.class,
-			b -> {
-				Refs refs = b.buildReferences(Refs.class);
-				return EntireState.just(new Root(
-					Catalog.empty(),
-					SideTable.empty(refs.keys())
-				));
-			},
+			BosonSerializerTest::emptyState,
 			BoskConfig.simple());
 		refs = bosk.buildReferences(Refs.class);
 		typeMap = new TypeScanner(TypeMap.Settings.DEFAULT)
@@ -68,6 +73,20 @@ public class BosonSerializerTest {
 			.scan(DataType.of(Root.class))
 			.build();
 		codec = CodecBuilder.using(typeMap).buildInterpreter();
+	}
+
+	private static BoskDriver.EntireState.SingleTree<Root> emptyState(Bosk<Root> b) throws InvalidTypeException {
+		return EntireState.just(emptyRoot(b));
+	}
+
+	private static @NonNull Root emptyRoot(Bosk<Root> b) throws InvalidTypeException {
+		Refs refs = b.buildReferences(Refs.class);
+		return new Root(
+			Catalog.empty(),
+			Catalog.empty(),
+			SideTable.empty(refs.keys()),
+			b.rootReference()
+		);
 	}
 
 	@Test
@@ -92,5 +111,45 @@ public class BosonSerializerTest {
 		gen.generate(stringWriter, refs.keys());
 		String json = stringWriter.toString();
 		assertEquals("\"/keys\"", json);
+	}
+
+	@Test
+	void selfReference() throws IOException, InvalidTypeException {
+		var parser = codec.parserFor(typeMap.get(DataType.of(Root.class)));
+		Root parsed = (Root)parser.parse(new CharArrayJsonReader(
+			"""
+			{
+				"keys": [],
+				"items": [],
+				"sideTable": {
+					"domain": "/keys",
+					"valuesById": []
+				}
+			}
+			""".toCharArray()
+		));
+		assertEquals(emptyRoot(bosk), parsed);
+	}
+
+	@Test
+	void catalogEntrySelfReference() throws IOException, InvalidTypeException {
+		var itemId = Identifier.from("e1");
+		var expectedItem = new Item(itemId, refs.items().then(itemId));
+		var originalRoot = new Root(
+			Catalog.empty(),
+			Catalog.of(expectedItem),
+			SideTable.empty(refs.keys()),
+			bosk.rootReference()
+		);
+
+		var gen = codec.generatorFor(typeMap.get(DataType.of(Root.class)));
+		StringWriter sw = new StringWriter();
+		gen.generate(sw, originalRoot);
+		String json = sw.toString();
+
+		var parser = codec.parserFor(typeMap.get(DataType.of(Root.class)));
+		Root parsedRoot = (Root)parser.parse(new CharArrayJsonReader(json.toCharArray()));
+
+		assertEquals(originalRoot, parsedRoot);
 	}
 }

--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
@@ -52,6 +52,7 @@ public class BosonSerializerTest {
 	public interface Refs {
 		@ReferencePath("/keys") CatalogReference<Key> keys();
 		@ReferencePath("/items") CatalogReference<Item> items();
+		@ReferencePath("/items/-item-") Reference<Item> item(Identifier item);
 		@ReferencePath("/sideTable") SideTableReference<Key, String> sideTable();
 	}
 
@@ -90,7 +91,7 @@ public class BosonSerializerTest {
 	}
 
 	@Test
-	void sideTable() throws InvalidTypeException, IOException {
+	void sideTable() throws IOException {
 		var object = SideTable.of(refs.keys(), Identifier.from("key"), "value");
 
 
@@ -114,13 +115,14 @@ public class BosonSerializerTest {
 	}
 
 	@Test
-	void selfReference() throws IOException, InvalidTypeException {
+	void selfReferences() throws IOException {
 		var parser = codec.parserFor(typeMap.get(DataType.of(Root.class)));
 		Root parsed = (Root)parser.parse(new CharArrayJsonReader(
+			// Note: no explicit self-references here
 			"""
 			{
 				"keys": [],
-				"items": [],
+				"items": [{"item1": {"id": "item1"}}],
 				"sideTable": {
 					"domain": "/keys",
 					"valuesById": []
@@ -128,28 +130,10 @@ public class BosonSerializerTest {
 			}
 			""".toCharArray()
 		));
-		assertEquals(emptyRoot(bosk), parsed);
+
+		assertEquals(bosk.rootReference(), parsed.self());
+		Identifier item1 = Identifier.from("item1");
+		assertEquals(refs.item(item1), parsed.items().get(item1).self());
 	}
 
-	@Test
-	void catalogEntrySelfReference() throws IOException, InvalidTypeException {
-		var itemId = Identifier.from("e1");
-		var expectedItem = new Item(itemId, refs.items().then(itemId));
-		var originalRoot = new Root(
-			Catalog.empty(),
-			Catalog.of(expectedItem),
-			SideTable.empty(refs.keys()),
-			bosk.rootReference()
-		);
-
-		var gen = codec.generatorFor(typeMap.get(DataType.of(Root.class)));
-		StringWriter sw = new StringWriter();
-		gen.generate(sw, originalRoot);
-		String json = sw.toString();
-
-		var parser = codec.parserFor(typeMap.get(DataType.of(Root.class)));
-		Root parsedRoot = (Root)parser.parse(new CharArrayJsonReader(json.toCharArray()));
-
-		assertEquals(originalRoot, parsedRoot);
-	}
 }

--- a/bosk-core/src/main/java/works/bosk/Listing.java
+++ b/bosk-core/src/main/java/works/bosk/Listing.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.pcollections.OrderedPSet;
@@ -240,6 +242,33 @@ public final class Listing<E extends Entity> extends AbstractCollection<Referenc
 
 	public static <TT extends Entity> Listing<TT> of(Reference<Catalog<TT>> domain, Stream<Identifier> ids) {
 		return of(domain, ids.collect(toList()));
+	}
+
+	//
+	// Collectors
+	//
+
+	/**
+	 * @return a {@link Collector} that accumulates items into a {@link Listing}
+	 * by extracting an {@link Identifier} from each item via <code>idMapper</code>.
+	 * Duplicate IDs are silently deduplicated.
+	 */
+	public static <T, EE extends Entity> Collector<T, ?, Listing<EE>> toListing(
+		Reference<Catalog<EE>> domain,
+		Function<? super T, Identifier> idMapper
+	) {
+		class Accumulator {
+			OrderedPSet<Identifier> ids = OrderedPSet.empty();
+			void accumulate(T item) { ids = ids.plus(idMapper.apply(item)); }
+			Accumulator combine(Accumulator other) { ids = ids.plusAll(other.ids); return this; }
+			Listing<EE> finish() { return Listing.of(domain, ids); }
+		}
+		return Collector.of(
+			Accumulator::new,
+			Accumulator::accumulate,
+			Accumulator::combine,
+			Accumulator::finish
+		);
 	}
 
 	//

--- a/bosk-core/src/main/java/works/bosk/MapValue.java
+++ b/bosk-core/src/main/java/works/bosk/MapValue.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
 import org.pcollections.OrderedPMap;
 
 import static java.util.Collections.emptyMap;
@@ -77,6 +78,30 @@ public final class MapValue<V> implements Map<String, V> {
 			requireNonNull(v);
 		});
 		return new MapValue<>(map);
+	}
+
+	/**
+	 * @return a {@link Collector} that accumulates items into a {@link MapValue}
+	 * by extracting a {@link String} key from each item via <code>keyMapper</code>
+	 * and a value via <code>valueMapper</code>.
+	 * If the same key appears twice, the later value silently overwrites the earlier one.
+	 */
+	public static <T, VV> Collector<T, ?, MapValue<VV>> toMapValue(
+		Function<? super T, String> keyMapper,
+		Function<? super T, ? extends VV> valueMapper
+	) {
+		class Accumulator {
+			OrderedPMap<String, VV> map = OrderedPMap.empty();
+			void accumulate(T item) { map = map.plus(keyMapper.apply(item), valueMapper.apply(item)); }
+			Accumulator combine(Accumulator other) { map = map.plusAll(other.map); return this; }
+			MapValue<VV> finish() { return MapValue.copyOf(map); }
+		}
+		return Collector.of(
+			Accumulator::new,
+			Accumulator::accumulate,
+			Accumulator::combine,
+			Accumulator::finish
+		);
 	}
 
 	private static <VV> void addToMap(LinkedHashMap<String, VV> map, String key, VV newValue) {

--- a/bosk-core/src/main/java/works/bosk/StateTreeSerializer.java
+++ b/bosk-core/src/main/java/works/bosk/StateTreeSerializer.java
@@ -411,6 +411,15 @@ public abstract class StateTreeSerializer {
 		}
 	}
 
+	protected final Reference<?> implicitReference(Class<?> nodeClass, RecordComponent parameter, BoskInfo<?> boskInfo) {
+		Reference<?> result = findImplicitReferenceIfAny(nodeClass, parameter, boskInfo);
+		if (result == null) {
+			throw new DeserializationException("No implicit reference for parameter \"" + parameter.getName()
+				+ "\" of " + nodeClass.getSimpleName());
+		}
+		return result;
+	}
+
 	private <T> Reference<T> selfReference(Class<T> targetClass, BoskInfo<?> boskInfo) throws AssertionError {
 		Path currentPath = currentScope.get().path();
 		try {

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -385,6 +385,22 @@ class ListingTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	void collector_deduplicatesIdentifiers() throws InvalidTypeException {
+		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.empty());
+		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> EntireState.just(root), BoskConfig.simple());
+		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
+
+		var items = List.of("a", "b", "a", "c", "b");
+		Listing<TestEntity> actual = items.stream()
+			.collect(Listing.toListing(childrenRef, Identifier::from));
+
+		var uniqueIds = Stream.of("a", "b", "c").map(Identifier::from).toList();
+		Listing<TestEntity> expected = Listing.of(childrenRef, uniqueIds);
+
+		assertEquals(expected, actual);
+	}
+
 	private List<TestEntity> distinctEntities(List<TestEntity> children) {
 		List<TestEntity> result = new ArrayList<>(children.size());
 		HashSet<Identifier> added = new HashSet<>(children.size());

--- a/bosk-core/src/test/java/works/bosk/ListingTest.java
+++ b/bosk-core/src/test/java/works/bosk/ListingTest.java
@@ -371,6 +371,20 @@ class ListingTest {
 		assertEquals(expected, listing.domain());
 	}
 
+	@Test
+	void collector_works() throws InvalidTypeException {
+		TestEntity root = new TestEntity(Identifier.unique("parent"), Catalog.empty());
+		Bosk<TestEntity> bosk = new Bosk<>(boskName(), TestEntity.class, _ -> EntireState.just(root), BoskConfig.simple());
+		CatalogReference<TestEntity> childrenRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.children));
+
+		var items = List.of("a", "b", "c", "d", "e");
+		var ids = items.stream().map(Identifier::from).toList();
+		Listing<TestEntity> expected = Listing.of(childrenRef, ids);
+		Listing<TestEntity> actual = items.stream()
+			.collect(Listing.toListing(childrenRef, Identifier::from));
+		assertEquals(expected, actual);
+	}
+
 	private List<TestEntity> distinctEntities(List<TestEntity> children) {
 		List<TestEntity> result = new ArrayList<>(children.size());
 		HashSet<Identifier> added = new HashSet<>(children.size());

--- a/bosk-core/src/test/java/works/bosk/MapValueTest.java
+++ b/bosk-core/src/test/java/works/bosk/MapValueTest.java
@@ -326,6 +326,15 @@ class MapValueTest extends AbstractBoskTest {
 	}
 
 	@Test
+	void collector_works() {
+		var items = List.of("a", "b", "c", "d", "e");
+		MapValue<String> expected = MapValue.fromFunction(items, s -> s + "_value");
+		MapValue<String> actual = items.stream()
+			.collect(MapValue.toMapValue(Function.identity(), s -> s + "_value"));
+		assertEquals(expected, actual);
+	}
+
+	@Test
 	void testBad_duplicateKeysFromFunction() {
 		assertThrows(IllegalArgumentException.class, () -> MapValue.fromFunction(asList("dup", "dup"), Identifier::unique));
 	}

--- a/bosk-core/src/test/java/works/bosk/MapValueTest.java
+++ b/bosk-core/src/test/java/works/bosk/MapValueTest.java
@@ -335,6 +335,15 @@ class MapValueTest extends AbstractBoskTest {
 	}
 
 	@Test
+	void collector_duplicateKey_laterValueWins() {
+		var items = List.of("first", "second");
+		MapValue<String> expected = MapValue.singleton("dup", "second");
+		MapValue<String> actual = items.stream()
+			.collect(MapValue.toMapValue(s -> "dup", Function.identity()));
+		assertEquals(expected, actual);
+	}
+
+	@Test
 	void testBad_duplicateKeysFromFunction() {
 		assertThrows(IllegalArgumentException.class, () -> MapValue.fromFunction(asList("dup", "dup"), Identifier::unique));
 	}

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -9,6 +9,7 @@ import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
@@ -17,7 +18,7 @@ import org.slf4j.MDC;
 import org.slf4j.Marker;
 
 import static ch.qos.logback.core.spi.FilterReply.NEUTRAL;
-import static java.util.Objects.requireNonNull;
+import static java.util.Collections.emptyMap;
 import static works.bosk.logback.RecordingTurboFilter.Overrides.NONE;
 
 /**
@@ -293,8 +294,15 @@ public class RecordingTurboFilter extends TurboFilter {
 		}
 
 		// We need to capture the current MDC. Can't wait until replay.
-		event.setMDCPropertyMap(requireNonNull(MDC.getCopyOfContextMap(), // ew, this is O(n)
-			"MDC can't be absent here!"));
+		// getCopyOfContextMap can return null sometimes; I can't say I fully
+		// understand why, but if that's null, there's no useful context
+		// and we might as well use an empty map.
+		//
+		// Possibly relevant:
+		// - https://jira.qos.ch/browse/LOGBACK-944
+		//
+		Map<String, String> mdcCopy = MDC.getCopyOfContextMap();
+		event.setMDCPropertyMap(mdcCopy != null ? mdcCopy : emptyMap());
 
 		LogEventBuffer buffer = buffersByTestId
 			.computeIfAbsent(testIdValue, _ -> new LogEventBuffer(effectiveCapacity));

--- a/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/RecordingTurboFilter.java
@@ -152,12 +152,9 @@ public class RecordingTurboFilter extends TurboFilter {
 	// Optional nested capture-time filter configured via <filter> under the turboFilter
 	private Filter<ILoggingEvent> filter;
 
-	// These things are static so the test lifecycle methods don't need to
-	// get their hands on the filter instance.
-
-	private static final ConcurrentHashMap<String, Overrides> overridesByTestId = new ConcurrentHashMap<>();
-	private static final ConcurrentHashMap<String, LogEventBuffer> buffersByTestId = new ConcurrentHashMap<>();
-	private static final ConcurrentHashMap<String, String> testIdsByRoutingKey = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, Overrides> overridesByTestId = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, LogEventBuffer> buffersByTestId = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, String> testIdsByRoutingKey = new ConcurrentHashMap<>();
 
 	// Setters for logback configuration properties
 
@@ -192,7 +189,7 @@ public class RecordingTurboFilter extends TurboFilter {
 	 */
 	public void setFilter(Filter<ILoggingEvent> filter) { this.filter = filter; }
 
-	static void putOverrides(String testId, Overrides overrides) {
+	void putOverrides(String testId, Overrides overrides) {
 		if (overrides == null || NONE.equals(overrides)) {
 			// We want to keep this map tidy so we can tell when it's empty
 			overridesByTestId.remove(testId);
@@ -201,7 +198,7 @@ public class RecordingTurboFilter extends TurboFilter {
 		}
 	}
 
-	static void removeOverrides(String testId) {
+	void removeOverrides(String testId) {
 		overridesByTestId.remove(testId);
 		cleanupForTest(testId);
 	}
@@ -321,7 +318,7 @@ public class RecordingTurboFilter extends TurboFilter {
 		return new QueueContents(buffer.queue, buffer.count.get() - buffer.queue.size());
 	}
 
-	static void cleanupForTest(String testId) {
+	void cleanupForTest(String testId) {
 		testIdsByRoutingKey.forEach((routingKeyValue, associatedTestId) -> {
 			if (testId.equals(associatedTestId)) {
 				testIdsByRoutingKey.remove(routingKeyValue);

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -60,6 +60,7 @@ public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEa
 		String testId = context.getUniqueId();
 
 		if (context.getExecutionException().isPresent() && filter != null) {
+			// This is what it's all about
 			replay(filter.queueContents(testId));
 		}
 
@@ -101,8 +102,8 @@ public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEa
 	@Nullable
 	private static RecordingTurboFilter findFilter(LoggerContext loggerContext) {
 		for (var f : loggerContext.getTurboFilterList()) {
-			if (f instanceof RecordingTurboFilter) {
-				return (RecordingTurboFilter) f;
+			if (f instanceof RecordingTurboFilter r) {
+				return r;
 			}
 		}
 		return null;

--- a/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/ReplayLogsOnFailureExtension.java
@@ -45,24 +45,27 @@ public class ReplayLogsOnFailureExtension implements BeforeEachCallback, AfterEa
 	public void beforeEach(ExtensionContext context) {
 		String testId = context.getUniqueId();
 		MDC.put(TEST_ID_KEY, testId);
-		RecordingTurboFilter.putOverrides(testId, resolveOverrides(context));
+		var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		RecordingTurboFilter filter = findFilter(loggerContext);
+		if (filter != null) {
+			filter.putOverrides(testId, resolveOverrides(context));
+		}
 	}
 
 	@Override
 	public void afterEach(ExtensionContext context) {
 		var loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		RecordingTurboFilter filter = findFilter(loggerContext);
 
 		String testId = context.getUniqueId();
 
-		if (context.getExecutionException().isPresent()) {
-			RecordingTurboFilter filter = findFilter(loggerContext);
-			if (filter != null) {
-				// This is what it's all about
-				replay(filter.queueContents(testId));
-			}
+		if (context.getExecutionException().isPresent() && filter != null) {
+			replay(filter.queueContents(testId));
 		}
 
-		RecordingTurboFilter.removeOverrides(testId);
+		if (filter != null) {
+			filter.removeOverrides(testId);
+		}
 		MDC.remove(TEST_ID_KEY);
 	}
 

--- a/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
+++ b/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 import static works.bosk.logback.RecordingTurboFilter.Overrides;
 import static works.bosk.logback.RecordingTurboFilter.TEST_ID_KEY;
-import static works.bosk.logback.RecordingTurboFilter.removeOverrides;
 
 @InjectFrom({
 	RecordingTurboFilterTest.BooleanInjector.class,
@@ -87,15 +86,15 @@ class RecordingTurboFilterTest {
 	@AfterEach
 	void teardown() {
 		MDC.clear();
-		removeOverrides(TEST_A);
-		removeOverrides(TEST_B);
-		removeOverrides(TEST);
+		filter.removeOverrides(TEST_A);
+		filter.removeOverrides(TEST_B);
+		filter.removeOverrides(TEST);
 	}
 
 	@InjectedTest
 	void enabled(boolean globalEnabled, Boolean perTestEnabled) {
 		filter.setEnabled(globalEnabled);
-		RecordingTurboFilter.putOverrides(TEST, new Overrides(perTestEnabled, null));
+		filter.putOverrides(TEST, new Overrides(perTestEnabled, null));
 
 		MDC.put(TEST_ID_KEY, TEST);
 		testLogger.debug("event");
@@ -110,7 +109,7 @@ class RecordingTurboFilterTest {
 	void capacity(Integer perTestCapacity) {
 		filter.setEnabled(true);
 		filter.setCapacity(2);
-		RecordingTurboFilter.putOverrides(TEST, new Overrides(true, perTestCapacity));
+		filter.putOverrides(TEST, new Overrides(true, perTestCapacity));
 
 		MDC.put(TEST_ID_KEY, TEST);
 		testLogger.debug("event 1");
@@ -242,7 +241,7 @@ class RecordingTurboFilterTest {
 		MDC.put(TEST_ID_KEY, TEST_B);
 		testLogger.debug("B");
 
-		RecordingTurboFilter.cleanupForTest(TEST_A);
+		filter.cleanupForTest(TEST_A);
 
 		var testAEvents = EventSnapshot.from(filter.queueContents(TEST_A).events());
 		var testBEvents = EventSnapshot.from(filter.queueContents(TEST_B).events());

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/AbstractMongoDriverTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/AbstractMongoDriverTest.java
@@ -137,6 +137,7 @@ abstract class AbstractMongoDriverTest {
 			SideTable.empty(refs.catalog()),
 			SideTable.empty(refs.catalog()),
 			TaggedUnion.of(new TestEntity.StringCase(rootID.toString())),
+			Optional.empty(),
 			Optional.empty()
 		);
 	}

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriver.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriver.java
@@ -24,7 +24,7 @@ public interface SqlDriver extends BoskDriver {
 			JacksonSerializer jacksonSerializer = new JacksonSerializer();
 			ObjectMapper mapper = objectMapperCustomizer.apply(b, JsonMapper.builder().addModule(jacksonSerializer.moduleFor(b))).build();
 			return new SqlDriverFacade(jacksonSerializer, new SqlDriverImpl(
-				settings, connectionSource, b, mapper, d
+				settings, connectionSource, b, mapper, jacksonSerializer, d
 			));
 		};
 	}

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
@@ -38,6 +38,7 @@ import works.bosk.drivers.sql.schema.Schema;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
+import works.bosk.jackson.JacksonSerializer;
 import works.bosk.jackson.JsonNodeSurgeon;
 import works.bosk.jackson.JsonNodeSurgeon.NodeInfo;
 import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.NonexistentParent;
@@ -64,6 +65,7 @@ class SqlDriverImpl implements SqlDriver {
 	private final BoskContext context;
 	private final ConnectionSource connectionSource;
 	private final ObjectMapper mapper;
+	private final JacksonSerializer jacksonSerializer;
 	private final JsonNodeSurgeon surgeon = new JsonNodeSurgeon();
 
 	private final AtomicBoolean isOpen = new AtomicBoolean(true);
@@ -90,6 +92,7 @@ class SqlDriverImpl implements SqlDriver {
 		ConnectionSource cs,
 		BoskInfo<?> bosk,
 		ObjectMapper mapper,
+		JacksonSerializer jacksonSerializer,
 		BoskDriver downstream
 	) {
 		this.settings = settings;
@@ -99,6 +102,7 @@ class SqlDriverImpl implements SqlDriver {
 		this.boskID	= bosk.instanceID();
 		this.context = requireNonNull(bosk.context());
 		this.mapper = requireNonNull(mapper);
+		this.jacksonSerializer = requireNonNull(jacksonSerializer);
 		this.connectionSource = () -> {
 			Connection result = cs.get();
 			// autoCommit is an idiotic default
@@ -183,8 +187,10 @@ class SqlDriverImpl implements SqlDriver {
 							if (newState == null) {
 								newValue = null;
 							} else {
-								newValue = mapper.readerFor(typeFactory.constructType(target.targetType()))
-									.readValue(newState);
+								try (var _ = jacksonSerializer.newDeserializationScope(target)) {
+									newValue = mapper.readerFor(typeFactory.constructType(target.targetType()))
+										.readValue(newState);
+								}
 							}
 							submitDownstream(target, newValue, changeID);
 						} catch (JacksonException e) {
@@ -307,7 +313,9 @@ class SqlDriverImpl implements SqlDriver {
 			throw new AssertionError("Epoch was just set, so it shouldn't mismatch in the same transaction", e);
 		}
 		JavaType valueType = typeFactory.constructType(rootType);
-		root = mapper.readValue(stateAndEpoch.state, valueType);
+		try (var _ = jacksonSerializer.newDeserializationScope(rootRef)) {
+			root = mapper.readValue(stateAndEpoch.state, valueType);
+		}
 		this.lastChangeSubmittedDownstream.set(-1);
 		connection.commit();
 		submitDownstream(rootRef, root, currentChangeID);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
@@ -40,6 +40,7 @@ import works.bosk.junit.InjectedTest;
 import works.bosk.junit.Injector;
 import works.bosk.junit.RunAnteTestsFirst;
 import works.bosk.testing.drivers.state.Primitives;
+import works.bosk.testing.drivers.state.SelfValue;
 import works.bosk.testing.drivers.state.TestEntity;
 import works.bosk.testing.drivers.state.TestEntity.IdentifierCase;
 import works.bosk.testing.drivers.state.TestEntity.StringCase;
@@ -394,6 +395,16 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 		driver.submitDeletion(ref);
 		assertCorrectBoskContents();
 		driver.submitDeletion(ref);
+		assertCorrectBoskContents();
+	}
+
+	@Test
+	void optional_selfReference() throws InvalidTypeException {
+		setupBosksAndReferences(driverFactory);
+		CatalogReference<TestEntity> catalogRef = bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog));
+		autoInitialize(catalogRef.then(child1ID));
+		Reference<SelfValue> selfValueRef = catalogRef.then(child1ID).then(SelfValue.class, "selfValue");
+		driver.submitReplacement(selfValueRef, new SelfValue(selfValueRef, "test"));
 		assertCorrectBoskContents();
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/state/SelfValue.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/state/SelfValue.java
@@ -1,0 +1,10 @@
+package works.bosk.testing.drivers.state;
+
+import works.bosk.Reference;
+import works.bosk.StateTreeNode;
+import works.bosk.annotations.Self;
+
+public record SelfValue(
+	@Self Reference<SelfValue> self,
+	String string
+) implements StateTreeNode {}

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/state/TestEntity.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/state/TestEntity.java
@@ -26,7 +26,8 @@ public record TestEntity(
 	SideTable<TestEntity, TestEntity> sideTable,
 	SideTable<TestEntity, SideTable<TestEntity, TestEntity>> nestedSideTable,
 	TaggedUnion<Variant> variant,
-	Optional<TestValues> values
+	Optional<TestValues> values,
+	Optional<SelfValue> selfValue
 ) implements Entity {
 
 	public interface Variant extends VariantCase {
@@ -56,6 +57,7 @@ public record TestEntity(
 			SideTable.empty(catalogRef),
 			SideTable.empty(catalogRef),
 			TaggedUnion.of(new StringCase("")),
+			Optional.empty(),
 			Optional.empty());
 	}
 

--- a/boson/src/main/java/works/bosk/boson/codec/compiler/SpecCompiler.java
+++ b/boson/src/main/java/works/bosk/boson/codec/compiler/SpecCompiler.java
@@ -574,13 +574,15 @@ public class SpecCompiler {
 
 				LocalVariable handlerResultLocal = null;
 				var keyHandler = acc.keyHandler();
-				boolean hasHandlerResult = keyHandler.returnType() != DataType.VOID;
+				boolean hasHandlerResult = !DataType.VOID.equals(keyHandler.returnType());
 				var keyHandlerMt = curryAndLoad(keyHandler.handle(), "keyHandler");
 				accumulator.load(codeBuilder);
 				keyLocal.load(codeBuilder);
 				_invokeExact(keyHandlerMt);
 				if (hasHandlerResult) {
-					handlerResultLocal = locals.allocate(REFERENCE);
+					TypeKind handlerKind = TypeKind.fromDescriptor(
+						keyHandler.returnType().leastUpperBoundClass().descriptorString());
+					handlerResultLocal = locals.allocate(handlerKind);
 					handlerResultLocal.store(codeBuilder);
 				}
 

--- a/boson/src/main/java/works/bosk/boson/codec/compiler/SpecCompiler.java
+++ b/boson/src/main/java/works/bosk/boson/codec/compiler/SpecCompiler.java
@@ -58,6 +58,7 @@ import works.bosk.boson.mapping.spec.SpecNode;
 import works.bosk.boson.mapping.spec.StringNode;
 import works.bosk.boson.mapping.spec.TypeRefNode;
 import works.bosk.boson.mapping.spec.UniformMapNode;
+import works.bosk.boson.types.DataType;
 import works.bosk.boson.types.KnownType;
 import works.bosk.boson.types.PrimitiveType;
 
@@ -567,9 +568,34 @@ public class SpecCompiler {
 
 				codeBuilder.labelBinding(member);
 				_parseAny(node.keyNode());
+				TypeKind keyKind = nodeReturnTypeKind(node.keyNode());
+				LocalVariable keyLocal = locals.allocate(keyKind);
+				keyLocal.store(codeBuilder);
+
+				LocalVariable handlerResultLocal = null;
+				var keyHandler = acc.keyHandler();
+				boolean hasHandlerResult = keyHandler.returnType() != DataType.VOID;
+				var keyHandlerMt = curryAndLoad(keyHandler.handle(), "keyHandler");
+				accumulator.load(codeBuilder);
+				keyLocal.load(codeBuilder);
+				_invokeExact(keyHandlerMt);
+				if (hasHandlerResult) {
+					handlerResultLocal = locals.allocate(REFERENCE);
+					handlerResultLocal.store(codeBuilder);
+				}
+
 				_parseAny(node.valueNode());
+				TypeKind valueKind = nodeReturnTypeKind(node.valueNode());
+				LocalVariable valueLocal = locals.allocate(valueKind);
+				valueLocal.store(codeBuilder);
+
 				var integratorType = curryAndLoad(acc.integrator().handle(), "acc_integrator");
 				accumulator.load(codeBuilder);
+				keyLocal.load(codeBuilder);
+				valueLocal.load(codeBuilder);
+				if (hasHandlerResult) {
+					handlerResultLocal.load(codeBuilder);
+				}
 				_invokeExact(integratorType);
 				if (integratorType.returnType() != void.class) {
 					accumulator.store(codeBuilder);

--- a/boson/src/main/java/works/bosk/boson/codec/compiler/SpecCompiler.java
+++ b/boson/src/main/java/works/bosk/boson/codec/compiler/SpecCompiler.java
@@ -566,10 +566,10 @@ public class SpecCompiler {
 				);
 
 				codeBuilder.labelBinding(member);
-				var integratorType = curryAndLoad(acc.integrator().handle(), "acc_integrator");
-				accumulator.load(codeBuilder);
 				_parseAny(node.keyNode());
 				_parseAny(node.valueNode());
+				var integratorType = curryAndLoad(acc.integrator().handle(), "acc_integrator");
+				accumulator.load(codeBuilder);
 				_invokeExact(integratorType);
 				if (integratorType.returnType() != void.class) {
 					accumulator.store(codeBuilder);

--- a/boson/src/main/java/works/bosk/boson/codec/interpreter/SpecInterpretingParser.java
+++ b/boson/src/main/java/works/bosk/boson/codec/interpreter/SpecInterpretingParser.java
@@ -328,12 +328,25 @@ public class SpecInterpretingParser implements Parser {
 		private class MapAccumulator implements Accumulator {
 			private final UniformMapNode n;
 			private final Object accumulator;
+			private final TypedHandle keyHandler;
 			Object key;
+			private Object keyHandlerResult;
 
 			public MapAccumulator(UniformMapNode n, Object firstKey) {
 				this.n = n;
 				this.key = firstKey;
 				this.accumulator = n.accumulator().creator().invoke();
+				this.keyHandler = n.accumulator().keyHandler();
+				this.keyHandlerResult = invokeKeyHandler(firstKey);
+			}
+
+			private Object invokeKeyHandler(Object key) {
+				if (keyHandler.returnType() == VOID) {
+					keyHandler.invoke(accumulator, key);
+					return null;
+				} else {
+					return keyHandler.invoke(accumulator, key);
+				}
 			}
 
 			@Override
@@ -343,11 +356,17 @@ public class SpecInterpretingParser implements Parser {
 
 			@Override
 			public Object accumulate(Object value) throws IOException {
-				n.accumulator().integrator().invoke(accumulator, key, value);
+				var integrator = n.accumulator().integrator();
+				if (keyHandler.returnType() != VOID) {
+					integrator.invoke(accumulator, key, value, keyHandlerResult);
+				} else {
+					integrator.invoke(accumulator, key, value);
+				}
 				if (nextTokenIs(END_OBJECT)) {
 					return n.accumulator().finisher().invoke(accumulator);
 				} else {
 					key = parseAny(n.keyNode());
+					keyHandlerResult = invokeKeyHandler(key);
 					return NO_RESULT;
 				}
 			}
@@ -511,11 +530,23 @@ public class SpecInterpretingParser implements Parser {
 			input.expectSyntax(START_OBJECT);
 			ObjectAccumulator acc = node.accumulator();
 			Object accumulator = acc.creator().invoke();
+			TypedHandle keyHandler = acc.keyHandler();
 			while (input.peekValueToken() != END_OBJECT) {
 				Object key = parseAny(node.keyNode());
+				Object handlerResult = null;
+				if (keyHandler.returnType() != VOID) {
+					handlerResult = keyHandler.invoke(accumulator, key);
+				} else {
+					keyHandler.invoke(accumulator, key);
+				}
 				Object value = parseAny(node.valueNode());
 				LOGGER.debug("| member [{}:{}]: |{}|", key, value, previewString());
-				Object returned = acc.integrator().invoke(accumulator, key, value);
+				Object returned;
+				if (keyHandler.returnType() != VOID) {
+					returned = acc.integrator().invoke(accumulator, key, value, handlerResult);
+				} else {
+					returned = acc.integrator().invoke(accumulator, key, value);
+				}
 				if (acc.integrator().returnType() != VOID) {
 					accumulator = returned;
 				}

--- a/boson/src/main/java/works/bosk/boson/codec/interpreter/SpecInterpretingParser.java
+++ b/boson/src/main/java/works/bosk/boson/codec/interpreter/SpecInterpretingParser.java
@@ -113,7 +113,7 @@ public class SpecInterpretingParser implements Parser {
 
 		private Object parseCallback(ParseCallbackSpec node) throws IOException {
 			Object result;
-			if (node.before().returnType() == VOID) {
+			if (VOID.equals(node.before().returnType())) {
 				node.before().invoke();
 				result = parseAny_recursive(node.child());
 				node.after().invoke(result);
@@ -233,7 +233,7 @@ public class SpecInterpretingParser implements Parser {
 						continue;
 					}
 					case ParseCallbackSpec n -> {
-						if (n.before().returnType() == VOID) {
+						if (VOID.equals(n.before().returnType())) {
 							n.before().invoke();
 							stack.push(new CallbackAccumulator(n.child(), null, n.after()));
 						} else {
@@ -341,7 +341,7 @@ public class SpecInterpretingParser implements Parser {
 			}
 
 			private Object invokeKeyHandler(Object key) {
-				if (keyHandler.returnType() == VOID) {
+				if (VOID.equals(keyHandler.returnType())) {
 					keyHandler.invoke(accumulator, key);
 					return null;
 				} else {
@@ -357,10 +357,10 @@ public class SpecInterpretingParser implements Parser {
 			@Override
 			public Object accumulate(Object value) throws IOException {
 				var integrator = n.accumulator().integrator();
-				if (keyHandler.returnType() != VOID) {
-					integrator.invoke(accumulator, key, value, keyHandlerResult);
-				} else {
+				if (VOID.equals(keyHandler.returnType())) {
 					integrator.invoke(accumulator, key, value);
+				} else {
+					integrator.invoke(accumulator, key, value, keyHandlerResult);
 				}
 				if (nextTokenIs(END_OBJECT)) {
 					return n.accumulator().finisher().invoke(accumulator);
@@ -517,7 +517,7 @@ public class SpecInterpretingParser implements Parser {
 			while (input.peekValueToken() != END_ARRAY) {
 				Object element = parseAny(node.elementNode());
 				var returned = acc.integrator().invoke(accumulator, element);
-				if (acc.integrator().returnType() != VOID) {
+				if (!VOID.equals(acc.integrator().returnType())) {
 					accumulator = returned;
 				}
 			}
@@ -534,20 +534,20 @@ public class SpecInterpretingParser implements Parser {
 			while (input.peekValueToken() != END_OBJECT) {
 				Object key = parseAny(node.keyNode());
 				Object handlerResult = null;
-				if (keyHandler.returnType() != VOID) {
-					handlerResult = keyHandler.invoke(accumulator, key);
-				} else {
+				if (VOID.equals(keyHandler.returnType())) {
 					keyHandler.invoke(accumulator, key);
+				} else {
+					handlerResult = keyHandler.invoke(accumulator, key);
 				}
 				Object value = parseAny(node.valueNode());
 				LOGGER.debug("| member [{}:{}]: |{}|", key, value, previewString());
 				Object returned;
-				if (keyHandler.returnType() != VOID) {
-					returned = acc.integrator().invoke(accumulator, key, value, handlerResult);
-				} else {
+				if (VOID.equals(keyHandler.returnType())) {
 					returned = acc.integrator().invoke(accumulator, key, value);
+				} else {
+					returned = acc.integrator().invoke(accumulator, key, value, handlerResult);
 				}
-				if (acc.integrator().returnType() != VOID) {
+				if (!VOID.equals(acc.integrator().returnType())) {
 					accumulator = returned;
 				}
 			}

--- a/boson/src/main/java/works/bosk/boson/codec/interpreter/SpecInterpretingParser.java
+++ b/boson/src/main/java/works/bosk/boson/codec/interpreter/SpecInterpretingParser.java
@@ -302,7 +302,7 @@ public class SpecInterpretingParser implements Parser {
 
 		private class ArrayAccumulator implements Accumulator {
 			private final ArrayNode n;
-			private final Object accumulator;
+			private Object accumulator;
 
 			public ArrayAccumulator(ArrayNode n) {
 				this.n = n;
@@ -316,7 +316,11 @@ public class SpecInterpretingParser implements Parser {
 
 			@Override
 			public Object accumulate(Object value) throws IOException {
-				n.accumulator().integrator().invoke(accumulator, value);
+				var integrator = n.accumulator().integrator();
+				var returned = integrator.invoke(accumulator, value);
+				if (!VOID.equals(integrator.returnType())) {
+					accumulator = returned;
+				}
 				if (InterpretedParseSession.this.nextTokenIs(END_ARRAY)) {
 					return n.accumulator().finisher().invoke(accumulator);
 				} else {
@@ -327,7 +331,7 @@ public class SpecInterpretingParser implements Parser {
 
 		private class MapAccumulator implements Accumulator {
 			private final UniformMapNode n;
-			private final Object accumulator;
+			private Object accumulator;
 			private final TypedHandle keyHandler;
 			Object key;
 			private Object keyHandlerResult;
@@ -357,10 +361,14 @@ public class SpecInterpretingParser implements Parser {
 			@Override
 			public Object accumulate(Object value) throws IOException {
 				var integrator = n.accumulator().integrator();
+				Object returned;
 				if (VOID.equals(keyHandler.returnType())) {
-					integrator.invoke(accumulator, key, value);
+					returned = integrator.invoke(accumulator, key, value);
 				} else {
-					integrator.invoke(accumulator, key, value, keyHandlerResult);
+					returned = integrator.invoke(accumulator, key, value, keyHandlerResult);
+				}
+				if (!VOID.equals(integrator.returnType())) {
+					accumulator = returned;
 				}
 				if (nextTokenIs(END_OBJECT)) {
 					return n.accumulator().finisher().invoke(accumulator);

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/FixedObjectNode.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/FixedObjectNode.java
@@ -91,37 +91,37 @@ public record FixedObjectNode(
 		);
 	}
 
-	public abstract static class Wrangler1<V, T1> {
+	public abstract static class OneMemberWrangler<V, M1> {
 		final String member1Name;
 
-		protected Wrangler1(String member1Name) {
+		protected OneMemberWrangler(String member1Name) {
 			this.member1Name = member1Name;
 		}
 
-		public abstract T1 accessor1(V value);
-		public abstract V finish(T1 member1);
+		public abstract M1 accessor(V value);
+		public abstract V finish(M1 member1);
 	}
 
-	public abstract static class Wrangler2<V, T1, T2> {
+	public abstract static class TwoMemberWrangler<V, M1, M2> {
 		final String member1Name;
 		final String member2Name;
 
-		protected Wrangler2(String member1Name, String member2Name) {
+		protected TwoMemberWrangler(String member1Name, String member2Name) {
 			this.member1Name = member1Name;
 			this.member2Name = member2Name;
 		}
 
-		public abstract T1 accessor1(V value);
-		public abstract T2 accessor2(V value);
-		public abstract V finish(T1 member1, T2 member2);
+		public abstract M1 accessor1(V value);
+		public abstract M2 accessor2(V value);
+		public abstract V finish(M1 member1, M2 member2);
 	}
 
-	public static FixedObjectNode of(Wrangler1<?, ?> wrangler) {
+	public static FixedObjectNode of(OneMemberWrangler<?, ?> wrangler) {
 		BoundType wranglerType = (BoundType) DataType.known(wrangler.getClass());
-		DataType valueType = wranglerType.parameterType(Wrangler1.class, 0);
+		DataType valueType = wranglerType.parameterType(OneMemberWrangler.class, 0);
 
 		var memberSpecs = new LinkedHashMap<String, RecognizedMember>();
-		DataType arg1Type = wranglerType.parameterType(Wrangler1.class, 1);
+		DataType arg1Type = wranglerType.parameterType(OneMemberWrangler.class, 1);
 		memberSpecs.put(wrangler.member1Name, new RecognizedMember(
 			new TypeRefNode(arg1Type),
 			new TypedHandle(
@@ -143,13 +143,13 @@ public record FixedObjectNode(
 		return new FixedObjectNode(memberSpecs, finisher);
 	}
 
-	public static FixedObjectNode of(Wrangler2<?, ?,?> wrangler) {
+	public static FixedObjectNode of(TwoMemberWrangler<?, ?,?> wrangler) {
 		BoundType wranglerType = (BoundType) DataType.known(wrangler.getClass());
-		DataType valueType = wranglerType.parameterType(Wrangler2.class, 0);
+		DataType valueType = wranglerType.parameterType(TwoMemberWrangler.class, 0);
 
 		var memberSpecs = new LinkedHashMap<String, RecognizedMember>();
-		DataType arg1Type = wranglerType.parameterType(Wrangler2.class, 1);
-		DataType arg2Type = wranglerType.parameterType(Wrangler2.class, 2);
+		DataType arg1Type = wranglerType.parameterType(TwoMemberWrangler.class, 1);
+		DataType arg2Type = wranglerType.parameterType(TwoMemberWrangler.class, 2);
 		memberSpecs.put(wrangler.member1Name, new RecognizedMember(
 			new TypeRefNode(arg1Type),
 			new TypedHandle(
@@ -190,15 +190,15 @@ public record FixedObjectNode(
 	static {
 		var lookup = MethodHandles.lookup();
 		try {
-			WRANGLER1_ACCESSOR1 = lookup.findVirtual(Wrangler1.class, "accessor1",
+			WRANGLER1_ACCESSOR1 = lookup.findVirtual(OneMemberWrangler.class, "accessor",
 				methodType(Object.class, Object.class));
-			WRANGLER1_FINISH = lookup.findVirtual(Wrangler1.class, "finish",
+			WRANGLER1_FINISH = lookup.findVirtual(OneMemberWrangler.class, "finish",
 				methodType(Object.class, Object.class));
-			WRANGLER2_ACCESSOR1 = lookup.findVirtual(Wrangler2.class, "accessor1",
+			WRANGLER2_ACCESSOR1 = lookup.findVirtual(TwoMemberWrangler.class, "accessor1",
 				methodType(Object.class, Object.class));
-			WRANGLER2_ACCESSOR2 = lookup.findVirtual(Wrangler2.class, "accessor2",
+			WRANGLER2_ACCESSOR2 = lookup.findVirtual(TwoMemberWrangler.class, "accessor2",
 				methodType(Object.class, Object.class));
-			WRANGLER2_FINISH = lookup.findVirtual(Wrangler2.class, "finish",
+			WRANGLER2_FINISH = lookup.findVirtual(TwoMemberWrangler.class, "finish",
 				methodType(Object.class, Object.class, Object.class));
 		} catch (NoSuchMethodException | IllegalAccessException e) {
 			throw new ExceptionInInitializerError(e);

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/ParseCallbackSpec.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/ParseCallbackSpec.java
@@ -25,11 +25,11 @@ public record ParseCallbackSpec(
 ) implements JsonValueSpec {
 	public ParseCallbackSpec {
 		assert before.parameterTypes().isEmpty();
-		assert after.returnType() == VOID;
+		assert VOID.equals(after.returnType());
 
 		DataType parsedValueType = child.dataType();
 		List<DataType> expected;
-		if (before.returnType() == VOID) {
+		if (VOID.equals(before.returnType())) {
 			expected = List.of(parsedValueType);
 		} else {
 			expected = List.of(before.returnType(), parsedValueType);

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/UniformMapNode.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/UniformMapNode.java
@@ -74,56 +74,102 @@ public record UniformMapNode(
 	}
 
 	/**
+	 * Wrangler corresponding to a common use case for {@link ObjectAccumulator#keyHandler()}.
+	 * <p>
+	 * {@code beforeValue} is called after the key is parsed but before the value.
+	 * {@code afterValue} is called after the value is parsed, but before
+	 * {@link OneMemberWrangler#finish}.
+	 *
+	 * @param <K> the map key type
+	 * @param <V> the map value type
+	 * @param <H> the type produced by {@code beforeValue} and passed to {@code afterValue}
+	 */
+	public interface MemberValueWrangler<K,V,H> {
+		H beforeValue(K key);
+		void afterValue(K key, V value, H handlerResult);
+
+		static <K,V,H> MemberValueWrangler<K,V,H> nop() {
+			return new MemberValueWrangler<>() {
+				@Override public H beforeValue(K key) { return null; }
+				@Override public void afterValue(K key, V value, H handlerResult) { }
+			};
+		}
+	}
+
+	/**
 	 * An efficient {@link UniformMapNode} for maps that have just one entry.
 	 *
 	 * @param wrangler object that knows how to extract the single key and value,
 	 *                  and how to create the value object from a key and a value
-	 * @param <T> the type of the value object representing the singleton map in memory
+	 * @param <T> the type of the value object representing the single-member map in memory
 	 * @param <K> the type of the map key (which corresponds to the JSON member name)
 	 * @param <V> the type of the map value (which corresponds to the JSON member value)
 	 */
-	public static <T,K,V> UniformMapNode singleton(OneMemberWrangler<T,K,V> wrangler) {
+	public static <T,K,V> UniformMapNode oneMember(OneMemberWrangler<T,K,V> wrangler) {
+		return oneMember(wrangler, MemberValueWrangler.nop());
+	}
+
+	/**
+	 * An efficient {@link UniformMapNode} for maps that have just one entry,
+	 * with a {@link MemberValueWrangler} for lifecycle hooks during deserialization.
+	 *
+	 * @param wrangler       knows how to extract the single key and value, and how to create the value object
+	 * @param memberValueWrangler lifecycle hooks for before/after the member value
+	 * @param <T> the type of the value object representing the single-member map in memory
+	 * @param <K> the type of the map key (which corresponds to the JSON member name)
+	 * @param <V> the type of the map value (which corresponds to the JSON member value)
+	 * @param <H> the type produced by {@link MemberValueWrangler#beforeValue} and passed to {@link MemberValueWrangler#afterValue}
+	 */
+	public static <T,K,V,H> UniformMapNode oneMember(
+		OneMemberWrangler<T,K,V> wrangler,
+		MemberValueWrangler<K,V,H> memberValueWrangler
+	) {
 		var wranglerType = (BoundType)DataType.of(wrangler.getClass());
 		var resultType = wranglerType.parameterType(OneMemberWrangler.class, 0);
 		var keyType = wranglerType.parameterType(OneMemberWrangler.class, 1);
 		var valueType = wranglerType.parameterType(OneMemberWrangler.class, 2);
+		var memberWranglerType = (BoundType)DataType.of(memberValueWrangler.getClass());
+		var handlerResultType = memberWranglerType.parameterType(MemberValueWrangler.class, 2);
 		Map<String, DataType> actualArguments = Map.of(
 			"T", resultType,
 			"K", keyType,
-			"V", valueType
+			"V", valueType,
+			"H", handlerResultType
 		);
 
-		// The "accumulator" here calls the finisher the first time
-		// the integrator is called; the actual finisher does nothing
-		ObjectAccumulator accumulator = ObjectAccumulator.from(new ObjectAccumulator.Wrangler<T,T,K,V>() {
-			@Override
-			public T create() {
-				return null;
-			}
+		ObjectAccumulator accumulator = ObjectAccumulator.from(
+			new ObjectAccumulator.KeyHandlingWrangler<T,T,K,V,H>() {
+				@Override
+				public T create() {
+					return null;
+				}
 
-			@Override
-			public T integrate(T acc, K key, V value) {
-				if (acc == null) {
-					return wrangler.finish(key, value);
-				} else {
-					throw new JsonContentException("More than one entry in singleton map");
+				@Override
+				public H keyHandler(T a, K key) {
+					return memberValueWrangler.beforeValue(key);
+				}
+
+				@Override
+				public T integrate(T a, K key, V value, H handlerResult) {
+					memberValueWrangler.afterValue(key, value, handlerResult);
+					if (a == null) {
+						return wrangler.finish(key, value);
+					} else {
+						throw new JsonContentException("More than one entry in single-member map");
+					}
+				}
+
+				@Override
+				public T finish(T a) {
+					if (a == null) {
+						throw new JsonContentException("Empty single-member map");
+					} else {
+						return a;
+					}
 				}
 			}
+		).substitute(actualArguments);
 
-			@Override
-			public T finish(T acc) {
-				if (acc == null) {
-					throw new JsonContentException("Empty singleton map");
-				} else {
-					return acc;
-				}
-			}
-		}).substitute(actualArguments);
-
-		// The "iterator" here is a kind of countdown of how many members
-		// are remaining: it starts at 1 and stops at 0. The getKey
-		// and getValue methods don't actually need this counter;
-		// it's there just to turn the for loop into a "do once" loop.
 		ObjectEmitter emitter = ObjectEmitter.forLoop(new ObjectEmitter.ForLoopWrangler<T,K,V>() {
 			@Override
 			public long start(T obj) {

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/UniformMapNode.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/UniformMapNode.java
@@ -67,7 +67,7 @@ public record UniformMapNode(
 		);
 	}
 
-	public interface SingletonWrangler<T,K,V> {
+	public interface OneMemberWrangler<T,K,V> {
 		K getKey(T value);
 		V getValue(T value);
 		T finish(K key, V value);
@@ -82,11 +82,11 @@ public record UniformMapNode(
 	 * @param <K> the type of the map key (which corresponds to the JSON member name)
 	 * @param <V> the type of the map value (which corresponds to the JSON member value)
 	 */
-	public static <T,K,V> UniformMapNode singleton(SingletonWrangler<T,K,V> wrangler) {
+	public static <T,K,V> UniformMapNode singleton(OneMemberWrangler<T,K,V> wrangler) {
 		var wranglerType = (BoundType)DataType.of(wrangler.getClass());
-		var resultType = wranglerType.parameterType(SingletonWrangler.class, 0);
-		var keyType = wranglerType.parameterType(SingletonWrangler.class, 1);
-		var valueType = wranglerType.parameterType(SingletonWrangler.class, 2);
+		var resultType = wranglerType.parameterType(OneMemberWrangler.class, 0);
+		var keyType = wranglerType.parameterType(OneMemberWrangler.class, 1);
+		var valueType = wranglerType.parameterType(OneMemberWrangler.class, 2);
 		Map<String, DataType> actualArguments = Map.of(
 			"T", resultType,
 			"K", keyType,

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ArrayAccumulator.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ArrayAccumulator.java
@@ -49,7 +49,7 @@ public record ArrayAccumulator(
 
 		assert integrator.parameterTypes().size() == 2;
 		assert integrator.parameterTypes().getFirst().isAssignableFrom(creator.returnType());
-		assert integrator.returnType() == VOID || integrator.returnType().equals(creator.returnType());
+		assert VOID.equals(integrator.returnType()) || integrator.returnType().equals(creator.returnType());
 
 		assert finisher.parameterTypes().size() == 1;
 		assert finisher.parameterTypes().getFirst().isAssignableFrom(creator.returnType());

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
@@ -52,17 +52,17 @@ public record ObjectAccumulator(
 		// TODO: injection
 		assert creator.parameterTypes().isEmpty();
 
-		if (keyHandler.returnType() != VOID) {
+		if (VOID.equals(keyHandler.returnType())) {
+			assert integrator.parameterTypes().size() == 3;
+		} else {
 			assert integrator.parameterTypes().size() == 4;
 			DataType handlerResultType = integrator.parameterTypes().get(3);
 			assert keyHandler.returnType().isAssignableFrom(handlerResultType):
 				"keyHandler return type " + keyHandler.returnType()
 					+ " must be assignable to integrator handler result param " + handlerResultType;
-		} else {
-			assert integrator.parameterTypes().size() == 3;
 		}
 		assert integrator.parameterTypes().getFirst().isAssignableFrom(creator.returnType());
-		assert integrator.returnType() == VOID || integrator.returnType().equals(creator.returnType());
+		assert VOID.equals(integrator.returnType()) || integrator.returnType().equals(creator.returnType());
 
 		assert finisher.parameterTypes().size() == 1;
 		assert finisher.parameterTypes().getFirst().isAssignableFrom(creator.returnType());

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
@@ -52,14 +52,16 @@ public record ObjectAccumulator(
 		// TODO: injection
 		assert creator.parameterTypes().isEmpty();
 
+		assert keyHandler.parameterTypes().size() == 2;
+		assert keyHandler.parameterTypes().get(0).isAssignableFrom(creator.returnType());
+		assert keyHandler.parameterTypes().get(1).isAssignableFrom(integrator.parameterTypes().get(1));
+
 		if (VOID.equals(keyHandler.returnType())) {
 			assert integrator.parameterTypes().size() == 3;
 		} else {
 			assert integrator.parameterTypes().size() == 4;
 			DataType handlerResultType = integrator.parameterTypes().get(3);
-			assert handlerResultType.isAssignableFrom(keyHandler.returnType()):
-				"keyHandler return type " + keyHandler.returnType()
-					+ " must be assignable to integrator handler result param " + handlerResultType;
+			assert handlerResultType.isAssignableFrom(keyHandler.returnType());
 		}
 		assert integrator.parameterTypes().getFirst().isAssignableFrom(creator.returnType());
 		assert VOID.equals(integrator.returnType()) || integrator.returnType().equals(creator.returnType());

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
@@ -167,12 +167,12 @@ public record ObjectAccumulator(
 
 		return new ObjectAccumulator(
 			new TypedHandle(
-				SEQ_WRANGLER_CREATE.bindTo(wrangler)
+				KEY_HANDLING_WRANGLER_CREATE.bindTo(wrangler)
 					.asType(MethodType.methodType(accumulatorType.leastUpperBoundClass())),
 				accumulatorType, List.of()
 			),
 			new TypedHandle(
-				SEQ_WRANGLER_KEY_HANDLER.bindTo(wrangler)
+				KEY_HANDLING_WRANGLER_KEY_HANDLER.bindTo(wrangler)
 					.asType(MethodType.methodType(
 						handlerResultType.leastUpperBoundClass(),
 						accumulatorType.leastUpperBoundClass(),
@@ -181,7 +181,7 @@ public record ObjectAccumulator(
 				handlerResultType, List.of(accumulatorType, keyType)
 			),
 			new TypedHandle(
-				SEQ_WRANGLER_INTEGRATE.bindTo(wrangler)
+				KEY_HANDLING_WRANGLER_INTEGRATE.bindTo(wrangler)
 					.asType(MethodType.methodType(
 						accumulatorType.leastUpperBoundClass(),
 						accumulatorType.leastUpperBoundClass(),
@@ -192,7 +192,7 @@ public record ObjectAccumulator(
 				accumulatorType, List.of(accumulatorType, keyType, valueType, handlerResultType)
 			),
 			new TypedHandle(
-				SEQ_WRANGLER_FINISH.bindTo(wrangler)
+				KEY_HANDLING_WRANGLER_FINISH.bindTo(wrangler)
 					.asType(MethodType.methodType(
 						resultType.leastUpperBoundClass(),
 						accumulatorType.leastUpperBoundClass()
@@ -206,10 +206,10 @@ public record ObjectAccumulator(
 	private static final MethodHandle WRANGLER_INTEGRATE;
 	private static final MethodHandle WRANGLER_FINISH;
 
-	private static final MethodHandle SEQ_WRANGLER_CREATE;
-	private static final MethodHandle SEQ_WRANGLER_KEY_HANDLER;
-	private static final MethodHandle SEQ_WRANGLER_INTEGRATE;
-	private static final MethodHandle SEQ_WRANGLER_FINISH;
+	private static final MethodHandle KEY_HANDLING_WRANGLER_CREATE;
+	private static final MethodHandle KEY_HANDLING_WRANGLER_KEY_HANDLER;
+	private static final MethodHandle KEY_HANDLING_WRANGLER_INTEGRATE;
+	private static final MethodHandle KEY_HANDLING_WRANGLER_FINISH;
 
 	static {
 		try {
@@ -229,22 +229,22 @@ public record ObjectAccumulator(
 				"finish",
 				MethodType.methodType(Object.class, Object.class)
 			);
-			SEQ_WRANGLER_CREATE = lookup.findVirtual(
+			KEY_HANDLING_WRANGLER_CREATE = lookup.findVirtual(
 				KeyHandlingWrangler.class,
 				"create",
 				MethodType.methodType(Object.class)
 			);
-			SEQ_WRANGLER_KEY_HANDLER = lookup.findVirtual(
+			KEY_HANDLING_WRANGLER_KEY_HANDLER = lookup.findVirtual(
 				KeyHandlingWrangler.class,
 				"keyHandler",
 				MethodType.methodType(Object.class, Object.class, Object.class)
 			);
-			SEQ_WRANGLER_INTEGRATE = lookup.findVirtual(
+			KEY_HANDLING_WRANGLER_INTEGRATE = lookup.findVirtual(
 				KeyHandlingWrangler.class,
 				"integrate",
 				MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class)
 			);
-			SEQ_WRANGLER_FINISH = lookup.findVirtual(
+			KEY_HANDLING_WRANGLER_FINISH = lookup.findVirtual(
 				KeyHandlingWrangler.class,
 				"finish",
 				MethodType.methodType(Object.class, Object.class)

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
@@ -33,13 +33,18 @@ import static works.bosk.boson.types.DataType.VOID;
  * If the integrator returns void, the accumulator is assumed to be updated in-place,
  * and the one returned by the creator will continue to be used.
  * Otherwise, the integrator returns the updated accumulator.
+ * <p>
+ * If {@code keyHandler} returns a value (rather than void), that value is passed
+ * as the last parameter to {@code integrator}, after the key and value.
  *
  * @param creator    produces the initial accumulator value
- * @param integrator given the accumulator, a key, and a value, updates the accumulator, and returns it (or void)
+ * @param keyHandler invoked with {@code (accumulator, key)} before each entry's value; if its return type is not void, the result is passed to integrator as the last argument
+ * @param integrator given the accumulator, a key, a value, and optionally the keyHandler result, updates the accumulator, and returns it (or void)
  * @param finisher   given the accumulator, returns the final result
  */
 public record ObjectAccumulator(
 	TypedHandle creator,
+	TypedHandle keyHandler,
 	TypedHandle integrator,
 	TypedHandle finisher
 ) {
@@ -47,7 +52,15 @@ public record ObjectAccumulator(
 		// TODO: injection
 		assert creator.parameterTypes().isEmpty();
 
-		assert integrator.parameterTypes().size() == 3;
+		if (keyHandler.returnType() != VOID) {
+			assert integrator.parameterTypes().size() == 4;
+			DataType handlerResultType = integrator.parameterTypes().get(3);
+			assert keyHandler.returnType().isAssignableFrom(handlerResultType):
+				"keyHandler return type " + keyHandler.returnType()
+					+ " must be assignable to integrator handler result param " + handlerResultType;
+		} else {
+			assert integrator.parameterTypes().size() == 3;
+		}
 		assert integrator.parameterTypes().getFirst().isAssignableFrom(creator.returnType());
 		assert integrator.returnType() == VOID || integrator.returnType().equals(creator.returnType());
 
@@ -70,6 +83,7 @@ public record ObjectAccumulator(
 	public ObjectAccumulator substitute(Map<String, DataType> actualArguments) {
 		return new ObjectAccumulator(
 			creator.substitute(actualArguments),
+			keyHandler.substitute(actualArguments),
 			integrator.substitute(actualArguments),
 			finisher.substitute(actualArguments)
 		);
@@ -94,12 +108,14 @@ public record ObjectAccumulator(
 		var keyType = wranglerType.parameterType(Wrangler.class, 2);
 		var valueType = wranglerType.parameterType(Wrangler.class, 3);
 
+		TypedHandle noopKeyHandler = noopKeyHandler(accumulatorType, keyType);
 		return new ObjectAccumulator(
 			new TypedHandle(
 				WRANGLER_CREATE.bindTo(wrangler)
 					.asType(MethodType.methodType(accumulatorType.leastUpperBoundClass())),
 				accumulatorType, List.of()
 			),
+			noopKeyHandler,
 			new TypedHandle(
 				WRANGLER_INTEGRATE.bindTo(wrangler)
 					.asType(MethodType.methodType(
@@ -121,9 +137,77 @@ public record ObjectAccumulator(
 		);
 	}
 
+	private static TypedHandle noopKeyHandler(DataType accumulatorType, DataType keyType) {
+		return TypedHandles.biConsumer(accumulatorType, keyType, (a, k) -> {});
+	}
+
+	/**
+	 * @param <T> the type of the value object representing the object in memory
+	 * @param <A> the accumulator type
+	 * @param <K> the map key type
+	 * @param <V> the map value type
+	 * @param <H> the type produced by {@code keyHandler} and passed as the last argument to {@code integrator}
+	 */
+	public interface KeyHandlingWrangler<T,A,K,V,H> {
+		A create();
+		H keyHandler(A accumulator, K key);
+		A integrate(A accumulator, K key, V value, H handlerResult);
+		T finish(A accumulator);
+	}
+
+	public static <T,A,K,V,H> ObjectAccumulator from(KeyHandlingWrangler<T,A,K,V,H> wrangler) {
+		var wranglerType = (BoundType)DataType.of(wrangler.getClass());
+		var resultType = wranglerType.parameterType(KeyHandlingWrangler.class, 0);
+		var accumulatorType = wranglerType.parameterType(KeyHandlingWrangler.class, 1);
+		var keyType = wranglerType.parameterType(KeyHandlingWrangler.class, 2);
+		var valueType = wranglerType.parameterType(KeyHandlingWrangler.class, 3);
+		var handlerResultType = wranglerType.parameterType(KeyHandlingWrangler.class, 4);
+
+		return new ObjectAccumulator(
+			new TypedHandle(
+				SEQ_WRANGLER_CREATE.bindTo(wrangler)
+					.asType(MethodType.methodType(accumulatorType.leastUpperBoundClass())),
+				accumulatorType, List.of()
+			),
+			new TypedHandle(
+				SEQ_WRANGLER_KEY_HANDLER.bindTo(wrangler)
+					.asType(MethodType.methodType(
+						handlerResultType.leastUpperBoundClass(),
+						accumulatorType.leastUpperBoundClass(),
+						keyType.leastUpperBoundClass()
+					)),
+				handlerResultType, List.of(accumulatorType, keyType)
+			),
+			new TypedHandle(
+				SEQ_WRANGLER_INTEGRATE.bindTo(wrangler)
+					.asType(MethodType.methodType(
+						accumulatorType.leastUpperBoundClass(),
+						accumulatorType.leastUpperBoundClass(),
+						keyType.leastUpperBoundClass(),
+						valueType.leastUpperBoundClass(),
+						handlerResultType.leastUpperBoundClass()
+					)),
+				accumulatorType, List.of(accumulatorType, keyType, valueType, handlerResultType)
+			),
+			new TypedHandle(
+				SEQ_WRANGLER_FINISH.bindTo(wrangler)
+					.asType(MethodType.methodType(
+						resultType.leastUpperBoundClass(),
+						accumulatorType.leastUpperBoundClass()
+					)),
+				resultType, List.of(accumulatorType)
+			)
+		);
+	}
+
 	private static final MethodHandle WRANGLER_CREATE;
 	private static final MethodHandle WRANGLER_INTEGRATE;
 	private static final MethodHandle WRANGLER_FINISH;
+
+	private static final MethodHandle SEQ_WRANGLER_CREATE;
+	private static final MethodHandle SEQ_WRANGLER_KEY_HANDLER;
+	private static final MethodHandle SEQ_WRANGLER_INTEGRATE;
+	private static final MethodHandle SEQ_WRANGLER_FINISH;
 
 	static {
 		try {
@@ -140,6 +224,26 @@ public record ObjectAccumulator(
 			);
 			WRANGLER_FINISH = lookup.findVirtual(
 				Wrangler.class,
+				"finish",
+				MethodType.methodType(Object.class, Object.class)
+			);
+			SEQ_WRANGLER_CREATE = lookup.findVirtual(
+				KeyHandlingWrangler.class,
+				"create",
+				MethodType.methodType(Object.class)
+			);
+			SEQ_WRANGLER_KEY_HANDLER = lookup.findVirtual(
+				KeyHandlingWrangler.class,
+				"keyHandler",
+				MethodType.methodType(Object.class, Object.class, Object.class)
+			);
+			SEQ_WRANGLER_INTEGRATE = lookup.findVirtual(
+				KeyHandlingWrangler.class,
+				"integrate",
+				MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class)
+			);
+			SEQ_WRANGLER_FINISH = lookup.findVirtual(
+				KeyHandlingWrangler.class,
 				"finish",
 				MethodType.methodType(Object.class, Object.class)
 			);

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/ObjectAccumulator.java
@@ -57,7 +57,7 @@ public record ObjectAccumulator(
 		} else {
 			assert integrator.parameterTypes().size() == 4;
 			DataType handlerResultType = integrator.parameterTypes().get(3);
-			assert keyHandler.returnType().isAssignableFrom(handlerResultType):
+			assert handlerResultType.isAssignableFrom(keyHandler.returnType()):
 				"keyHandler return type " + keyHandler.returnType()
 					+ " must be assignable to integrator handler result param " + handlerResultType;
 		}

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/handles/TypedHandles.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/handles/TypedHandles.java
@@ -183,6 +183,21 @@ public final class TypedHandles {
 		);
 	}
 
+	public static <T1,T2,T3> TypedHandle triConsumer(DataType argType1, DataType argType2, DataType argType3, TriConsumer<T1,T2,T3> triConsumer) {
+		return new TypedHandle(
+			TRI_CONSUMER_ACCEPT
+				.bindTo(triConsumer)
+				.asType(methodType(void.class, argType1.leastUpperBoundClass(), argType2.leastUpperBoundClass(), argType3.leastUpperBoundClass())),
+			VOID,
+			List.of(argType1, argType2, argType3)
+		);
+	}
+
+	@FunctionalInterface
+	public interface TriConsumer<T1,T2,T3> {
+		void accept(T1 t1, T2 t2, T3 t3);
+	}
+
 	private static final MethodHandle FUNCTION_APPLY;
 	private static final MethodHandle BI_FUNCTION_APPLY;
 	private static final MethodHandle PREDICATE_TEST;
@@ -190,6 +205,7 @@ public final class TypedHandles {
 	private static final MethodHandle CONSUMER_ACCEPT;
 	private static final MethodHandle BICONSUMER_ACCEPT;
 	private static final MethodHandle CALLABLE_CALL;
+	private static final MethodHandle TRI_CONSUMER_ACCEPT;
 
 	static {
 		try {
@@ -200,6 +216,7 @@ public final class TypedHandles {
 			CONSUMER_ACCEPT = MethodHandles.lookup().findVirtual(java.util.function.Consumer.class, "accept", methodType(void.class, Object.class));
 			BICONSUMER_ACCEPT = MethodHandles.lookup().findVirtual(java.util.function.BiConsumer.class, "accept", methodType(void.class, Object.class, Object.class));
 			CALLABLE_CALL = MethodHandles.lookup().findVirtual(Callable.class, "call", methodType(Object.class));
+			TRI_CONSUMER_ACCEPT = MethodHandles.lookup().findVirtual(TriConsumer.class, "accept", methodType(void.class, Object.class, Object.class, Object.class));
 		} catch (NoSuchMethodException | IllegalAccessException e) {
 			throw new ExceptionInInitializerError(e);
 		}

--- a/boson/src/main/java/works/bosk/boson/mapping/spec/package-info.java
+++ b/boson/src/main/java/works/bosk/boson/mapping/spec/package-info.java
@@ -55,9 +55,9 @@
  *         in terms of another that is already defined.
  *     </li>
  *     <li>
- *         {@link works.bosk.boson.mapping.spec.FixedObjectNode.Wrangler1}
+ *         {@link works.bosk.boson.mapping.spec.FixedObjectNode.OneMemberWrangler}
  *         can specify a JSON object with one member,
- *         and {@link works.bosk.boson.mapping.spec.FixedObjectNode.Wrangler2}
+ *         and {@link works.bosk.boson.mapping.spec.FixedObjectNode.TwoMemberWrangler}
  *         can specify one with two members.
  *     </li>
  *     <li>

--- a/boson/src/test/java/works/bosk/boson/codec/CodecHappyParseTest.java
+++ b/boson/src/test/java/works/bosk/boson/codec/CodecHappyParseTest.java
@@ -207,6 +207,50 @@ public class CodecHappyParseTest {
 			codec.parserFor(spec).parse(JsonReader.create(json)));
 	}
 
+	@Test
+	void arrayIntegratorReturnValueApplied() throws IOException {
+		var typeMap = scanner.scan(STRING).build();
+		var spec = new ArrayNode(
+			new StringNode(),
+			ArrayAccumulator.from(new ArrayAccumulator.Wrangler<Integer, String, String>() {
+				@Override public Integer create() { return 0; }
+				@Override public Integer integrate(Integer acc, String elem) { return acc + 1; }
+				@Override public String finish(Integer acc) { return "count=" + acc; }
+			}),
+			ArrayEmitter.from(new ArrayEmitter.Wrangler<String, Integer, String>() {
+				@Override public Integer start(String representation) { return 0; }
+				@Override public boolean hasNext(Integer iterator) { return false; }
+				@Override public String next(Integer iterator) { return ""; }
+			})
+		);
+		var codec = CodecBuilder.using(typeMap).build(spec);
+		var result = codec.parserFor(spec).parse(JsonReader.create("[\"a\", \"b\"]"));
+		assertEquals("count=2", result);
+	}
+
+	@Test
+	void mapIntegratorReturnValueApplied() throws IOException {
+		var typeMap = scanner.scan(STRING).build();
+		var acc = ObjectAccumulator.from(new ObjectAccumulator.Wrangler<Integer, Integer, String, String>() {
+			@Override public Integer create() { return 0; }
+			@Override public Integer integrate(Integer acc, String key, String value) { return acc + 1; }
+			@Override public Integer finish(Integer acc) { return acc; }
+		});
+		var emitter = ObjectEmitter.forLoop(new ObjectEmitter.ForLoopWrangler<Integer, String, String>() {
+			@Override public long start(Integer obj) { return 0; }
+			@Override public boolean hasNext(long iter, Integer obj) { return false; }
+			@Override public long next(long iter, Integer obj) { return 0; }
+			@Override public String getKey(long iter, Integer obj) { return ""; }
+			@Override public String getValue(long iter, Integer obj) { return null; }
+		});
+		var spec = new UniformMapNode(new StringNode(), new StringNode(), acc, emitter);
+		var codec = CodecBuilder.using(typeMap).build(spec);
+		var result = codec.parserFor(spec).parse(JsonReader.create("""
+			{"a": "x", "b": "y"}
+			"""));
+		assertEquals(2, result);
+	}
+
 	/**
 	 * As a demonstration of flexibility, we represent the map as a colon-separated string,
 	 * rather than the more obvious record or map.

--- a/boson/src/test/java/works/bosk/boson/codec/CodecHappyParseTest.java
+++ b/boson/src/test/java/works/bosk/boson/codec/CodecHappyParseTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import works.bosk.boson.codec.PrimitiveInjector.PrimitiveNumber;
 import works.bosk.boson.mapping.TypeMap.Settings;
 import works.bosk.boson.mapping.TypeScanner;
@@ -30,10 +31,12 @@ import works.bosk.boson.mapping.spec.RecognizedMember;
 import works.bosk.boson.mapping.spec.RepresentAsSpec;
 import works.bosk.boson.mapping.spec.StringNode;
 import works.bosk.boson.mapping.spec.UniformMapNode;
+import works.bosk.boson.mapping.spec.UniformMapNode.MemberValueWrangler;
 import works.bosk.boson.mapping.spec.handles.ArrayAccumulator;
 import works.bosk.boson.mapping.spec.handles.ArrayEmitter;
 import works.bosk.boson.mapping.spec.handles.MemberPresenceCondition;
 import works.bosk.boson.mapping.spec.handles.ObjectAccumulator;
+import works.bosk.boson.mapping.spec.handles.ObjectAccumulator.KeyHandlingWrangler;
 import works.bosk.boson.mapping.spec.handles.ObjectEmitter;
 import works.bosk.boson.mapping.spec.handles.TypedHandle;
 import works.bosk.boson.mapping.spec.handles.TypedHandles;
@@ -72,7 +75,7 @@ public class CodecHappyParseTest {
 		return new SettingsInjector().values();
 	}
 
-	@InjectedTest
+	@Test
 	void bareLiterals() throws IOException {
 		var typeMap = scanner
 			.scan(BOOLEAN)
@@ -86,7 +89,7 @@ public class CodecHappyParseTest {
 		assertNull(codec.parserFor(new MaybeNullSpec(new StringNode())).parse(JsonReader.create("null")));
 	}
 
-	@InjectedTest
+	@Test
 	void bareString() throws IOException {
 		var typeMap = scanner
 			.scan(STRING)
@@ -125,7 +128,7 @@ public class CodecHappyParseTest {
 		assertNull(codec.parserFor(new MaybeNullSpec(spec)).parse(JsonReader.create("null")));
 	}
 
-	@InjectedTest
+	@Test
 	void bigDecimal() throws IOException {
 		var typeMap = scanner
 			.scan(DataType.of(BigDecimal.class))
@@ -136,7 +139,7 @@ public class CodecHappyParseTest {
 			codec.parserFor(new BigNumberNode(BigDecimal.class)).parse(JsonReader.create(pi)));
 	}
 
-	@InjectedTest
+	@Test
 	void enumByName() throws IOException {
 		var typeMap = scanner
 			.scan(DataType.of(TimeUnit.class))
@@ -150,7 +153,7 @@ public class CodecHappyParseTest {
 	 * As a demonstration of flexibility, we represent the array as a pipe-separated string,
 	 * rather than the more obvious List<String>.
 	 */
-	@InjectedTest
+	@Test
 	void array() throws IOException {
 		var spec = new ArrayNode(
 			new StringNode(),
@@ -206,7 +209,7 @@ public class CodecHappyParseTest {
 	 * As a demonstration of flexibility, we represent the map as a colon-separated string,
 	 * rather than the more obvious record or map.
 	 */
-	@InjectedTest
+	@Test
 	void fixedObject() throws IOException {
 		var memberSpecs = new LinkedHashMap<String, RecognizedMember>();
 		memberSpecs.put("intField",
@@ -243,7 +246,7 @@ public class CodecHappyParseTest {
 			codec.parserFor(spec).parse(JsonReader.create(json)));
 	}
 
-	@InjectedTest
+	@Test
 	void optionalField() throws IOException {
 		record TestRecord(int intField, String strField) {}
 		var optional = new RecognizedMember(
@@ -277,7 +280,7 @@ public class CodecHappyParseTest {
 					""")));
 	}
 
-	@InjectedTest
+	@Test
 	void parseCallback() throws IOException {
 		// Set up the callback
 		record Event(String beforeResult, String parsedValue) {}
@@ -298,7 +301,87 @@ public class CodecHappyParseTest {
 		assertEquals(List.of(new Event("before result", "parsed value")), eventRecord);
 	}
 
-	@InjectedTest
+	@Test
+	void oneMemberWithNullKeyHandlerResult() throws IOException {
+		// Using MemberValueWrangler.nop() which returns null from beforeValue.
+		// The interpreter must pass this null to the integrator,
+		// not skip it (which would cause a WrongMethodTypeException).
+		record Result(String key, String value) {}
+
+		var wrangler = new UniformMapNode.OneMemberWrangler<Result, String, String>() {
+			@Override public String getKey(Result v) { return v.key(); }
+			@Override public String getValue(Result v) { return v.value(); }
+			@Override public Result finish(String key, String value) { return new Result(key, value); }
+		};
+		var spec = UniformMapNode.oneMember(wrangler, MemberValueWrangler.nop());
+		var typeMap = scanner.scan(STRING).build();
+		var codec = CodecBuilder.using(typeMap).build(spec);
+
+		var actual = codec.parserFor(spec).parse(JsonReader.create("""
+			{"hello": "world"}
+			"""));
+		assertEquals(new Result("hello", "world"), actual);
+	}
+
+	@Test
+	void memberCallback() throws IOException {
+		// Prepare to record calls
+		record Call(String key, BigDecimal value, String context) {}
+		var actualCalls = new ArrayList<Call>();
+
+		var acc = ObjectAccumulator.from(
+			new KeyHandlingWrangler<
+							LinkedHashMap<String, BigDecimal>,
+							LinkedHashMap<String, BigDecimal>,
+							String, BigDecimal, String>() {
+				@Override public LinkedHashMap<String, BigDecimal> create() { return new LinkedHashMap<>(); }
+				@Override public String keyHandler(LinkedHashMap<String, BigDecimal> acc, String key) {
+					return "context for " + key;
+				}
+				@Override public LinkedHashMap<String, BigDecimal> integrate(
+					LinkedHashMap<String, BigDecimal> acc, String key, BigDecimal value, String handlerResult) {
+					actualCalls.add(new Call(key, value, handlerResult));
+					acc.put(key, value);
+					return acc;
+				}
+				@Override public LinkedHashMap<String, BigDecimal> finish(LinkedHashMap<String, BigDecimal> acc) { return acc; }
+			}
+		);
+
+		BoundType mapType = (BoundType) DataType.known(new TypeReference<LinkedHashMap<String, BigDecimal>>() { });
+		var typeMap = scanner.scan(mapType).build();
+		var spec = new UniformMapNode(
+			new StringNode(),
+			new BigNumberNode(BigDecimal.class),
+			acc,
+			TypeScanner.mapEmitter(mapType)
+		);
+		var codec = CodecBuilder.using(typeMap).build(spec);
+
+		var json = """
+			{
+				"member1": 10,
+				"member2": 20,
+				"member3": 30
+			}
+			""";
+		Map<?,?> actualValue = (Map<?, ?>) codec.parserFor(spec).parse(JsonReader.create(json));
+		assertEquals(Map.of(
+			"member1", new BigDecimal("10"),
+			"member2", new BigDecimal("20"),
+			"member3", new BigDecimal("30")
+		), actualValue);
+		assertEquals(List.of("member1", "member2", "member3"), List.copyOf(actualValue.keySet()),
+			"Keys must be added in the correct order");
+
+		assertEquals(List.of(
+			new Call("member1", new BigDecimal("10"), "context for member1"),
+			new Call("member2", new BigDecimal("20"), "context for member2"),
+			new Call("member3", new BigDecimal("30"), "context for member3")
+		), actualCalls);
+	}
+
+	@Test
 	void representAs() throws IOException {
 		record TestRecord(String value) {}
 		var typeMap = scanner
@@ -315,8 +398,8 @@ public class CodecHappyParseTest {
 				.parse(JsonReader.create("\"test value\"")));
 	}
 
-	@InjectedTest
-	void uniformMapNode() throws IOException, NoSuchMethodException, IllegalAccessException {
+	@Test
+	void uniformMapNode() throws IOException {
 		BoundType mapType = (BoundType) DataType.known(new TypeReference<LinkedHashMap<String, BigDecimal>>() { });
 		var spec = new UniformMapNode(
 			new StringNode(),
@@ -353,7 +436,7 @@ public class CodecHappyParseTest {
 	 * This is a silly test, but it demonstrates the expressiveness of UniformMapNode
 	 * by directly summing the map values during parsing, entirely with primitives.
 	 */
-	@InjectedTest
+	@Test
 	void primitiveUniformMapNode() throws IOException, NoSuchMethodException, IllegalAccessException {
 		TypedHandle intIdentity = new TypedHandle(
 			MethodHandles.identity(int.class),
@@ -364,6 +447,7 @@ public class CodecHappyParseTest {
 			new PrimitiveNumberNode(int.class),
 			new ObjectAccumulator(
 				TypedHandles.constant(INT, 0),
+				TypedHandles.biConsumer(INT, STRING, (a, k) -> {}),
 				new TypedHandle(
 					MethodHandles.lookup().findStatic(
 						CodecHappyParseTest.class,
@@ -390,6 +474,69 @@ public class CodecHappyParseTest {
 			}
 			""";
 		assertEquals(60, codec.parserFor(spec).parse(JsonReader.create(json)));
+	}
+
+	@Test
+	void memberCallbackPrimitive() throws IOException, NoSuchMethodException, IllegalAccessException {
+		memberCallbackAfterCalls.clear();
+		memberCallbackBeforeCalls.clear();
+
+		var keyHandler = new TypedHandle(
+			MethodHandles.lookup().findStatic(CodecHappyParseTest.class, "memberCallbackBefore",
+				MethodType.methodType(void.class, int.class, String.class)),
+			DataType.VOID, List.of(INT, STRING));
+
+		var spec = new UniformMapNode(
+			new StringNode(),
+			new PrimitiveNumberNode(int.class),
+			new ObjectAccumulator(
+				TypedHandles.constant(INT, 0),
+				keyHandler,
+				new TypedHandle(
+					MethodHandles.lookup().findStatic(CodecHappyParseTest.class, "sumAndRecordIntegrator",
+						MethodType.methodType(int.class, int.class, String.class, int.class)),
+					INT, List.of(INT, STRING, INT)),
+				TypedHandles.identity(INT)
+			),
+			Unsummer.emitter()
+		);
+
+		var typeMap = scanner
+			.scan(INT)
+			.build();
+		var codec = CodecBuilder.using(typeMap).build(spec);
+		var json = """
+			{
+				"member1": 10,
+				"member2": 20,
+				"member3": 30
+			}
+			""";
+		assertEquals(60, codec.parserFor(spec).parse(JsonReader.create(json)));
+
+		assertEquals(List.of("member1", "member2", "member3"), memberCallbackBeforeCalls);
+		assertEquals(List.of(
+			Map.entry("member1", 10),
+			Map.entry("member2", 20),
+			Map.entry("member3", 30)
+		), memberCallbackAfterCalls);
+	}
+
+	static final List<String> memberCallbackBeforeCalls = new ArrayList<>();
+
+	static void memberCallbackBefore(int accumulator, String key) {
+		memberCallbackBeforeCalls.add(key);
+	}
+
+	static int sumAndRecordIntegrator(int accumulator, String key, int value) {
+		memberCallbackAfterCalls.add(Map.entry(key, value));
+		return accumulator + value;
+	}
+
+	static final List<Map.Entry<String, Integer>> memberCallbackAfterCalls = new ArrayList<>();
+
+	static void memberCallbackAfterInt(String key, int value) {
+		memberCallbackAfterCalls.add(Map.entry(key, value));
 	}
 
 	static int sumIntegrator(int accumulator, String key, int value) {

--- a/boson/src/test/java/works/bosk/boson/codec/CodecHappyParseTest.java
+++ b/boson/src/test/java/works/bosk/boson/codec/CodecHappyParseTest.java
@@ -49,8 +49,10 @@ import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
 import works.bosk.junit.InjectedTest;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static works.bosk.boson.types.DataType.BOOLEAN;
 import static works.bosk.boson.types.DataType.INT;
 import static works.bosk.boson.types.DataType.STRING;
@@ -541,6 +543,35 @@ public class CodecHappyParseTest {
 
 	static int sumIntegrator(int accumulator, String key, int value) {
 		return accumulator + value;
+	}
+
+	@Test
+	void objectAccumulator_typeChecks() {
+		// keyHandler return type must be assignable TO integrator handler result param
+		assertDoesNotThrow(() -> buildAccumulator(String.class, Object.class),
+			"narrow keyHandler return should be assignable to wide integrator param");
+		assertDoesNotThrow(() -> buildAccumulator(String.class, String.class),
+			"equal types should be assignable");
+		assertThrows(AssertionError.class, () -> buildAccumulator(Object.class, String.class),
+			"wide keyHandler return should not be assignable to narrow integrator param");
+	}
+
+	private static ObjectAccumulator buildAccumulator(Class<?> keyHandlerReturn, Class<?> integratorHandlerParam) {
+		DataType accType = DataType.known(Object.class);
+		DataType keyType = DataType.known(String.class);
+		DataType valueType = DataType.known(Integer.class);
+		DataType khReturn = DataType.known(keyHandlerReturn);
+		DataType integParam = DataType.known(integratorHandlerParam);
+
+		return new ObjectAccumulator(
+			TypedHandles.constant(accType, new Object()),
+			new TypedHandle(
+				MethodHandles.empty(MethodType.methodType(keyHandlerReturn, Object.class, String.class)),
+				khReturn, List.of(accType, keyType)),
+			new TypedHandle(
+				MethodHandles.empty(MethodType.methodType(Object.class, Object.class, String.class, Integer.class, integratorHandlerParam)),
+				accType, List.of(accType, keyType, valueType, integParam)),
+			TypedHandles.identity(accType));
 	}
 
 	/**

--- a/boson/src/test/java/works/bosk/boson/codec/RoundTripTest.java
+++ b/boson/src/test/java/works/bosk/boson/codec/RoundTripTest.java
@@ -186,6 +186,7 @@ public final class RoundTripTest {
 
 		ObjectAccumulator accumulator = new ObjectAccumulator(
 			constant(INT, 0),
+			TypedHandles.biConsumer(INT, STRING, (a, k) -> {}),
 			new TypedHandle(
 				MethodHandles.lookup().findStatic(RoundTripTest.class, "accumulateMax", MethodType.methodType(int.class, int.class, String.class, int.class)),
 				INT, List.of(INT, STRING, INT)

--- a/lib-testing/build.gradle
+++ b/lib-testing/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	// These are for AbstractRoundTripTest. That logic ought to be moved to their respective sub-projects
 	implementation project(":bosk-jackson")
 	implementation project(":bosk-mongo")
+	implementation project(":bosk-boson")
 
 	// The main build.gradle brings these in as test dependencies,
 	// but we need them as main dependencies.

--- a/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/AbstractRoundTripTest.java
@@ -1,6 +1,7 @@
 package works.bosk;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.util.IdentityHashMap;
@@ -29,6 +30,15 @@ import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.type.TypeFactory;
+import works.bosk.boson.codec.CodecBuilder;
+import works.bosk.boson.codec.Generator;
+import works.bosk.boson.codec.JsonReader;
+import works.bosk.boson.codec.Parser;
+import works.bosk.boson.mapping.TypeMap;
+import works.bosk.boson.mapping.TypeScanner;
+import works.bosk.boson.mapping.spec.JsonValueSpec;
+import works.bosk.boson.types.DataType;
+import works.bosk.bosonSerializer.BosonSerializer;
 import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.jackson.JacksonSerializer;
@@ -47,7 +57,9 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 
 				jacksonRoundTripFactory(JacksonSerializerConfiguration.defaultConfiguration()),
 
-				bsonRoundTripFactory()
+				bsonRoundTripFactory(),
+
+				bosonRoundTripFactory()
 		);
 	}
 
@@ -107,6 +119,51 @@ public abstract class AbstractRoundTripTest extends AbstractBoskTest {
 
 	public static <R extends Entity> DriverFactory<R> bsonRoundTripFactory() {
 		return new BsonRoundTripDriverFactory<>();
+	}
+
+	public static <R extends Entity> DriverFactory<R> bosonRoundTripFactory() {
+		return new BosonRoundTripDriverFactory<>();
+	}
+
+	private static class BosonRoundTripDriverFactory<R extends Entity> implements DriverFactory<R> {
+		@Override
+		public BoskDriver build(BoskInfo<R> boskInfo, BoskDriver driver) {
+			var bosonSerializer = new BosonSerializer();
+			var rootType = DataType.of(boskInfo.rootReference().targetType());
+			var bundle = bosonSerializer.bundleFor(boskInfo);
+			var typeMap = new TypeScanner(TypeMap.Settings.DEFAULT.withCompiled(false))
+				.addBundle(bundle)
+				.scan(rootType)
+				.build();
+			var codec = CodecBuilder.using(typeMap).build();
+
+			return new PreprocessingDriver(driver) {
+				@Override
+				protected <T> T preprocess(Reference<T> reference, T newValue) {
+					try {
+						JsonValueSpec targetSpec = typeMap.get(DataType.of(reference.targetType()));
+						Generator generator = codec.generatorFor(targetSpec);
+						Parser parser = codec.parserFor(targetSpec);
+
+						var writer = new StringWriter();
+						generator.generate(writer, newValue);
+						String json = writer.toString();
+
+						try (var _ = bosonSerializer.newDeserializationScope(reference)) {
+							Object parsed = parser.parse(JsonReader.create(json));
+							return reference.targetClass().cast(parsed);
+						}
+					} catch (IOException e) {
+						throw new AssertionError(e);
+					}
+				}
+			};
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + identityHashCode(this);
+		}
 	}
 
 	@RequiredArgsConstructor

--- a/lib-testing/src/main/java/works/bosk/SerializerRoundTripTest.java
+++ b/lib-testing/src/main/java/works/bosk/SerializerRoundTripTest.java
@@ -27,6 +27,8 @@ public class SerializerRoundTripTest extends AbstractRoundTripTest {
 			Reference<TestEntity> parentRef = bosk.rootReference().then(TestEntity.class, "entities", "parent");
 			assertEquals(parentRef.then(ImplicitRefs.class, "implicitRefs"), parentRef.value().implicitRefs().reference());
 			assertEquals(parentRef, parentRef.value().implicitRefs().enclosingRef());
+			assertEquals(parentRef.then(ImplicitRefs.class, "implicitRefs"), parentRef.value().implicitRefs().reference2());
+			assertEquals(parentRef, parentRef.value().implicitRefs().enclosingRef2());
 		}
 	}
 


### PR DESCRIPTION
Turns out I forgot this and the tests don't cover it: if you dumbly serialize self references and then deserialize them normally, round-trip tests pass.

A few other random tweaks too, like #13 and a fix for `@ReplayOnFailure`.