### PR TITLE
Refine build-and-test triggers

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,12 +5,10 @@
 name: "Build and test"
 
 on:
+  pull_request:
   push:
     branches:
-      - '**'
-    tags-ignore: # already run when a commit is pushed; no need to also run when it's tagged
-      - '**'
-  pull_request:
+      - main
 
 jobs:
   build_and_test:


### PR DESCRIPTION
I want main always to be tested, and I want every PR to be tested. Turns out there's a simpler way to say that without getting duplication on every dependabot PR.