### PR TITLE
Multitenancy for bosk-mongo Pando format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
 
 ### Testing
 
+- When developing a bug fix, write the test first and verify it fails against the unfixed code. Then apply the fix and confirm the test passes. This ensures the test would actually catch the bug.
 - Prefer building the entire expected data structure and using `assertEquals` over checking individual fields one-by-one. Tests with per-field assertions get stale when the object acquires new fields.
 - Assertion message strings should state what was expected (e.g. `"Set must have the new item"`), not describe the error (e.g. `"Set does not contain the new item"`).
 - Use `./gradlew <task> --rerun` (not `--rerun-tasks`) to force Gradle to re-execute a task when cached results exist.

--- a/bosk-logback/src/main/java/works/bosk/logback/BoskLogFilter.java
+++ b/bosk-logback/src/main/java/works/bosk/logback/BoskLogFilter.java
@@ -61,6 +61,9 @@ public class BoskLogFilter extends TurboFilter {
 
 		// We'd like to use SLF4J's "Level" but that doesn't support OFF
 		public void setLogging(Level level, Class<?>... loggers) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Setting logging level {} for loggers {} on {}", level, Stream.of(loggers).map(Class::getName).toList(), System.identityHashCode(this));
+			}
 			// Put them all in one atomic operation
 			overrides.putAll(Stream.of(loggers).collect(toMap(Class::getName, _->level)));
 		}
@@ -83,7 +86,7 @@ public class BoskLogFilter extends TurboFilter {
 	public static <R extends StateTreeNode> DriverFactory<R> withController(LogController controller) {
 		return (b, d) -> {
 			if (LOGGER.isDebugEnabled()) {
-				LOGGER.debug("Registering controller {} for bosk {} \"{}\"", System.identityHashCode(controller), b.instanceID(), b.name(), new Exception("Stack trace"));
+				LOGGER.debug("Registering controller {} for bosk {} \"{}\"", System.identityHashCode(controller), b.instanceID(), b.name());
 			}
 			// We don't actually create a driver object here; we only
 			// need to set the logging override at driver-creation time.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -3,17 +3,13 @@ package works.bosk.drivers.mongo;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Value;
-import org.bson.BsonString;
 import works.bosk.Bosk;
 import works.bosk.BoskDriver;
 
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 import static works.bosk.drivers.mongo.MongoDriverSettings.InitialDatabaseUnavailableMode.DISCONNECT;
-import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestDocumentIdMode.STANDARD;
 import static works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode.EARNEST;
 import static works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode.HASTY;
-import static works.bosk.drivers.mongo.internal.MainDriver.LEGACY_MANIFEST_ID;
-import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 
 @Value
 @Builder(toBuilder = true)
@@ -52,8 +48,6 @@ public class MongoDriverSettings {
 	 * this works across a wide range of values.
 	 */
 	@Default int timescaleMS = 10_000;
-
-	@Default ManifestDocumentIdMode manifestDocumentIdMode = STANDARD;
 
 	/**
 	 * @see DatabaseFormat#SEQUOIA
@@ -149,23 +143,6 @@ public class MongoDriverSettings {
 		 * Unused documents may be left behind, to be cleaned up later.
 		 */
 		HASTY,
-	}
-
-	public enum ManifestDocumentIdMode {
-		/**
-		 * Use {@code manifest}
-		 */
-		LEGACY,
-
-		/**
-		 * Use {@code !Manifest}
-		 */
-		STANDARD,
-		;
-
-		public BsonString manifestDocumentId() {
-			return this == LEGACY ? LEGACY_MANIFEST_ID : MANIFEST_ID;
-		}
 	}
 
 	public void validate() {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -146,6 +146,19 @@ public class MongoDriverSettings {
 		HASTY,
 	}
 
+	public enum TenancyFormat {
+		/**
+		 * There is no concept of tenants in the collection, and there is only one
+		 * copy of the bosk state tree.
+		 */
+		NONE,
+
+		/**
+		 * The tenant ID is prefixed onto the {@code _id} field, enclosed in angle brackets.
+		 */
+		ID_PREFIX,
+	}
+
 	public void validate() {
 		if (preferredDatabaseFormat() instanceof PandoFormat) {
 			if (experimental.orphanDocumentMode() == EARNEST) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/MongoDriverSettings.java
@@ -98,6 +98,7 @@ public class MongoDriverSettings {
 		 * Simple format that stores the entire bosk state in a single document,
 		 * and (except for {@link MongoDriver#refurbish() refirbish})
 		 * doesn't require any multi-document transactions.
+		 * Does not support multitenancy.
 		 *
 		 * <p>
 		 * This limits the entire bosk state to 16MB when converted to BSON.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
@@ -5,6 +5,7 @@ import works.bosk.Catalog;
 import works.bosk.ListValue;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
+import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 
 import static java.util.Arrays.asList;
 
@@ -27,9 +28,8 @@ import static java.util.Arrays.asList;
  *                   are to be stored in their own documents.
  */
 public record PandoFormat(
-	// TODO: Since this is used for updates and not reads, it should probably be called prunePoints or something
 	ListValue<String> graftPoints
-) implements StateTreeNode, MongoDriverSettings.DatabaseFormat {
+) implements StateTreeNode, DatabaseFormat {
 	@Override public String name() { return "Pando"; }
 
 	/**

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
@@ -6,8 +6,10 @@ import works.bosk.ListValue;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
+import works.bosk.drivers.mongo.MongoDriverSettings.TenancyFormat;
 
 import static java.util.Arrays.asList;
+import static works.bosk.drivers.mongo.MongoDriverSettings.TenancyFormat.NONE;
 
 /**
  * A scalable format that stores the bosk state in multiple documents,
@@ -28,7 +30,8 @@ import static java.util.Arrays.asList;
  *                   are to be stored in their own documents.
  */
 public record PandoFormat(
-	ListValue<String> graftPoints
+	ListValue<String> graftPoints,
+	TenancyFormat tenancyFormat
 ) implements StateTreeNode, DatabaseFormat {
 	@Override public String name() { return "Pando"; }
 
@@ -37,14 +40,18 @@ public record PandoFormat(
 	 * and (2) Sequoia is designed not to need multi-document transactions.
 	 */
 	public static PandoFormat oneBigDocument() {
-		return new PandoFormat(ListValue.empty());
+		return new PandoFormat(ListValue.empty(), NONE);
 	}
 
 	public static PandoFormat withGraftPoints(Collection<String> pathStrings) {
-		return new PandoFormat(ListValue.from(pathStrings));
+		return new PandoFormat(ListValue.from(pathStrings), NONE);
 	}
 
 	public static PandoFormat withGraftPoints(String... pathStrings) {
 		return withGraftPoints(asList(pathStrings));
+	}
+
+	public PandoFormat withTenancyFormat(TenancyFormat tenancyFormat) {
+		return new PandoFormat(graftPoints, tenancyFormat);
 	}
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -39,7 +39,6 @@ import works.bosk.drivers.mongo.status.MongoStatus;
 import works.bosk.drivers.mongo.status.StateStatus;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
-import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.util.PerTenant;
 import works.bosk.util.PerTenant.MultiTenant;
 import works.bosk.util.PerTenant.NoTenant;
@@ -55,6 +54,7 @@ import static java.util.Objects.requireNonNull;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_BEFORE_ANY;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
+import static works.bosk.drivers.mongo.internal.Formatter.getTenantFromDocumentId;
 import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 
 abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implements FormatDriver<R> {
@@ -300,7 +300,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		return switch (tenancyModel) {
 			case None _ -> Tenant.NONE;
 			case Fixed(var fixedId) -> Tenant.setTo(fixedId);
-			case Persistent _ -> throw new NotYetImplementedException("multitenancy");
+			case Persistent _ -> getTenantFromDocumentId(id);
 		};
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -5,10 +5,8 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.bson.BsonDocument;
@@ -49,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_BEFORE_ANY;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
-import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_IDS;
+import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 
 abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implements FormatDriver<R> {
 	final RootReference<R> rootRef;
@@ -59,7 +57,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	final TransactionalCollection collection;
 	final BoskDriver downstream;
 	final FlushLock flushLock;
-	@Nullable final BsonString manifestId;
 
 	public AbstractFormatDriver(
 		RootReference<R> rootRef,
@@ -68,8 +65,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		Formatter formatter,
 		TransactionalCollection collection,
 		BoskDriver downstream,
-		long flushTimeoutMS,
-		@Nullable BsonString manifestId
+		long flushTimeoutMS
 	) {
 		this.rootRef = rootRef;
 		this.context = context;
@@ -77,7 +73,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		this.formatter = formatter;
 		this.collection = collection;
 		this.downstream = downstream;
-		this.manifestId = manifestId;
 
 		// The proper revision number will be established by loadAllState or initializeCollection.
 		// The value we use here doesn't matter a lot, provided that either loadAllState or
@@ -104,7 +99,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 					comp.difference(inMemoryState, loadedBsonState)
 				))
 			);
-		} catch (UninitializedCollectionException e) {
+		} catch (InvalidCollectionContentsException e) {
 			return new MongoStatus(
 				e.toString(),
 				null,
@@ -114,7 +109,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException {
+	public StateAndMetadata<R> loadAllState() throws IOException, InvalidCollectionContentsException {
 		BsonStateAndMetadata bsonStateAndMetadata = loadBsonStateAndMetadata();
 		if (bsonStateAndMetadata.state() == null) {
 			throw new IOException("No existing state in document");
@@ -149,7 +144,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * @return the contents of the database; fields of the returned
 	 * record can be null if they don't exist in the database.
 	 */
-	abstract BsonStateAndMetadata loadBsonStateAndMetadata() throws UninitializedCollectionException;
+	abstract BsonStateAndMetadata loadBsonStateAndMetadata() throws InvalidCollectionContentsException;
 
 	protected BsonDocument blankUpdateDoc() {
 		return new BsonDocument()
@@ -204,16 +199,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 */
 	protected void validateManifestEvent(ChangeStreamDocument<BsonDocument> event, Manifest effectiveManifest) throws UnprocessableEventException {
 		LOGGER.debug("onManifestEvent({})", event.getOperationType().name());
-		if (!Objects.equals(manifestId, event.getDocumentKey().get("_id"))) {
-			// This is important to avoid additional disconnect churn when a refurbish
-			// deletes the old manifest and creates a new one with a different ID.
-			// We'll already be handling this when the manifest we care about changes;
-			// no need to react to the other one.
-			// Note that it actually doesn't matter which one we watch, as long
-			// as we watch just one.
-			LOGGER.debug("Ignoring event for different manifest document with ID {}", event.getDocumentKey().get("_id"));
-			return;
-		} else if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
+		if (event.getOperationType() == INSERT || event.getOperationType() == REPLACE) {
 			BsonDocument manifestDoc = requireNonNull(event.getFullDocument());
 			Manifest manifest;
 			try {
@@ -313,9 +299,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	protected void writeManifest(Manifest manifest) {
-		BsonDocument doc = new BsonDocument("_id", requireNonNull(manifestId));
+		BsonDocument doc = new BsonDocument("_id", requireNonNull(MANIFEST_ID));
 		doc.putAll((BsonDocument) formatter.object2bsonValue(manifest, Manifest.class));
-		BsonDocument filter = new BsonDocument("_id", manifestId);
+		BsonDocument filter = new BsonDocument("_id", MANIFEST_ID);
 		LOGGER.debug("| Initial manifest: {}", doc);
 		ReplaceOptions options = new ReplaceOptions().upsert(true);
 		UpdateResult result = collection.replaceOne(filter, doc, options);
@@ -335,7 +321,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	protected boolean isManifestID(BsonValue documentId) {
-		return MANIFEST_IDS.contains(documentId);
+		return MANIFEST_ID.equals(documentId);
 	}
 
 	/**

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -6,19 +6,27 @@ import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
-import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskConfig.TenancyModel.Fixed;
+import works.bosk.BoskConfig.TenancyModel.None;
+import works.bosk.BoskConfig.TenancyModel.Persistent;
 import works.bosk.BoskContext;
 import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.Established;
 import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.BoskDriver;
 import works.bosk.MapValue;
@@ -56,7 +64,16 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	final Formatter formatter;
 	final TransactionalCollection collection;
 	final BoskDriver downstream;
-	final FlushLock flushLock;
+	final long flushTimeoutMS;
+	final Supplier<EntireState<R>> entireStateSupplier;
+
+	/**
+	 * Null only during initialization, until {@link #ensureFlushLocksInitialized},
+	 * and only used after that point.
+	 * (Therefore, there's no need for null tests before using this:
+	 * an NPE is an acceptable outcome if someone ever violates these rules.)
+	 */
+	final AtomicReference<PerTenant<FlushLock>> flushLocks = new AtomicReference<>(null);
 
 	public AbstractFormatDriver(
 		RootReference<R> rootRef,
@@ -65,7 +82,8 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		Formatter formatter,
 		TransactionalCollection collection,
 		BoskDriver downstream,
-		long flushTimeoutMS
+		long flushTimeoutMS,
+		Supplier<EntireState<R>> entireStateSupplier
 	) {
 		this.rootRef = rootRef;
 		this.context = context;
@@ -73,31 +91,34 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		this.formatter = formatter;
 		this.collection = collection;
 		this.downstream = downstream;
-
-		// The proper revision number will be established by loadAllState or initializeCollection.
-		// The value we use here doesn't matter a lot, provided that either loadAllState or
-		// initializeCollection is called before the first flush (a condition that is trivially
-		// satisfied if this driver is discarded before the first flush).
-		// In the meantime, let's use a value guaranteed to be less than any real revision number
-		// on the basis that blocking is safer than accidentally proceeding without waiting on a flush.
-		this.flushLock = new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS);
+		this.flushTimeoutMS = flushTimeoutMS;
+		this.entireStateSupplier = entireStateSupplier;
 	}
 
 	@Override
 	public MongoStatus readStatus() {
 		try {
-			BsonStateAndMetadata dbContents = loadBsonStateAndMetadata();
-			BsonDocument loadedBsonState = dbContents.state;
-			BsonValue inMemoryState = formatter.object2bsonValue(rootRef.value(), rootRef.targetType());
+			PerTenant<BsonStateAndMetadata> dbStates = loadBsonStateAndMetadata();
+			var entireState = entireStateSupplier.get();
+			var inMemoryBsonValues = PerTenant.from(entireState,
+				r -> formatter.object2bsonValue(r, rootRef.targetType()));
 			BsonComparator comp = new BsonComparator();
+			var stateStatuses = dbStates.map((Established tenant, BsonStateAndMetadata dbState) -> {
+				BsonValue inMemory = switch (inMemoryBsonValues) {
+					case NoTenant<BsonValue>(var v) -> v;
+					case MultiTenant<BsonValue> m -> m.get(tenant);
+				};
+				BsonDocument loadedBsonState = dbState.state();
+				return new StateStatus(
+					dbState.revision().longValue(),
+					formatter.bsonValueBinarySize(loadedBsonState),
+					comp.difference(inMemory, loadedBsonState)
+				);
+			});
 			return new MongoStatus(
 				null,
 				null, // MainDriver should fill this in
-				NoTenant.just(new StateStatus(
-					dbContents.revision.longValue(),
-					formatter.bsonValueBinarySize(loadedBsonState),
-					comp.difference(inMemoryState, loadedBsonState)
-				))
+				stateStatuses
 			);
 		} catch (InvalidCollectionContentsException e) {
 			return new MongoStatus(
@@ -109,33 +130,81 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public StateAndMetadata<R> loadAllState() throws IOException, InvalidCollectionContentsException {
-		BsonStateAndMetadata bsonStateAndMetadata = loadBsonStateAndMetadata();
-		if (bsonStateAndMetadata.state() == null) {
-			throw new IOException("No existing state in document");
+	public PerTenant<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException {
+		try {
+			PerTenant<BsonStateAndMetadata> bsonStateAndMetadata = loadBsonStateAndMetadata();
+			ensureFlushLocksInitialized(bsonStateAndMetadata);
+			return bsonStateAndMetadata.map((Established _, BsonStateAndMetadata bsm) -> {
+				if (bsm.state() == null) {
+					throw new TunneledCheckedException(new IOException("No existing state in document"));
+				}
+
+				R root = formatter.document2object(bsm.state(), rootRef);
+				BsonInt64 revision = bsm.revision() == null ? REVISION_ZERO : bsm.revision();
+				MapValue<String> diagnosticAttributes = bsm.diagnosticAttributes() == null
+					? MapValue.empty() // It's not clear what missing attributes mean, but using null here would have the effect of leaving the old attributes in place, which seems flaky
+					: formatter.decodeDiagnosticAttributes(bsm.diagnosticAttributes());
+
+				return new StateAndMetadata<>(root, revision, diagnosticAttributes);
+			});
+		} catch (TunneledCheckedException e) {
+			try {
+				throw e.getCause();
+			} catch (IOException | RuntimeException | Error cause) {
+				throw cause;
+			} catch (Throwable t) {
+				throw e;
+			}
 		}
-
-		R root = formatter.document2object(bsonStateAndMetadata.state(), rootRef);
-		MapValue<String> diagnosticAttributes = bsonStateAndMetadata.diagnosticAttributes() == null
-			? MapValue.empty() // It's not clear what missing attributes mean, but using null here would have the effect of leaving the old attributes in place, which seems flaky
-			: formatter.decodeDiagnosticAttributes(bsonStateAndMetadata.diagnosticAttributes());
-
-		return new StateAndMetadata<>(
-			root,
-			bsonStateAndMetadata.revision() == null
-				? REVISION_ZERO
-				: bsonStateAndMetadata.revision(),
-			diagnosticAttributes
-		);
 	}
 
 	@Override
 	public void hasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
-		switch (contents) {
-			case NoTenant(var s) -> flushLock.finishedRevision(s.revision());
-			case MultiTenant<StateAndMetadata<R>> _ -> throw new NotYetImplementedException();
-		}
+		contents.forEach((tenant, stateAndMetadata) -> {
+			finishedRevision(tenant, stateAndMetadata.revision());
+		});
 	}
+
+	/**
+	 * Converts a {@link PerTenant} to the variant appropriate for the {@link #tenancyModel}.
+	 * For {@code None} tenancy, {@code NoTenant} is returned as-is.
+	 * For {@code Fixed} tenancy, {@code NoTenant} is converted to
+	 * {@link MultiTenant} with the fixed tenant ID.
+	 */
+	protected <T> PerTenant<T> normalizePerTenant(PerTenant<T> contents) {
+		return switch (contents) {
+			case NoTenant<T>(var value) -> switch (tenancyModel) {
+				case None _ -> contents;
+				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), value);
+				case Persistent _ -> throw new AssertionError(
+					"Should not have NoTenant contents with Persistent tenancy");
+			};
+			case MultiTenant<T> _ -> contents;
+		};
+	}
+
+	/**
+	 * Must be called before {@link #hasBeenApplied} or any event processing.
+	 */
+	protected void ensureFlushLocksInitialized(PerTenant<?> contents) {
+		flushLocks.compareAndSet(null, switch (contents) {
+			case NoTenant<?> _ -> switch (tenancyModel) {
+				case None _ -> NoTenant.just(new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS));
+				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id),
+					new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS));
+				case Persistent _ -> throw new AssertionError(
+					"Should not have NoTenant contents with Persistent tenancy");
+			};
+			case MultiTenant<?> m -> {
+				SortedMap<TenantId, FlushLock> locks = new TreeMap<>();
+				for (var tenantId : m.values().keySet()) {
+					locks.put(tenantId, new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS));
+				}
+				yield new MultiTenant<>(locks);
+			}
+		});
+	}
+
 
 	/**
 	 * Low-level read of the database contents, with only the minimum interpretation
@@ -144,7 +213,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * @return the contents of the database; fields of the returned
 	 * record can be null if they don't exist in the database.
 	 */
-	abstract BsonStateAndMetadata loadBsonStateAndMetadata() throws InvalidCollectionContentsException;
+	abstract PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() throws InvalidCollectionContentsException;
 
 	protected BsonDocument blankUpdateDoc() {
 		return new BsonDocument()
@@ -188,8 +257,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		return blankUpdateDoc().append("$unset", new BsonDocument(key, BsonNull.VALUE));
 	}
 
-	protected boolean shouldSkip(BsonInt64 revision) {
-		return revision != null && flushLock.alreadySeen(revision);
+	protected boolean shouldSkip(Established tenant, BsonInt64 revision) {
+		FlushLock lock = flushLocks.get().get(tenant);
+		return lock == null || lock.alreadySeen(revision);
 	}
 
 	/**
@@ -218,64 +288,54 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		LOGGER.debug("Ignoring benign manifest change event");
 	}
 
+	protected void finishedRevision(Established tenant, BsonInt64 revision) {
+		flushLocks.get().get(tenant).finishedRevision(revision);
+	}
+
 	/**
 	 * @return the {@link Tenant} that should be established before processing
-	 * a document with the given {@code id}.
+	 * a document with the given {@code id}
 	 */
-	protected Tenant.Established tenantFor(BsonString id) {
+	protected @NotNull BoskContext.Tenant.Established tenantFor(BsonString id) {
 		return switch (tenancyModel) {
-			case TenancyModel.None _ -> Tenant.NONE;
-			case TenancyModel.Fixed(var fixedId) -> new TenantId(fixedId);
-			case TenancyModel.Explicit _ -> throw new NotYetImplementedException();
+			case None _ -> Tenant.NONE;
+			case Fixed(var fixedId) -> Tenant.setTo(fixedId);
+			case Persistent _ -> throw new NotYetImplementedException("multitenancy");
 		};
 	}
 
-	@Override
-	public abstract BsonDocument rootDocumentsFilter();
+	/**
+	 * @return cursor giving the {@code _id} and {@code revision}
+	 * for all documents that have a revision field,
+	 * read using read concern {@link com.mongodb.ReadConcern#LOCAL LOCAL}.
+	 */
+	protected MongoCursor<BsonDocument> revisionDocumentCursor() {
+		return collection
+			.withReadConcern(LOCAL)
+			.find(rootDocumentsFilter())
+			.projection(fields(include("_id", DocumentFields.revision.name())))
+			.cursor();
+	}
 
 	/**
-	 * @return all potentially relevant revision numbers found in the database,
-	 * one per tenant (or just the one in non-multitenant situations).
-	 * If the database contains no revision number, returns {@link Formatter#REVISION_ZERO}.
-	 * @throws RevisionFieldDisruptedException if unexpected database contents make it impossible
+	 * @return all potentially relevant revision numbers found in the database
+	 * @throws RevisionFieldDisruptedException if unexpected database contents make it impossible to determine the revision number
 	 */
-	protected @Nonnull PerTenant<BsonInt64> readRevisionNumbers() throws FlushFailureException {
-		LOGGER.debug("readRevisionNumbers");
-		try {
-			try (MongoCursor<BsonDocument> cursor = collection
-				.withReadConcern(LOCAL)
-				.find(rootDocumentsFilter())
-				.projection(fields(include(DocumentFields.revision.name())))
-				.cursor()
-			) {
-				BsonDocument doc = cursor.next();
-				BsonInt64 result = doc.getInt64(DocumentFields.revision.name(), null);
-				if (result == null) {
-					// TODO: Is this still relevant? Seems like legacy
-					LOGGER.debug("No revision field; assuming {}", REVISION_ZERO.longValue());
-					return NoTenant.just(REVISION_ZERO);
-				} else {
-					LOGGER.debug("Read revision {}", result.longValue());
-					return NoTenant.just(result);
-				}
-			}
-		} catch (NoSuchElementException e) {
-			LOGGER.debug("Document is missing", e);
-			throw new RevisionFieldDisruptedException("State document is missing", e);
-		} catch (RuntimeException e) {
-			LOGGER.debug("readRevisionNumbers failed", e);
-			throw new FlushFailureException(e);
-		}
-	}
+	abstract @Nonnull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException;
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		PerTenant<BsonInt64> revisions = readRevisionNumbers();
+		var revisions = readRevisionNumbers();
 		try {
-			revisions.forEach((_, revision) -> {
+			flushLocks.get().forEach((tenant, lock) -> {
+				BsonInt64 revision = revisions.get(tenant);
 				try {
-					flushLock.awaitRevision(revision);
-				} catch (InterruptedException | IOException e) {
+					if (revision == null) {
+						throw new RevisionFieldDisruptedException("No revision number for tenant: " + tenant);
+					} else {
+						lock.awaitRevision(revision);
+					}
+				} catch (InterruptedException | FlushFailureException e) {
 					throw new TunneledCheckedException(e);
 				}
 			});
@@ -285,7 +345,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 			} catch (IOException | InterruptedException cause) {
 				throw cause;
 			} catch (Throwable ex) {
-				throw new AssertionError("Unexpected exception type", ex);
+				throw e;
 			}
 		}
 		LOGGER.debug("| Flush downstream");
@@ -295,7 +355,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	@Override
 	public void close() {
 		LOGGER.debug("+ close()");
-		flushLock.close();
+		flushLocks.get().forEach((_, flushLock) -> flushLock.close());
 	}
 
 	protected void writeManifest(Manifest manifest) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonSurgeon.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonSurgeon.java
@@ -67,9 +67,9 @@ class BsonSurgeon {
 		}
 	}
 
-	private static final String BSON_PATH_FIELD = DocumentFields._id.name();
+	static final String BSON_PATH_FIELD = DocumentFields._id.name();
 
-	private static final String STATE_FIELD = DocumentFields.state.name();
+	static final String STATE_FIELD = DocumentFields.state.name();
 
 	public BsonSurgeon(List<Reference<? extends EnumerableByIdentifier<?>>> graftPoints) {
 		this.graftPoints = new ArrayList<>(graftPoints.size());

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeListener.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeListener.java
@@ -21,7 +21,7 @@ interface ChangeListener {
 		InterruptedException,
 		IOException,
 		InitialStateActionException,
-		TimeoutException, FailedMongoClientSessionException;
+		TimeoutException, FailedMongoClientSessionException, InvalidCollectionContentsException;
 
 	/**
 	 * @param event is a document-specific event, with a non-null {@link ChangeStreamDocument#getDocumentKey() document key}.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
@@ -187,6 +187,9 @@ class ChangeReceiver implements Closeable {
 						} catch (UninitializedCollectionException e) {
 							disconnect("MongoDB collection is not initialized", REMEDY_RETURN, e);
 							return;
+						} catch (InvalidCollectionContentsException e) {
+							disconnect("MongoDB collection contents are invalid", REMEDY_RETURN, e);
+							return;
 						} catch (InitialStateActionException e) {
 							disconnect("Unable to initialize bosk state", REMEDY_RETURN, e);
 							return;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
@@ -63,12 +63,12 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public StateAndMetadata<R> loadAllState() {
+	public PerTenant<StateAndMetadata<R>> loadAllState() {
 		throw disconnected();
 	}
 
 	@Override
-	public void initializeCollection(StateAndMetadata<R> priorContents) {
+	public void initializeCollection(PerTenant<StateAndMetadata<R>> priorContents) {
 		throw disconnected();
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -47,7 +47,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 *
 	 * @throws InvalidCollectionContentsException if the collection contents don't match the declared format
 	 */
-	StateAndMetadata<R> loadAllState() throws IOException, InvalidCollectionContentsException;
+	PerTenant<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException;
 
 	/**
 	 * Initializes the collection to the given state.
@@ -63,7 +63,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 * "prior" state of the database; in particular, the revision number should be incremented
 	 * so that a {@link #flush} after a {@link #refurbish} succeeds in waiting for the new state.
 	 */
-	void initializeCollection(StateAndMetadata<R> priorContents);
+	void initializeCollection(PerTenant<StateAndMetadata<R>> priorContents);
 
 	/**
 	 * @return a query filter that returns documents corresponding to the roots of the state tree,

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -40,13 +40,14 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 
 	/**
 	 * Loads the entire collection contents.
+	 * <p>
+	 * This method can assume the manifest exists and indicates the appropriate format;
+	 * manifest creation/validation is handled elsewhere, and if this assumption is violated for whatever
+	 * reason, {@code InvalidCollectionContentsException} is an acceptable exception to throw.
 	 *
-	 * @throws UninitializedCollectionException if it looks like the database has not yet
-	 * been created (as opposed to being in a damaged or unrecognizable state).
-	 * This signals to {@link MainDriver} that it may, if appropriate,
-	 * automatically initialize the collection.
+	 * @throws InvalidCollectionContentsException if the collection contents don't match the declared format
 	 */
-	StateAndMetadata<R> loadAllState() throws IOException, UninitializedCollectionException;
+	StateAndMetadata<R> loadAllState() throws IOException, InvalidCollectionContentsException;
 
 	/**
 	 * Initializes the collection to the given state.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
@@ -249,6 +249,22 @@ final class Formatter extends BsonFormatter {
 		return updateDescription.getUpdatedFields();
 	}
 
+	/**
+	 * @return the tenant info extracted from the given {@code id}.
+	 * This does not necessarily correspond to the tenant that should be established
+	 * in the bosk context! If the {@code id} has no tenant info, this will return {@link Tenant#NONE}.
+	 */
+	@Nonnull static Tenant.Established getTenantFromDocumentId(BsonString id) {
+		int pathStartIndex = id.getValue().indexOf('|');
+		if (pathStartIndex < 0) {
+			throw new IllegalArgumentException("Document _id has no path separator: " + id.getValue());
+		}
+		String tenantPart = id.getValue().substring(0, pathStartIndex);
+		return tenantPart.isEmpty()
+			? Tenant.NONE
+			: new TenantId(Identifier.from(tenantPart.substring(1, tenantPart.length() - 1)));
+	}
+
 	static BsonDocument getDiagnosticAttributesIfAny(BsonDocument fullDocument) {
 		if (fullDocument == null) {
 			return null;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/InvalidCollectionContentsException.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/InvalidCollectionContentsException.java
@@ -1,0 +1,20 @@
+package works.bosk.drivers.mongo.internal;
+
+import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
+
+/**
+ * The collection contents don't obey the rules of the format declared by the manifest document.
+ */
+public class InvalidCollectionContentsException extends Exception {
+	InvalidCollectionContentsException(DatabaseFormat format, String details) {
+		super(message(format, details));
+	}
+
+	InvalidCollectionContentsException(DatabaseFormat format, String details, Throwable cause) {
+		super(message(format, details), cause);
+	}
+
+	private static String message(DatabaseFormat format, String details) {
+		return "Collection contents don't match " + format.name() + " format: " + details;
+	}
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -17,8 +17,6 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeoutException;
@@ -28,7 +26,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
-import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonValue;
@@ -47,6 +44,7 @@ import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 import works.bosk.drivers.mongo.MongoDriverSettings.InitialDatabaseUnavailableMode;
+import works.bosk.drivers.mongo.MongoDriverSettings.SequoiaFormat;
 import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.drivers.mongo.exceptions.DisconnectedException;
 import works.bosk.drivers.mongo.exceptions.InitialStateFailureException;
@@ -58,6 +56,7 @@ import works.bosk.logging.MappedDiagnosticContext.MDCScope;
 import works.bosk.util.PerTenant.NoTenant;
 
 import static com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL;
+import static com.mongodb.client.model.Sorts.ascending;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
@@ -354,7 +353,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				LOGGER.warn("Failed to initialize database; disconnecting", e2);
 				setDisconnectedDriver(e2);
 			}
-		} catch (RuntimeException | UnrecognizedFormatException | IOException | FailedMongoClientSessionException e) {
+		} catch (RuntimeException | UnrecognizedFormatException | InvalidCollectionContentsException | IOException | FailedMongoClientSessionException e) {
 			switch (driverSettings.initialDatabaseUnavailableMode()) {
 				case FAIL_FAST:
 					LOGGER.debug("Unable to load initial state from database; aborting initialization", e);
@@ -403,9 +402,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// FormatDriver must cope with deletions of the manifest document
 			// to avoid disconnection during refurbish operations,
 			// which is a burden. Let's just not.
-			// Note that this does delete the other manifest if it exists,
-			// which is deliberate.
-			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", driverSettings.manifestDocumentIdMode().manifestDocumentId()));
+			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
 			LOGGER.trace("Deleting state documents: {}", deletionFilter);
 			queryCollection.deleteMany(deletionFilter);
 
@@ -419,8 +416,8 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 			// Refurbish doesn't actually change what state has been applied to the bosk.
 			// No need to do any downstream submit/flush, nor call hasBeenApplied.
-		} catch (UninitializedCollectionException e) {
-			throw new IOException("Unable to refurbish uninitialized database collection", e);
+		} catch (InvalidCollectionContentsException e) {
+			throw new IOException("Unable to refurbish database collection with invalid contents", e);
 		}
 	}
 
@@ -535,7 +532,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			InterruptedException,
 			IOException,
 			InitialStateActionException,
-			TimeoutException
+			InvalidCollectionContentsException
 		{
 			LOGGER.debug("onConnectionSucceeded");
 			FutureTask<EntireState<R>> initialStateAction = this.taskRef.get();
@@ -643,17 +640,10 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	}
 
 	private FormatDriver<R> newPreferredFormatDriver() {
-		DatabaseFormat preferred = driverSettings.preferredDatabaseFormat();
-		if (preferred.equals(SEQUOIA) || preferred instanceof PandoFormat) {
-			return newFormatDriver(
-				preferred,
-				driverSettings.manifestDocumentIdMode().manifestDocumentId()
-			);
-		}
-		throw new AssertionError("Unknown database format setting: " + preferred);
+		return newFormatDriver(driverSettings.preferredDatabaseFormat());
 	}
 
-	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException {
+	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException, InvalidCollectionContentsException {
 		LOGGER.debug("Detecting format");
 		var manifestInfo = loadManifest();
 		Manifest manifest = manifestInfo.manifest();
@@ -664,9 +654,9 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		FindIterable<BsonDocument> result = queryCollection.find(new BsonDocument("_id", documentId));
 		try (MongoCursor<BsonDocument> cursor = result.cursor()) {
 			if (cursor.hasNext()) {
-				return newFormatDriver(format, manifestInfo.manifestId());
+				return newFormatDriver(format);
 			} else {
-				throw new UninitializedCollectionException("Document doesn't exist: "
+				throw new InvalidCollectionContentsException(format, "Document doesn't exist: "
 					+ "collection=" + driverSettings.database()
 					+ "." + COLLECTION_NAME
 					+ " id=" + documentId.getValue());
@@ -676,26 +666,30 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 	record ManifestInfo(Manifest manifest, @Nullable BsonString manifestId) {}
 
-	private ManifestInfo loadManifest() throws UnrecognizedFormatException {
-		try (MongoCursor<BsonDocument> cursor = queryCollection.find(new BsonDocument("_id",
-			new BsonDocument("$in", new BsonArray(List.of(MANIFEST_ID, LEGACY_MANIFEST_ID)))
-		)).cursor()) {
+	private ManifestInfo loadManifest() throws UnrecognizedFormatException, UninitializedCollectionException {
+		// The manifest ID is deliberately chosen to sort first by ID.
+		// This way we can distinguish three cases in one query:
+		// 1) No documents at all: the collection is uninitialized.
+		// 2) A manifest document exists: the collection is initialized and we can proceed.
+		// 3) No manifest document, but another document exists: the collection contents are invalid.
+		try (MongoCursor<BsonDocument> cursor = queryCollection
+			.find(new BsonDocument()).sort(ascending("_id")).limit(1).cursor()
+		) {
 			if (cursor.hasNext()) {
 				BsonDocument doc = cursor.next();
-				if (doc.get("_id").equals(LEGACY_MANIFEST_ID)) {
-					LOGGER.info("Found legacy manifest");
+				if (MANIFEST_ID.equals(doc.getString("_id"))) {
+					return new ManifestInfo(formatter.decodeManifest(doc), doc.getString("_id"));
 				} else {
-					LOGGER.debug("Found manifest");
+					throw new UnrecognizedFormatException("Manifest document not found: "
+						+ "collection=" + driverSettings.database()
+						+ "." + COLLECTION_NAME
+						+ " id=" + MANIFEST_ID);
 				}
-				Manifest result = formatter.decodeManifest(doc);
-				if (cursor.hasNext()) {
-					throw new UnrecognizedFormatException("Multiple manifest documents found");
-				}
-				return new ManifestInfo(result, doc.getString("_id"));
 			} else {
-				// For legacy databases with no manifest
-				LOGGER.debug("Manifest is missing; checking for Sequoia format in {}", driverSettings.database());
-				return new ManifestInfo(Manifest.forSequoia(), null);
+				throw new UninitializedCollectionException(
+					"Collection is empty: " + driverSettings.database()
+						+ "." + COLLECTION_NAME
+				);
 			}
 		}
 	}
@@ -703,34 +697,31 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	/**
 	 * Meant for tests
 	 */
-	ManifestInfo loadManifestInfo() throws UnrecognizedFormatException, FailedMongoClientSessionException {
+	ManifestInfo loadManifestInfo() throws UnrecognizedFormatException, FailedMongoClientSessionException, UninitializedCollectionException {
 		try (var _ = queryCollection.newReadOnlySession()) {
 			return loadManifest();
 		}
 	}
 
-	private FormatDriver<R> newFormatDriver(DatabaseFormat format, @Nullable BsonString manifestId) {
-		if (format.equals(SEQUOIA)) {
-			return new SequoiaFormatDriver<>(
+	private FormatDriver<R> newFormatDriver(DatabaseFormat format) {
+		return switch (format) {
+			case SequoiaFormat _ -> new SequoiaFormatDriver<>(
 				boskInfo,
 				queryCollection,
 				driverSettings,
 				bsonSerializer,
 				flushTimeout,
-				manifestId,
-				downstream);
-		} else if (format instanceof PandoFormat pandoFormat) {
-			return new PandoFormatDriver<>(
+				downstream
+			);
+			case PandoFormat pandoFormat -> new PandoFormatDriver<>(
 				boskInfo,
 				queryCollection,
 				driverSettings,
 				pandoFormat,
 				bsonSerializer,
 				flushTimeout,
-				manifestId,
 				downstream);
-		}
-		throw new IllegalArgumentException("Unexpected database format: " + format);
+		};
 	}
 
 
@@ -897,8 +888,6 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 	public static final String COLLECTION_NAME = "boskCollection";
 	public static final BsonString MANIFEST_ID = new BsonString("!Manifest");
-	public static final BsonString LEGACY_MANIFEST_ID = new BsonString("manifest");
-	public static final Set<BsonValue> MANIFEST_IDS = Set.of(MANIFEST_ID, LEGACY_MANIFEST_ID);
 	private static final Exception FAILURE_TO_COMPUTE_INITIAL_STATE = new InitialStateFailureException("Failure to compute initial state");
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainDriver.class);
 	private static final Logger UNINITIALIZED_COLLECTION_LOGGER = LoggerFactory.getLogger(UNINITIALIZED_COLLECTION_LOGGER_NAME);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -5,7 +5,6 @@ import com.mongodb.MongoClientSettings.Builder;
 import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
 import com.mongodb.WriteConcern;
-import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
@@ -31,10 +30,8 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import works.bosk.BoskConfig.TenancyModel.Implicit;
 import works.bosk.BoskDriver;
 import works.bosk.BoskDriver.EntireState.MultiTree;
-import works.bosk.BoskDriver.EntireState.SingleTree;
 import works.bosk.BoskInfo;
 import works.bosk.Identifier;
 import works.bosk.Reference;
@@ -51,8 +48,8 @@ import works.bosk.drivers.mongo.exceptions.InitialStateFailureException;
 import works.bosk.drivers.mongo.status.MongoStatus;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
-import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.logging.MappedDiagnosticContext.MDCScope;
+import works.bosk.util.PerTenant;
 import works.bosk.util.PerTenant.NoTenant;
 
 import static com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL;
@@ -159,11 +156,6 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			this.driverSettings = driverSettings;
 			this.bsonSerializer = bsonSerializer;
 			this.downstream = downstream;
-
-			switch (boskInfo.tenancyModel()) {
-				case Implicit _ -> {}
-				default -> throw new IllegalArgumentException("Tenancy model not yet supported: " + boskInfo.tenancyModel());
-			}
 
 			// Flushes work by waiting for the latest version to arrive on the change stream.
 			// If we wait for two heartbeats and don't see the update, something has gone wrong.
@@ -325,12 +317,15 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		EntireState<R> entireState;
 		try (var _ = queryCollection.newReadOnlySession()){
 			FormatDriver<R> detectedDriver = detectFormat();
-			StateAndMetadata<R> loadedState = detectedDriver.loadAllState();
+			PerTenant<StateAndMetadata<R>> loadedState = detectedDriver.loadAllState();
+			entireState = switch (loadedState.map(StateAndMetadata::state)) {
+				case NoTenant<R>(R root) -> EntireState.just(root);
+				case PerTenant.MultiTenant<R> v -> v.values().entrySet().stream().collect(MultiTree.collector());
+			};
 
 			// Hasn't technically been applied, but we're still initializing the Bosk, and its constructor won't return until the state has been applied
-			detectedDriver.hasBeenApplied(NoTenant.just(loadedState));
+			detectedDriver.hasBeenApplied(loadedState);
 
-			entireState = EntireState.just(loadedState.state());
 			publishFormatDriver(detectedDriver);
 		} catch (UninitializedCollectionException e) {
 			// We log this at warn because, in production, this is a big deal.
@@ -341,11 +336,9 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				var session = queryCollection.newSession()
 			) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
-				var root = switch (entireState) {
-					case SingleTree(var r) -> r;
-					case MultiTree<R> _ -> throw new NotYetImplementedException();
-				};
-				preferredDriver.initializeCollection(new StateAndMetadata<>(root, REVISION_ZERO, boskInfo.context().getAttributes()));
+				PerTenant<StateAndMetadata<R>> priorContents = PerTenant.from(entireState, root ->
+					new StateAndMetadata<>(root, REVISION_ZERO, boskInfo.context().getAttributes()));
+				preferredDriver.initializeCollection(priorContents);
 				session.commitTransactionIfAny();
 				// We can now publish the driver knowing that the transaction, if there is one, has committed
 				publishFormatDriver(preferredDriver);
@@ -394,7 +387,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// Design note: this operation shouldn't do any special coordination with
 			// the receiver/listener system, because other replicas won't.
 			// That system needs to cope with refurbish operations without any help.
-			StateAndMetadata<R> result = formatDriver.loadAllState();
+			PerTenant<StateAndMetadata<R>> result = formatDriver.loadAllState();
 			FormatDriver<R> newFormatDriver = newPreferredFormatDriver();
 
 			// initializeCollection is required to replace the manifest anyway,
@@ -538,12 +531,12 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			FutureTask<EntireState<R>> initialStateAction = this.taskRef.get();
 			if (initialStateAction == null) {
 				FormatDriver<R> newDriver;
-				StateAndMetadata<R> loadedState;
+				PerTenant<StateAndMetadata<R>> contents;
 				try (var _ = queryCollection.newReadOnlySession()) {
 					LOGGER.debug("Loading database state to submit to downstream driver");
 					newDriver = detectFormat();
-					loadedState = newDriver.loadAllState();
-					LOGGER.trace("Loaded state: {}", loadedState);
+					contents = newDriver.loadAllState();
+					LOGGER.trace("Loaded state: {}", contents);
 				}
 				// Note: can't call downstream methods with a session open,
 				// because that could run hooks, which could themselves submit
@@ -557,19 +550,27 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 				publishFormatDriver(newDriver);
 
-				// TODO: It's not clear we actually want loadedState.diagnosticAttributes here.
-				// This causes downstream.submitReplacement to be associated with the last update to the state,
-				// which is of dubious relevance. We might just want to use the context from the current thread,
-				// which is probably empty because this runs on the ChangeReceiver thread.
-				try (
-					var _ = boskInfo.context().withOnly(loadedState.diagnosticAttributes());
-				) {
-					downstream.submitReplacement(boskInfo.rootReference(), loadedState.state());
+				if (contents instanceof PerTenant.NoTenant<StateAndMetadata<R>>(var soleContents)) {
+					downstream.submitReplacement(boskInfo.rootReference(), soleContents.state());
 					LOGGER.debug("Done submitting downstream");
+				} else {
+					// TODO: It's not clear we actually want loadedState.diagnosticAttributes here.
+					// This causes downstream.submitReplacement to be associated with the last update to the state,
+					// which is of dubious relevance. We might just want to use the context from the current thread,
+					// which is probably empty because this runs on the ChangeReceiver thread.
+					contents.forEach((tenant, s) -> {
+						try (
+							var _ = boskInfo.context().withOnly(s.diagnosticAttributes());
+							var _ = boskInfo.context().withTenant(tenant)
+						) {
+							downstream.submitReplacement(boskInfo.rootReference(), s.state());
+							LOGGER.debug("Done submitting downstream");
+						}
+					});
 				}
 
 				downstream.flush();
-				newDriver.hasBeenApplied(NoTenant.just(loadedState));
+				newDriver.hasBeenApplied(contents);
 			} else {
 				LOGGER.debug("Running initialState action");
 				runInitialStateAction(initialStateAction);
@@ -643,25 +644,11 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		return newFormatDriver(driverSettings.preferredDatabaseFormat());
 	}
 
-	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException, InvalidCollectionContentsException {
+	private FormatDriver<R> detectFormat() throws UninitializedCollectionException, UnrecognizedFormatException {
 		LOGGER.debug("Detecting format");
-		var manifestInfo = loadManifest();
-		Manifest manifest = manifestInfo.manifest();
+		Manifest manifest = loadManifest().manifest();
 		DatabaseFormat format = manifest.pando().isPresent()? manifest.pando().get() : SEQUOIA;
-		BsonString documentId = (format == SEQUOIA)
-			? SequoiaFormatDriver.DOCUMENT_ID
-			: PandoFormatDriver.ROOT_DOCUMENT_ID;
-		FindIterable<BsonDocument> result = queryCollection.find(new BsonDocument("_id", documentId));
-		try (MongoCursor<BsonDocument> cursor = result.cursor()) {
-			if (cursor.hasNext()) {
-				return newFormatDriver(format);
-			} else {
-				throw new InvalidCollectionContentsException(format, "Document doesn't exist: "
-					+ "collection=" + driverSettings.database()
-					+ "." + COLLECTION_NAME
-					+ " id=" + documentId.getValue());
-			}
-		}
+		return newFormatDriver(format);
 	}
 
 	record ManifestInfo(Manifest manifest, @Nullable BsonString manifestId) {}
@@ -673,7 +660,10 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		// 2) A manifest document exists: the collection is initialized and we can proceed.
 		// 3) No manifest document, but another document exists: the collection contents are invalid.
 		try (MongoCursor<BsonDocument> cursor = queryCollection
-			.find(new BsonDocument()).sort(ascending("_id")).limit(1).cursor()
+			.find(new BsonDocument())
+			.sort(ascending("_id"))
+			.limit(1)
+			.cursor()
 		) {
 			if (cursor.hasNext()) {
 				BsonDocument doc = cursor.next();
@@ -683,7 +673,8 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 					throw new UnrecognizedFormatException("Manifest document not found: "
 						+ "collection=" + driverSettings.database()
 						+ "." + COLLECTION_NAME
-						+ " id=" + MANIFEST_ID);
+						+ " _id=" + MANIFEST_ID
+						+ "; found \"" + doc.getString("_id") + "\"");
 				}
 			} else {
 				throw new UninitializedCollectionException(

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -15,6 +15,9 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -25,7 +28,13 @@ import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskConfig.TenancyModel.Fixed;
+import works.bosk.BoskConfig.TenancyModel.Persistent;
 import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.Established;
+import works.bosk.BoskContext.Tenant.None;
+import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
 import works.bosk.Entity;
@@ -43,6 +52,9 @@ import works.bosk.drivers.mongo.exceptions.FormatMisconfigurationException;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
+import works.bosk.util.PerTenant;
+import works.bosk.util.PerTenant.MultiTenant;
+import works.bosk.util.PerTenant.NoTenant;
 
 import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Filters.regex;
@@ -68,13 +80,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	private final Demultiplexer demultiplexer = new Demultiplexer();
 	private final List<Reference<? extends EnumerableByIdentifier<?>>> graftPoints;
 
-	static final BsonString ROOT_DOCUMENT_ID = new BsonString("|");
+	private static final BsonString ROOT_PATH = new BsonString("/");
 
 	PandoFormatDriver(
 		BoskInfo<R> boskInfo,
 		TransactionalCollection collection,
 		MongoDriverSettings driverSettings,
-		PandoFormat format, BsonSerializer bsonSerializer,
+		PandoFormat format,
+		BsonSerializer bsonSerializer,
 		long flushTimeoutMS,
 		BoskDriver downstream
 	) {
@@ -85,7 +98,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			new Formatter(boskInfo, bsonSerializer),
 			collection,
 			downstream,
-			flushTimeoutMS
+			flushTimeoutMS,
+			() -> boskInfo.bosk().entireState()
 		);
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 		this.settings = driverSettings;
@@ -150,8 +164,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	BsonStateAndMetadata loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
-		List<BsonDocument> allParts = new ArrayList<>();
+	PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() {
+		// Look for runs of state documents with the same tenant info.
+		// Make a BsonStateAndMetadata for each run.
+		SortedMap<Established, BsonStateAndMetadata> states = new TreeMap<>(comparing(t -> switch (t) {
+			case None _ -> "";
+			case TenantId(var id) -> id.toString();
+		}));
+		List<BsonDocument> partsBuffer = new ArrayList<>();
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
 			.find(regex("_id", "^" + Pattern.quote("|")))
@@ -159,48 +179,130 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			.cursor()
 		) {
 			while (cursor.hasNext()) {
-				allParts.add(cursor.next());
+				BsonDocument lastPart = cursor.next();
+				partsBuffer.add(lastPart);
+				// Only the root/main document has a path field, and it's always "/" regardless
+				// of tenancy mode; sub-part documents have no path field at all.
+				if (ROOT_PATH.equals(lastPart.getString(DocumentFields.path.name(), null))) {
+					// The lastPart is a main part
+
+					// Pull what we need from the parts before gather() mutates them
+					BsonInt64 revision = lastPart.getInt64(DocumentFields.revision.name(), null);
+					BsonDocument diagnosticAttributes = Formatter.getDiagnosticAttributesIfAny(lastPart);
+
+					BsonDocument state = gather(partsBuffer); // mutates partsBuffer!
+
+					// At the Bson level, where we're describing the contents of the database,
+					// we use Tenant.NONE here because the database info itself does not record tenancy.
+					// For TenancyModel.Fixed, this won't be the right tenant to use when establishing
+					// the bosk context.
+					states.put(Tenant.NONE, new BsonStateAndMetadata(
+						state,
+						revision,
+						diagnosticAttributes
+					));
+
+					partsBuffer.clear();
+				}
 			}
 		}
-		BsonDocument mainPart = allParts.getLast();
-		if (!ROOT_DOCUMENT_ID.equals(mainPart.get("_id"))) {
-			throw new IllegalStateException("Cannot locate root document");
+
+		if (!partsBuffer.isEmpty()) {
+			throw new IllegalStateException("Found parts without a main document: "
+				+ partsBuffer.stream().map(part -> part.get("_id")).toList());
 		}
 
-		return new BsonStateAndMetadata(
-			bsonSurgeon.gather(allParts),
-			mainPart.getInt64(DocumentFields.revision.name(), null),
-			Formatter.getDiagnosticAttributesIfAny(mainPart)
-		);
+		// Note: we tolerate extra documents here, in the spirit of HASTY mode:
+		// documents are not necessarily deleted promptly, so there can be extra ones lying around.
+		var theState = states.get(Tenant.NONE);
+		if (theState == null) {
+			// Appropriate error message depends on what we did actually discover
+			if (states.isEmpty()) {
+				throw new IllegalStateException("No state documents");
+			} else {
+				throw new IllegalStateException("All state documents have tenant info");
+			}
+		}
+		return switch (tenancyModel) {
+			case TenancyModel.None _ -> new NoTenant<>(theState);
+			case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), theState);
+			case Persistent _ -> throw new AssertionError(
+				"Persistent tenancy should use ID_PREFIX format");
+		};
 	}
 
 	@Override
-	public void initializeCollection(StateAndMetadata<R> priorContents) {
-		BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
-		BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision().longValue());
-		// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
-
-		LOGGER.debug("** Initial upsert for {}", ROOT_DOCUMENT_ID.getValue());
-		collection.ensureTransactionStarted();
-		if (initialState instanceof BsonDocument) {
-			upsertAndRemoveSubParts(rootRef, initialState.asDocument()); // Mutates initialState!
+	@Nonnull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
+		LOGGER.debug("readRevisionNumbers");
+		try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
+			BsonDocument doc = cursor.next();
+			BsonInt64 revision = doc.getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+			return switch (tenancyModel) {
+				case TenancyModel.None _ -> NoTenant.just(revision);
+				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), revision);
+				case Persistent _ -> throw new AssertionError(
+					"Persistent tenancy should use ID_PREFIX format");
+			};
+		} catch (NoSuchElementException e) {
+			throw new RevisionFieldDisruptedException("No matching root document");
 		}
-		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, ROOT_DOCUMENT_ID));
-		BsonDocument filter = documentFilter(rootRef);
-		UpdateOptions options = new UpdateOptions().upsert(true);
-		LOGGER.trace("| Filter: {}", filter);
-		LOGGER.trace("| Update: {}", update);
-		LOGGER.trace("| Options: {}", options);
-		UpdateResult result = collection.updateOne(filter, update, options);
-		LOGGER.debug("| Result: {}", result);
-		writeManifest(Manifest.forPando(format));
-
-		// Update the state that we "know about"
-		flushLock.finishedRevision(newRevision);
 	}
 
 	/**
-	 * We're required to cope with anything we might ourselves do in {@link #initializeCollection}.
+	 * For efficiency, this modifies <code>partsList</code> in-place.
+	 */
+	private BsonDocument gather(List<BsonDocument> allParts) {
+		return bsonSurgeon.gather(allParts);
+	}
+
+	@Override
+	public void initializeCollection(PerTenant<StateAndMetadata<R>> priorContentsArg) {
+		var allPriorContents = normalizePerTenant(validateAndNormalize(priorContentsArg));
+		ensureFlushLocksInitialized(allPriorContents);
+		allPriorContents.forEach((tenant, priorContents) -> {
+			BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
+			BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision().longValue());
+			// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
+
+			LOGGER.debug("** Initial upsert");
+			collection.ensureTransactionStarted();
+			if (initialState instanceof BsonDocument) {
+				upsertAndRemoveSubParts(rootRef, initialState.asDocument()); // Mutates initialState!
+			}
+			BsonString documentId = new BsonString("|");
+			BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, documentId));
+			BsonDocument filter = rootDocumentsFilter();
+			filter.put("_id", documentId);
+			UpdateOptions options = new UpdateOptions().upsert(true);
+			LOGGER.trace("| Filter: {}", filter);
+			LOGGER.trace("| Update: {}", update);
+			LOGGER.trace("| Options: {}", options);
+			UpdateResult result = collection.updateOne(filter, update, options);
+			LOGGER.debug("| Result: {}", result);
+			writeManifest(Manifest.forPando(format));
+
+			// Update the state that we "know about"
+			finishedRevision(tenant, newRevision);
+		});
+	}
+
+	private PerTenant<StateAndMetadata<R>> validateAndNormalize(PerTenant<StateAndMetadata<R>> given) {
+		return switch (tenancyModel) {
+			case TenancyModel.None _ -> switch (given) {
+				case NoTenant<StateAndMetadata<R>> v -> v;
+				case MultiTenant<StateAndMetadata<R>> _ -> throw new IllegalArgumentException(
+					"Tenancy model " + tenancyModel + " not compatible with MultiTenant state");
+			};
+			case Persistent _ -> throw new NotYetImplementedException("multitenancy");
+			case Fixed(_) -> switch (given) { // The complex, permissive one
+				case NoTenant<StateAndMetadata<R>> v -> v;
+				case MultiTenant<StateAndMetadata<R>> _ -> throw new NotYetImplementedException("multitenancy");
+			};
+		};
+	}
+
+	/**
+	 * We're required to cope with anything we might ourselves do in {@link FormatDriver#initializeCollection}.
 	 */
 	@Override
 	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
@@ -237,10 +339,10 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	/**
 	 * The final event updates the revision field of the root document.
-	 * Only the root document has a bson path ending with "|" because every other document
-	 * has a bson path ending with the last path segment.
 	 */
 	private boolean isFinalEventOfTree(ChangeStreamDocument<BsonDocument> event) {
+		// Only the root document has a bson path ending with "|" because every other document
+		// has a bson path ending with the last path segment.
 		return
 			event.getDocumentKey().get("_id").asString().getValue().endsWith("|")
 				&& updateEventHasField(event, DocumentFields.revision);
@@ -248,6 +350,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	private void processTree(List<ChangeStreamDocument<BsonDocument>> events) throws UnprocessableEventException {
 		ChangeStreamDocument<BsonDocument> finalEvent = events.getLast();
+		Established tenant = tenantFor(finalEvent.getDocumentKey().getString("_id"));
 		switch (finalEvent.getOperationType()) {
 			case INSERT: case REPLACE: {
 				BsonDocument fullDocument = finalEvent.getFullDocument();
@@ -255,13 +358,12 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					throw new UnprocessableEventException("Missing fullDocument on final event", finalEvent.getOperationType());
 				}
 
-			// Grab the tenant and diagnostics early. If we're supposed to skip this event,
-			// we still need to stash the tenant for later events.
-			Tenant.Established tenant = tenantFor(finalEvent.getDocumentKey().getString("_id"));
+				// Grab the tenant and diagnostics early. If we're supposed to skip this event,
+				// we still need to stash the tenant for later events.
 				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
 
 				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
-				if (shouldSkip(revision)) {
+				if (shouldSkip(tenant, revision)) {
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
@@ -272,7 +374,10 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				) {
 					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
 					if (state == null) {
-						// Final event has only the new revision number; the previous event is the main event
+						// Final event has only the new revision number; the previous event is the main event.
+						// A standalone INSERT/REPLACE always has a state field; lacking one is nonsensical
+						// and implies a programming error or an unexpected database state.
+						assert events.size() >= 2 : "INSERT/REPLACE without state needs a prior main event";
 						ChangeStreamDocument<BsonDocument> mainEvent = events.get(events.size() - 2);
 						LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
 						propagateDownstream(mainEvent, events.subList(0, events.size() - 2));
@@ -282,16 +387,15 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					}
 				}
 
-				flushLock.finishedRevision(revision);
+				finishedRevision(tenant, revision);
 			} break;
 			case UPDATE: {
 				// TODO: Combine code with INSERT and REPLACE events
 				BsonInt64 revision = formatter.getRevisionFromUpdateEvent(finalEvent);
-				if (shouldSkip(revision)) {
+				if (shouldSkip(tenant, revision)) {
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
-				Tenant.Established tenant = tenantFor(finalEvent.getDocumentKey().getString("_id"));
 				MapValue<String> attributes = formatter.eventDiagnosticAttributesFromUpdate(finalEvent);
 				try (
 					var _ = context.withTenant(tenant);
@@ -309,12 +413,12 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 						propagateDownstream(mainEvent, events.subList(0, events.size() - 2));
 					}
 				}
-				flushLock.finishedRevision(revision);
+				finishedRevision(tenant, revision);
 			} break;
 			case DELETE: {
 				// No other events in the transaction matter if the root document is gone
 				LOGGER.debug("Document containing revision field has been deleted; assuming revision=0");
-				flushLock.finishedRevision(REVISION_ZERO);
+				finishedRevision(tenant, REVISION_ZERO);
 			} break;
 			default: {
 				throw new UnprocessableEventException("Cannot process event", finalEvent.getOperationType());
@@ -345,8 +449,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					LOGGER.debug("{} prior events", priorEvents.size());
 					List<BsonDocument> parts = subpartDocuments(priorEvents);
 					parts.add(fullDocument);
-					bsonState = bsonSurgeon.gather(parts);
-					mainRef = documentID2MainRef(fullDocument.getString("_id").getValue(), mainEvent);
+					String id = fullDocument.getString("_id").getValue();
+					bsonState = gather(parts); // Mutates parts
+					mainRef = documentID2MainRef(id, mainEvent);
 				}
 
 				LOGGER.debug("| Replace downstream {}", mainRef);
@@ -395,13 +500,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		downstream.submitReplacement(mainRef, newValue);
 	}
 
-	private Reference<?> documentID2MainRef(String pipedPath, ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
+	private Reference<?> documentID2MainRef(String documentId, ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		// referenceTo does everything we need already. Build a fake dotted field name and use that
-		String dottedName = "state" + pipedPath.replace('|', '.');
+		String dottedName = "state" + documentId
+			.replace('|', '.');
 		try {
 			return BsonFormatter.referenceTo(dottedName, rootRef);
 		} catch (InvalidTypeException e) {
-			throw new UnprocessableEventException("Invalid path from document ID: \"" + pipedPath + "\"", e, event.getOperationType());
+			throw new UnprocessableEventException("Invalid path from document ID: \"" + documentId + "\"", e, event.getOperationType());
 		}
 	}
 
@@ -621,7 +727,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	@Override
 	public BsonDocument rootDocumentsFilter() {
-		return new BsonDocument("_id", ROOT_DOCUMENT_ID);
+		return new BsonDocument("_id", new BsonString("|"));
 	}
 
 	private BsonDocument documentFilter(Reference<?> docRef) {
@@ -703,12 +809,12 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 						parts.addAll(subParts);
 						parts.add(mainDocument);
 
-						replacementValue = bsonSurgeon.gather(parts);
+						replacementValue = gather(parts);
 					} else if (subParts.isEmpty()) {
 						LOGGER.debug("Replacement value is scalar: {}", replacementValue);
 					} else if (TRUE.equals(replacementValue)) {
 						LOGGER.debug("Replacement value is stub; gather {} subparts", subParts.size());
-						replacementValue = bsonSurgeon.gather(subParts);
+						replacementValue = gather(subParts);
 					} else {
 						throw new UnprocessableEventException("Scalar " + replacementValue + " has subparts:\n\t" + subParts, operationType);
 					}
@@ -785,7 +891,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 		LOGGER.debug("Document has {} sub-parts", subParts.size());
 		for (BsonDocument part: subParts) {
-			BsonDocument filter = new BsonDocument("_id", part.get("_id"));
+			// scatter() already prepended idPrefix to the _id; don't prepend it again
+			BsonString id = part.getString("_id");
+			BsonDocument filter = new BsonDocument("_id", id);
 			LOGGER.debug("Pre-delete sub-part: filter={}", filter);
 			collection.deleteOne(filter);
 			LOGGER.debug("Insert sub-part: filter={} replacement={}", filter, part);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
@@ -66,8 +65,11 @@ import static java.util.stream.Collectors.toList;
 import static org.bson.BsonBoolean.TRUE;
 import static works.bosk.Path.parseParameterized;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.docBsonPath;
+import static works.bosk.drivers.mongo.internal.BsonSurgeon.BSON_PATH_FIELD;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
+import static works.bosk.drivers.mongo.internal.Formatter.getTenantFromDocumentId;
 import static works.bosk.util.Classes.enumerableByIdentifier;
+import static works.bosk.util.PerTenant.MultiTenant.multiTenant;
 
 /**
  * Implements {@link PandoFormat}.
@@ -164,7 +166,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() {
+	PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		// Look for runs of state documents with the same tenant info.
 		// Make a BsonStateAndMetadata for each run.
 		SortedMap<Established, BsonStateAndMetadata> states = new TreeMap<>(comparing(t -> switch (t) {
@@ -174,7 +176,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		List<BsonDocument> partsBuffer = new ArrayList<>();
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
-			.find(regex("_id", "^" + Pattern.quote("|")))
+			.find(regex("_id", "^[|<]"))
 			.sort(new BsonDocument("_id", new BsonInt32(-1))) // Root doc last
 			.cursor()
 		) {
@@ -189,14 +191,16 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// Pull what we need from the parts before gather() mutates them
 					BsonInt64 revision = lastPart.getInt64(DocumentFields.revision.name(), null);
 					BsonDocument diagnosticAttributes = Formatter.getDiagnosticAttributesIfAny(lastPart);
+					Established documentTenant = getTenantFromDocumentId(lastPart.getString("_id"));
 
 					BsonDocument state = gather(partsBuffer); // mutates partsBuffer!
 
-					// At the Bson level, where we're describing the contents of the database,
-					// we use Tenant.NONE here because the database info itself does not record tenancy.
-					// For TenancyModel.Fixed, this won't be the right tenant to use when establishing
-					// the bosk context.
-					states.put(Tenant.NONE, new BsonStateAndMetadata(
+					// Note that documentTenant is strictly the tenant from the document.
+					// In the case of TenancyFormat.NONE and TenancyModel.Fixed, this
+					// will be Tenant.NONE which is not actually the correct fixed tenant ID,
+					// but that's ok because we're not going to use it as the tenant ID anyway.
+					// This is just a way of describing what we've found in the database.
+					states.put(documentTenant, new BsonStateAndMetadata(
 						state,
 						revision,
 						diagnosticAttributes
@@ -214,45 +218,108 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 		// Note: we tolerate extra documents here, in the spirit of HASTY mode:
 		// documents are not necessarily deleted promptly, so there can be extra ones lying around.
-		var theState = states.get(Tenant.NONE);
-		if (theState == null) {
-			// Appropriate error message depends on what we did actually discover
-			if (states.isEmpty()) {
-				throw new IllegalStateException("No state documents");
-			} else {
-				throw new IllegalStateException("All state documents have tenant info");
+		return switch (format.tenancyFormat()) {
+			case NONE -> {
+				var theState = states.get(Tenant.NONE);
+				if (theState == null) {
+					// Appropriate error message depends on what we did actually discover
+					if (states.isEmpty()) {
+						throw new IllegalStateException("No state documents");
+					} else {
+						throw new IllegalStateException("All state documents have tenant info, inconsistent with tenancyFormat=NONE");
+					}
+				}
+				yield switch (tenancyModel) {
+					case TenancyModel.None _ -> new NoTenant<>(theState);
+					case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), theState);
+					case Persistent _ -> throw new AssertionError(
+						"Persistent tenancy should use ID_PREFIX format");
+				};
 			}
-		}
-		return switch (tenancyModel) {
-			case TenancyModel.None _ -> new NoTenant<>(theState);
-			case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), theState);
-			case Persistent _ -> throw new AssertionError(
-				"Persistent tenancy should use ID_PREFIX format");
+			case ID_PREFIX -> states.entrySet().stream()
+				.filter(e -> e.getKey() != Tenant.NONE)
+				.collect(multiTenant(e -> (TenantId) e.getKey(), Entry::getValue));
 		};
 	}
 
 	@Override
 	@Nonnull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
 		LOGGER.debug("readRevisionNumbers");
-		try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
-			BsonDocument doc = cursor.next();
-			BsonInt64 revision = doc.getInt64(DocumentFields.revision.name(), REVISION_ZERO);
-			return switch (tenancyModel) {
-				case TenancyModel.None _ -> NoTenant.just(revision);
-				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), revision);
-				case Persistent _ -> throw new AssertionError(
-					"Persistent tenancy should use ID_PREFIX format");
+		try {
+			return switch (format.tenancyFormat()) {
+				case NONE -> {
+					try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
+						while (cursor.hasNext()) {
+							BsonDocument doc = cursor.next();
+							if (getTenantFromDocumentId(doc.getString("_id")) instanceof None) {
+								BsonInt64 revision = doc.getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+								yield switch (tenancyModel) {
+									case TenancyModel.None _ -> NoTenant.just(revision);
+									case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), revision);
+									case Persistent _ -> throw new AssertionError(
+										"Persistent tenancy should use ID_PREFIX format");
+								};
+							}
+						}
+					}
+					throw new RevisionFieldDisruptedException("No matching root document");
+				}
+				case ID_PREFIX -> {
+					SortedMap<TenantId, BsonInt64> revisions = new TreeMap<>();
+					try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
+						while (cursor.hasNext()) {
+							BsonDocument doc = cursor.next();
+							if (getTenantFromDocumentId(doc.getString("_id")) instanceof TenantId tid) {
+								revisions.put(tid, doc.getInt64(DocumentFields.revision.name(), REVISION_ZERO));
+							}
+						}
+					}
+					yield new MultiTenant<>(revisions);
+				}
 			};
-		} catch (NoSuchElementException e) {
-			throw new RevisionFieldDisruptedException("No matching root document");
+		} catch (RuntimeException e) {
+			throw new RevisionFieldDisruptedException(e);
 		}
 	}
 
 	/**
 	 * For efficiency, this modifies <code>partsList</code> in-place.
+	 * <p>
+	 * A version of {@link BsonSurgeon#gather(List)} that handles tenant IDs.
+	 * The "part" recipe documents must all have the same tenant ID.
 	 */
 	private BsonDocument gather(List<BsonDocument> allParts) {
+		var tenantId = getTenantFromDocumentId(allParts.getFirst().getString("_id"));
+		allParts.forEach(d -> removeTenantFromId(d, tenantId));
 		return bsonSurgeon.gather(allParts);
+	}
+
+	/**
+	 * A version of {@link BsonSurgeon#scatter(Reference, BsonDocument)} that handles tenant IDs.
+	 * The resulting "part" recipe documents have the tenant ID prepended to their IDs.
+	 * <p>
+	 * (The incoming {@code value} is not a fully fledged database document yet:
+	 * it is the document produced by the {@link BsonSerializer}, not a "recipe" from the BsonSurgeon.)
+	 */
+	private <T> List<BsonDocument> scatter(Reference<T> target, BsonDocument value, String idPrefix) {
+		return bsonSurgeon.scatter(target, value).stream()
+			.peek(d -> prependTenantToId(d, idPrefix))
+			.toList();
+	}
+
+	private void removeTenantFromId(BsonDocument doc, Established tenant) {
+		String id = doc.getString(BSON_PATH_FIELD).getValue();
+		assert id.startsWith(tenantPrefix(tenant)):
+			"Document ID must start with [" + tenantPrefix(tenant) + "]: " + id;
+		doc.put(BSON_PATH_FIELD, new BsonString(removeTenantFrom(id)));
+	}
+
+	private String removeTenantFrom(String documentId) {
+		return documentId.substring(documentId.indexOf("|"));
+	}
+
+	private void prependTenantToId(BsonDocument doc, String idPrefix) {
+		doc.put(BSON_PATH_FIELD, new BsonString(idPrefix + doc.getString(BSON_PATH_FIELD).getValue()));
 	}
 
 	@Override
@@ -266,10 +333,11 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 			LOGGER.debug("** Initial upsert");
 			collection.ensureTransactionStarted();
+			String tenantPrefix = tenantPrefix(tenant);
 			if (initialState instanceof BsonDocument) {
-				upsertAndRemoveSubParts(rootRef, initialState.asDocument()); // Mutates initialState!
+				upsertAndRemoveSubParts(rootRef, initialState.asDocument(), tenantPrefix); // Mutates initialState!
 			}
-			BsonString documentId = new BsonString("|");
+			BsonString documentId = new BsonString(tenantPrefix + "|");
 			BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, documentId));
 			BsonDocument filter = rootDocumentsFilter();
 			filter.put("_id", documentId);
@@ -286,6 +354,11 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		});
 	}
 
+	/**
+	 * @return {@code given} if it's value, except for {@link Fixed},
+	 * where it's coerced into either a {@link NoTenant} or a {@link MultiTenant} with one tenant
+	 * depending on the {@link PandoFormat#tenancyFormat() tenancyFormat}.
+	 */
 	private PerTenant<StateAndMetadata<R>> validateAndNormalize(PerTenant<StateAndMetadata<R>> given) {
 		return switch (tenancyModel) {
 			case TenancyModel.None _ -> switch (given) {
@@ -293,10 +366,30 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				case MultiTenant<StateAndMetadata<R>> _ -> throw new IllegalArgumentException(
 					"Tenancy model " + tenancyModel + " not compatible with MultiTenant state");
 			};
-			case Persistent _ -> throw new NotYetImplementedException("multitenancy");
-			case Fixed(_) -> switch (given) { // The complex, permissive one
-				case NoTenant<StateAndMetadata<R>> v -> v;
-				case MultiTenant<StateAndMetadata<R>> _ -> throw new NotYetImplementedException("multitenancy");
+			case Persistent _ -> switch (given) {
+				case MultiTenant<StateAndMetadata<R>> v -> v;
+				case NoTenant<StateAndMetadata<R>> _ -> throw new IllegalArgumentException(
+					"Tenancy model " + tenancyModel + " not compatible with NoTenant state");
+			};
+			case Fixed(Identifier id) -> switch (given) { // The complex, permissive one
+				case NoTenant<StateAndMetadata<R>> v -> switch (format.tenancyFormat()) {
+					case NONE -> v;
+					case ID_PREFIX -> MultiTenant.singleton(Tenant.setTo(id), v.value());
+				};
+				case MultiTenant<StateAndMetadata<R>> v -> switch (format.tenancyFormat()) {
+					case NONE -> v.asNoTenant(Tenant.setTo(id));
+					case ID_PREFIX -> v;
+				};
+			};
+		};
+	}
+
+	private String tenantPrefix(Established tenant) {
+		return switch (format.tenancyFormat()) {
+			case NONE -> "";
+			case ID_PREFIX -> switch (tenant) {
+				case TenantId(var id) -> "<" + id + ">";
+				default -> throw new IllegalStateException("Expected tenant ID for ID_PREFIX tenancy format, but got: " + tenant);
 			};
 		};
 	}
@@ -502,7 +595,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	private Reference<?> documentID2MainRef(String documentId, ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		// referenceTo does everything we need already. Build a fake dotted field name and use that
-		String dottedName = "state" + documentId
+		String dottedName = "state" + removeTenantFrom(documentId)
 			.replace('|', '.');
 		try {
 			return BsonFormatter.referenceTo(dottedName, rootRef);
@@ -599,7 +692,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		BsonValue value = formatter.object2bsonValue(newValue, target.targetType());
 		if (value instanceof BsonDocument b) {
 			deletePartsUnder(target);
-			upsertAndRemoveSubParts(target, b);
+			upsertAndRemoveSubParts(target, b, tenantPrefix(context.getEstablishedTenant()));
 			// Note that value will now have the sub-parts removed
 		}
 		if (rootRef.equals(mainRef)) {
@@ -727,11 +820,20 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	@Override
 	public BsonDocument rootDocumentsFilter() {
-		return new BsonDocument("_id", new BsonString("|"));
+		return switch (format.tenancyFormat()) {
+			case NONE ->
+				new BsonDocument("_id", new BsonString("|"));
+			case ID_PREFIX ->
+				// Whether a document is a root document cannot be determined by a prefix
+				// on the _id field, so the index won't work, and we'll be doing a table scan.
+				// At least with the path field, the search is simpler, and we could in principle
+				// speed it up with an index if need be.
+				new BsonDocument("path", ROOT_PATH);
+		};
 	}
 
 	private BsonDocument documentFilter(Reference<?> docRef) {
-		return new BsonDocument("_id", new BsonString(docBsonPath(docRef, rootRef)));
+		return new BsonDocument("_id", new BsonString(tenantPrefix(context.getEstablishedTenant()) + docBsonPath(docRef, rootRef)));
 	}
 
 	private <T> BsonDocument standardRootPreconditions(Reference<T> target) {
@@ -801,7 +903,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					BsonValue replacementValue = entry.getValue();
 					if (replacementValue instanceof BsonDocument) {
 						LOGGER.debug("Replacement value is a document; gather along with {} subparts", subParts.size());
-						String mainID = docBsonPath(ref, mainRef);
+						String mainID = tenantPrefix(context.getEstablishedTenant()) + docBsonPath(ref, mainRef);
 						BsonDocument mainDocument = new BsonDocument()
 							.append("_id", new BsonString(mainID))
 							.append("state", replacementValue);
@@ -883,8 +985,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	/**
 	 * @param value is mutated to stub-out the parts written to the database
 	 */
-	private <T> void upsertAndRemoveSubParts(Reference<T> target, BsonDocument value) {
-		List<BsonDocument> allParts = bsonSurgeon.scatter(target, value);
+	private <T> void upsertAndRemoveSubParts(Reference<T> target, BsonDocument value, String idPrefix) {
+		List<BsonDocument> allParts = scatter(target, value, idPrefix);
 		// NOTE: `value` has now been mutated so the parts have been stubbed out
 
 		List<BsonDocument> subParts = allParts.subList(0, allParts.size() - 1);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -77,7 +76,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		MongoDriverSettings driverSettings,
 		PandoFormat format, BsonSerializer bsonSerializer,
 		long flushTimeoutMS,
-		BsonString manifestId,
 		BoskDriver downstream
 	) {
 		super(
@@ -87,8 +85,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			new Formatter(boskInfo, bsonSerializer),
 			collection,
 			downstream,
-			flushTimeoutMS,
-			manifestId
+			flushTimeoutMS
 		);
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 		this.settings = driverSettings;
@@ -153,7 +150,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	BsonStateAndMetadata loadBsonStateAndMetadata() throws UninitializedCollectionException {
+	BsonStateAndMetadata loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		List<BsonDocument> allParts = new ArrayList<>();
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
@@ -164,8 +161,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			while (cursor.hasNext()) {
 				allParts.add(cursor.next());
 			}
-		} catch (NoSuchElementException e) {
-			throw new UninitializedCollectionException("No existing document", e);
 		}
 		BsonDocument mainPart = allParts.getLast();
 		if (!ROOT_DOCUMENT_ID.equals(mainPart.get("_id"))) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -30,6 +30,7 @@ import works.bosk.exceptions.InvalidTypeException;
 
 import static com.mongodb.ReadConcern.LOCAL;
 import static org.bson.BsonBoolean.FALSE;
+import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.referenceTo;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
@@ -48,7 +49,6 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 		MongoDriverSettings driverSettings,
 		BsonSerializer bsonSerializer,
 		long flushTimeoutMS,
-		@Nullable BsonString manifestId,
 		BoskDriver downstream
 	) {
 		super(
@@ -58,8 +58,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			new Formatter(boskInfo, bsonSerializer),
 			collection,
 			downstream,
-			flushTimeoutMS,
-			manifestId
+			flushTimeoutMS
 		);
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 	}
@@ -100,7 +99,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	BsonStateAndMetadata loadBsonStateAndMetadata() throws UninitializedCollectionException {
+	BsonStateAndMetadata loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
 			.find(documentFilter())
@@ -114,7 +113,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				Formatter.getDiagnosticAttributesIfAny(document)
 			);
 		} catch (NoSuchElementException e) {
-			throw new UninitializedCollectionException("No existing document", e);
+			throw new InvalidCollectionContentsException(SEQUOIA, "State document not found: " + DOCUMENT_ID, e);
 		}
 
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -7,6 +7,7 @@ import com.mongodb.client.model.changestream.OperationType;
 import com.mongodb.client.model.changestream.UpdateDescription;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.lang.Nullable;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -16,6 +17,9 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import works.bosk.BoskConfig.TenancyModel.Fixed;
+import works.bosk.BoskConfig.TenancyModel.None;
+import works.bosk.BoskConfig.TenancyModel.Persistent;
 import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
@@ -27,6 +31,10 @@ import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
 import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.exceptions.NotYetImplementedException;
+import works.bosk.util.PerTenant;
+import works.bosk.util.PerTenant.MultiTenant;
+import works.bosk.util.PerTenant.NoTenant;
 
 import static com.mongodb.ReadConcern.LOCAL;
 import static org.bson.BsonBoolean.FALSE;
@@ -58,8 +66,13 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			new Formatter(boskInfo, bsonSerializer),
 			collection,
 			downstream,
-			flushTimeoutMS
+			flushTimeoutMS,
+			() -> boskInfo.bosk().entireState()
 		);
+		if (boskInfo.tenancyModel() instanceof Persistent) {
+			throw new IllegalArgumentException(
+				"SequoiaFormat does not support " + boskInfo.tenancyModel());
+		}
 		this.description = getClass().getSimpleName() + ": " + driverSettings;
 	}
 
@@ -99,7 +112,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	BsonStateAndMetadata loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
 			.find(documentFilter())
@@ -107,11 +120,18 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			.cursor()
 		) {
 			BsonDocument document = cursor.next();
-			return new BsonStateAndMetadata(
+			// Saves the tenant info for subsequent events
+			tenantFor(document.getString("_id"));
+			var bsm = new BsonStateAndMetadata(
 				document.getDocument(DocumentFields.state.name(), null),
 				document.getInt64(DocumentFields.revision.name(), null),
 				Formatter.getDiagnosticAttributesIfAny(document)
 			);
+			return switch (tenancyModel) {
+				case None _ -> NoTenant.just(bsm);
+				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), bsm);
+				case Persistent _ -> throw new NotYetImplementedException();
+			};
 		} catch (NoSuchElementException e) {
 			throw new InvalidCollectionContentsException(SEQUOIA, "State document not found: " + DOCUMENT_ID, e);
 		}
@@ -119,32 +139,57 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	public void initializeCollection(StateAndMetadata<R> priorContents) {
-		BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
-		BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision().longValue());
-		// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
-		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, DOCUMENT_ID));
-		BsonDocument filter = documentFilter();
-		UpdateOptions options = new UpdateOptions().upsert(true);
-		LOGGER.debug("** Initial upsert for {}", DOCUMENT_ID);
-		LOGGER.trace("| Filter: {}", filter);
-		LOGGER.trace("| Update: {}", update);
-		LOGGER.trace("| Options: {}", options);
-		UpdateResult result = collection.updateOne(filter, update, options);
-		LOGGER.debug("| Result: {}", result);
+	@Nonnull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
+		LOGGER.debug("readRevisionNumbers");
+		try {
+			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
+				// Our revisionDocumentCursor matches only one document
+				BsonInt64 revision = cursor.next().getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+				return switch (tenancyModel) {
+					case None _ -> NoTenant.just(revision);
+					case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), revision);
+					case Persistent _ -> throw new NotYetImplementedException();
+				};
+			}
+		} catch (NoSuchElementException e) {
+			throw new RevisionFieldDisruptedException("No root documents found", e);
+		} catch (RuntimeException e) {
+			throw new RevisionFieldDisruptedException(e);
+		}
+	}
 
-		// This is the only time Sequoia changes two documents for the same operation.
-		// Aside from refurbish, it's the only reason we'd want multi-document transactions,
-		// and it's not even a strong reason, because this still works correctly
-		// if interpreted as two separate events.
-		writeManifest(Manifest.forSequoia());
+	@Override
+	public void initializeCollection(PerTenant<StateAndMetadata<R>> priorContentsArg) {
+		var normalized = normalizePerTenant(priorContentsArg);
+		ensureFlushLocksInitialized(normalized);
+		normalized.forEach((tenant, priorContents) -> {
+			// Sequoia has only one document regardless of tenancy
+			BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
+			BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision().longValue());
+			// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
+			BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, DOCUMENT_ID));
+			BsonDocument filter = documentFilter();
+			UpdateOptions options = new UpdateOptions().upsert(true);
+			LOGGER.debug("** Initial upsert for {}", DOCUMENT_ID);
+			LOGGER.trace("| Filter: {}", filter);
+			LOGGER.trace("| Update: {}", update);
+			LOGGER.trace("| Options: {}", options);
+			UpdateResult result = collection.updateOne(filter, update, options);
+			LOGGER.debug("| Result: {}", result);
 
-		// Update the state that we "know about"
-		flushLock.finishedRevision(newRevision);
+			// This is the only time Sequoia changes two documents for the same operation.
+			// Aside from refurbish, it's the only reason we'd want multi-document transactions,
+			// and it's not even a strong reason, because this still works correctly
+			// if interpreted as two separate events.
+			writeManifest(Manifest.forSequoia());
+
+			// Update the state that we "know about"
+			finishedRevision(tenant, newRevision);
+		});
 	}
 
 	/**
-	 * We're required to cope with anything we might ourselves do in {@link #initializeCollection}.
+	 * We're required to cope with anything we might ourselves do in {@link FormatDriver#initializeCollection}.
 	 */
 	@Override
 	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
@@ -161,6 +206,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			LOGGER.debug("Ignoring event for unrecognized document key: {}", event.getDocumentKey());
 			return;
 		}
+		Tenant.Established tenant = tenantFor(event.getDocumentKey().getString("_id"));
 		switch (event.getOperationType()) {
 			case INSERT: case REPLACE: {
 				// Note: an INSERT could be coming from this very bosk initializing the collection,
@@ -175,7 +221,6 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					// also REPLACE. That would imply that this case is impossible.
 					throw new UnprocessableEventException("Missing fullDocument", event.getOperationType());
 				}
-				Tenant.Established tenant = tenantFor(event.getDocumentKey().getString("_id"));
 				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
 				try (
 					var _ = context.withTenant(tenant);
@@ -192,15 +237,14 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					// disappears, we don't null out revisionToSkip. TODO: Rethink what's the right way to handle this.
 					LOGGER.debug("| Replace {}", rootRef);
 					downstream.submitReplacement(rootRef, newRoot);
-					flushLock.finishedRevision(revision);
+					finishedRevision(tenant, revision);
 				}
 			} break;
 			case UPDATE: {
 				UpdateDescription updateDescription = event.getUpdateDescription();
 				if (updateDescription != null) {
 					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
-					if (!shouldSkip(revision)) {
-						Tenant.Established tenant = tenantFor(event.getDocumentKey().getString("_id"));
+					if (!shouldSkip(tenant, revision)) {
 						MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromUpdate(event);
 						try (
 							var _ = context.withTenant(tenant);
@@ -210,12 +254,12 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 							deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
 						}
 					}
-					flushLock.finishedRevision(revision);
+					finishedRevision(tenant, revision);
 				}
 			} break;
 			case DELETE: {
 				LOGGER.debug("Document containing revision field has been deleted; assuming revision=0");
-				flushLock.finishedRevision(REVISION_ZERO);
+				finishedRevision(tenant, REVISION_ZERO);
 			} break;
 			default: {
 				throw new UnprocessableEventException("Cannot process event", event.getOperationType());

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/ForwardingChangeListener.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/ForwardingChangeListener.java
@@ -13,7 +13,7 @@ class ForwardingChangeListener implements ChangeListener {
 	}
 
 	@Override
-	public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException, InterruptedException, IOException, InitialStateActionException, TimeoutException, FailedMongoClientSessionException {
+	public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException, InterruptedException, IOException, InitialStateActionException, TimeoutException, FailedMongoClientSessionException, InvalidCollectionContentsException {
 		downstream.onConnectionSucceeded();
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
@@ -23,10 +23,12 @@ import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
+import works.bosk.drivers.mongo.MongoDriverSettings.TenancyFormat;
 import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.drivers.mongo.internal.ErrorRecordingChangeListener.ErrorRecorder;
 import works.bosk.drivers.mongo.internal.MainDriver.MongoClientFactory;
 import works.bosk.drivers.mongo.internal.MongoDriverConformanceTest.ParameterSetInjector;
+import works.bosk.drivers.mongo.internal.MongoDriverConformanceTest.TenancyFormatInjector;
 import works.bosk.drivers.mongo.internal.TestParameters.EventTiming;
 import works.bosk.drivers.mongo.internal.TestParameters.ParameterSet;
 import works.bosk.junit.InjectFields;
@@ -34,7 +36,6 @@ import works.bosk.junit.InjectFrom;
 import works.bosk.junit.Injected;
 import works.bosk.junit.Injector;
 import works.bosk.logback.ReplayLogsOnFailure;
-import works.bosk.testing.drivers.AbstractDriverTest.SingleTreeScenarioInjector;
 import works.bosk.testing.drivers.PolyfillDriverConformanceTest;
 import works.bosk.testing.junit.Slow;
 
@@ -43,7 +44,7 @@ import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOI
 @Slow
 @InjectFields
 @ReplayLogsOnFailure
-@InjectFrom({SingleTreeScenarioInjector.class, ParameterSetInjector.class})
+@InjectFrom({TenancyFormatInjector.class, ParameterSetInjector.class})
 class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
 	private static MongoService mongoService;
@@ -77,7 +78,23 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 		SHARED_CLIENTS.values().forEach(MongoClient::close);
 	}
 
-	record ParameterSetInjector(Scenario scenario) implements Injector {
+	record TenancyFormatInjector(Scenario scenario) implements Injector {
+		@Override
+		public boolean supports(AnnotatedElement element, Class<?> elementType) {
+			return elementType == TenancyFormat.class;
+		}
+
+		@Override
+		public List<?> values() {
+			return switch (scenario) {
+				case NO_TENANTS -> List.of(TenancyFormat.NONE);
+				case FIXED_TENANT -> List.of(TenancyFormat.NONE, TenancyFormat.ID_PREFIX);
+				case PERSISTENT_TENANT -> List.of(TenancyFormat.ID_PREFIX);
+			};
+		}
+	}
+
+	record ParameterSetInjector(Scenario scenario, TenancyFormat tenancyFormat) implements Injector {
 		@Override
 		public boolean supports(AnnotatedElement element, Class<?> elementType) {
 			return elementType == ParameterSet.class;
@@ -109,7 +126,7 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 //				PandoFormat.withGraftPoints("/nestedSideTable"), // Documents are themselves side tables
 //				PandoFormat.withGraftPoints("/catalog/-x-/sideTable", "/sideTable/-x-/catalog", "/sideTable/-x-/sideTable/-y-/catalog"), // Nesting, parameters
 //				PandoFormat.withGraftPoints("/sideTable/-x-/sideTable/-y-/catalog"), // Multiple parameters in the not-separated part
-			);
+			).map(f -> f.withTenancyFormat(tenancyFormat));
 		}
 
 	}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverConformanceTest.java
@@ -22,7 +22,9 @@ import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.drivers.mongo.internal.ErrorRecordingChangeListener.ErrorRecorder;
 import works.bosk.drivers.mongo.internal.MainDriver.MongoClientFactory;
 import works.bosk.drivers.mongo.internal.MongoDriverConformanceTest.ParameterSetInjector;
 import works.bosk.drivers.mongo.internal.TestParameters.EventTiming;
@@ -48,11 +50,11 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 	@Injected ParameterSet parameters;
 	private MongoDriverSettings driverSettings;
 	private final AtomicInteger numOpenDrivers = new AtomicInteger(0);
-	private ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
+	private ErrorRecorder errorRecorder;
 
 	@BeforeEach
 	void setupErrorRecording() {
-		errorRecorder = new ErrorRecordingChangeListener.ErrorRecorder();
+		errorRecorder = new ErrorRecorder();
 		MainDriver.LISTENER_FACTORY.set(downstream -> new ErrorRecordingChangeListener(errorRecorder, downstream));
 
 		// This guy uses a literal bazillion TCP ports if we don't share clients
@@ -75,22 +77,7 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 		SHARED_CLIENTS.values().forEach(MongoClient::close);
 	}
 
-	static List<ParameterSet> parameterSets() {
-		return TestParameters.driverSettings(
-				Stream.of(
-					PandoFormat.oneBigDocument(),
-					PandoFormat.withGraftPoints("/catalog", "/sideTable"), // Exercises pre-deletion
-//					PandoFormat.withGraftPoints("/nestedSideTable"), // Documents are themselves side tables
-					PandoFormat.withGraftPoints("/nestedSideTable/-x-"), // Graft points are side table entries
-//					PandoFormat.withGraftPoints("/catalog/-x-/sideTable", "/sideTable/-x-/catalog", "/sideTable/-x-/sideTable/-y-/catalog"), // Nesting, parameters
-//					PandoFormat.withGraftPoints("/sideTable/-x-/sideTable/-y-/catalog"), // Multiple parameters in the not-separated part
-					SEQUOIA
-				),
-				Stream.of(EventTiming.NORMAL)) // EARLY is slow; LATE is really slow
-			.toList();
-	}
-
-	record ParameterSetInjector() implements Injector {
+	record ParameterSetInjector(Scenario scenario) implements Injector {
 		@Override
 		public boolean supports(AnnotatedElement element, Class<?> elementType) {
 			return elementType == ParameterSet.class;
@@ -98,8 +85,33 @@ class MongoDriverConformanceTest extends PolyfillDriverConformanceTest {
 
 		@Override
 		public List<?> values() {
-			return parameterSets();
+			Stream<DatabaseFormat> formats = switch (scenario) {
+				case NO_TENANTS, FIXED_TENANT ->
+					Stream.concat(sequoiaFormats(), pandoFormats());
+				case PERSISTENT_TENANT ->
+					pandoFormats();
+			};
+			return TestParameters.driverSettings(
+					formats,
+					Stream.of(EventTiming.NORMAL)) // EARLY is slow; LATE is really slow
+				.toList();
 		}
+
+		private Stream<DatabaseFormat> sequoiaFormats() {
+			return Stream.of(SEQUOIA);
+		}
+
+		private Stream<DatabaseFormat> pandoFormats() {
+			return Stream.of(
+				PandoFormat.oneBigDocument(),
+				PandoFormat.withGraftPoints("/catalog", "/sideTable"), // Exercises pre-deletion
+				PandoFormat.withGraftPoints("/nestedSideTable/-x-") // Graft points are side table entries
+//				PandoFormat.withGraftPoints("/nestedSideTable"), // Documents are themselves side tables
+//				PandoFormat.withGraftPoints("/catalog/-x-/sideTable", "/sideTable/-x-/catalog", "/sideTable/-x-/sideTable/-y-/catalog"), // Nesting, parameters
+//				PandoFormat.withGraftPoints("/sideTable/-x-/sideTable/-y-/catalog"), // Multiple parameters in the not-separated part
+			);
+		}
+
 	}
 
 	@BeforeAll

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverRecoveryTest.java
@@ -14,6 +14,7 @@ import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -21,12 +22,18 @@ import org.slf4j.LoggerFactory;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
 import works.bosk.BoskDriver;
+import works.bosk.DriverFactory;
+import works.bosk.DriverStack;
 import works.bosk.Listing;
+import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.MongoDriverSettings.InitialDatabaseUnavailableMode;
 import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.drivers.mongo.exceptions.InitialStateFailureException;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.logback.BoskLogFilter;
 import works.bosk.testing.drivers.state.TestEntity;
 import works.bosk.testing.junit.Slow;
 
@@ -35,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 import static works.bosk.drivers.mongo.internal.MainDriver.COLLECTION_NAME;
+import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 import static works.bosk.drivers.mongo.internal.TestParameters.SHORT_TIMESCALE;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
@@ -286,6 +294,42 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 		try (var _ = bosk.readSession()) {
 			assertEquals(beforeState, bosk.rootReference().value());
 		}
+	}
+
+	@Test
+	void stateDocumentDeletedBeforeStartup_failsOnInitialize(TestInfo testInfo) {
+		// Initialize the database with content that differs from initialState
+		TestEntity beforeState = initializeDatabase("state document deleted");
+
+		// Delete all non-manifest documents, simulating a state document getting lost
+		mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME, BsonDocument.class)
+			.deleteMany(new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID)));
+
+		// Starting a new Bosk in FAIL_FAST mode should throw because the
+		// manifest exists but the state document is missing
+		MongoDriverSettings failFastSettings = driverSettings.toBuilder()
+			.initialDatabaseUnavailableMode(InitialDatabaseUnavailableMode.FAIL_FAST)
+			.build();
+		DriverFactory<TestEntity> failFastFactory = DriverStack.of(
+			BoskLogFilter.withController(logController),
+			(info, downstream) ->
+				MongoDriver.<TestEntity>factory(
+					mongoService.clientSettings(testInfo),
+					failFastSettings,
+					new BsonSerializer()
+				).build(info, downstream)
+		);
+
+		assertThrows(InitialStateFailureException.class, () -> new Bosk<>(
+			boskName("stateDocDeleted"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(failFastFactory)
+				.build()
+		));
 	}
 
 	private void setRevision(long revisionNumber) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverRecoveryTest.java
@@ -227,17 +227,14 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 			.getDatabase(driverSettings.database())
 			.getCollection(COLLECTION_NAME);
 		AtomicReference<Document> originalDocument = new AtomicReference<>();
-		BsonString rootDocumentID = (driverSettings.preferredDatabaseFormat() == MongoDriverSettings.DatabaseFormat.SEQUOIA)?
-			SequoiaFormatDriver.DOCUMENT_ID :
-			PandoFormatDriver.ROOT_DOCUMENT_ID;
-		BsonDocument rootDocumentFilter = new BsonDocument("_id", rootDocumentID);
+		BsonDocument rootDocumentsFilter = new BsonDocument("path", new BsonString("/"));
 		testRecovery(() -> {
 			LOGGER.debug("Save original document");
-			try (var cursor = collection.find(rootDocumentFilter).cursor()) {
+			try (var cursor = collection.find(rootDocumentsFilter).cursor()) {
 				originalDocument.set(cursor.next());
 			}
 			LOGGER.debug("Delete document");
-			collection.deleteMany(rootDocumentFilter);
+			collection.deleteMany(rootDocumentsFilter);
 		}, (b) -> {
 			LOGGER.debug("Restore original document");
 			// NOTE: This doesn't actually work cleanly with Pando, because restoring the root document by itself

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import lombok.With;
-import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
@@ -21,10 +20,8 @@ import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.jetbrains.annotations.NotNull;
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -68,7 +65,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
@@ -90,7 +87,6 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	 * and we want this test to fail.
 	 */
 	public static final String MANIFEST_ID = "!Manifest";
-	public static final String LEGACY_MANIFEST_ID = "manifest"; // Ditto
 
 	ErrorRecordingChangeListener.ErrorRecorder errorRecorder;
 
@@ -886,7 +882,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			@Override
 			public void onConnectionSucceeded() throws UnrecognizedFormatException, UninitializedCollectionException,
 				FailedMongoClientSessionException, InterruptedException, IOException,
-				InitialStateActionException, TimeoutException {
+				InitialStateActionException, TimeoutException, InvalidCollectionContentsException {
 				if (initializationDone.get()) {
 					LOGGER.debug("onConnectionSucceeded waiting for appAtPreWait");
 					appAtPreWait.await();
@@ -926,8 +922,9 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			MongoCollection<BsonDocument> collection = mongoService.client()
 				.getDatabase(driverSettings.database())
 				.getCollection(MainDriver.COLLECTION_NAME, BsonDocument.class);
-			BsonDocument originalManifest = assertUniqueManifest(collection, MANIFEST_ID);
-			collection.deleteOne(new BsonDocument("_id", new BsonString(MANIFEST_ID)));
+			BsonDocument originalManifest = collection.findOneAndDelete(
+				new BsonDocument("_id", new BsonString(MANIFEST_ID)));
+			assertNotNull(originalManifest, "Manifest document must exist");
 			collection.insertOne(originalManifest);
 
 			LOGGER.debug("Waiting for disconnect to complete before submitting replacement");
@@ -948,131 +945,6 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			MainDriver.LISTENER_FACTORY.remove();
 			MainDriver.DRIVER_PUBLICATION_PRE_WAIT_ACTION.remove();
 		}
-	}
-
-	/**
-	 * Note that we don't test upgrading the manifest and also changing the format at the same time.
-	 * That should work in theory, but it's not recommended.
-	 */
-	@Disabled("Leads to expected errors. This is a good test but it doesn't really belong in this class.")
-	@Test
-	void manifestUpgrade_works() throws InvalidTypeException, IOException, InterruptedException {
-		TestValues distinctiveValues = TestValues.blank().withString("distinctive value");
-
-		LOGGER.debug("Initialize the database");
-		{
-			Bosk<TestEntity> initializeBosk = new Bosk<>(
-				boskName("Initialize"),
-				TestEntity.class,
-				AbstractMongoDriverTest::initialState,
-				BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
-			var initializeRefs = initializeBosk.buildReferences(Refs.class);
-
-			BoskDriver driver = initializeBosk.driver();
-			driver.submitReplacement(initializeRefs.values(), distinctiveValues);
-			driver.flush();
-			initializeBosk.getDriver(MongoDriver.class).close();
-		}
-
-		LOGGER.debug("Use the legacy ID for the manifest");
-		MongoCollection<BsonDocument> collection = mongoService.client()
-			.getDatabase(driverSettings.database())
-			.getCollection(MainDriver.COLLECTION_NAME, BsonDocument.class);
-		BsonDocument newManifest;
-		try (var cursor = findManifestDocs(collection)) {
-			newManifest = cursor.next();
-		}
-		collection.deleteOne(new BsonDocument("_id", new BsonString(MANIFEST_ID)));
-		newManifest.put("_id", new BsonString(LEGACY_MANIFEST_ID));
-		newManifest.put("version", new BsonInt32(1));
-		collection.insertOne(newManifest);
-
-		LOGGER.debug("Connect bosk for refurbishing and verify contents");
-		Bosk<TestEntity> refurbishBosk = new Bosk<>(
-			boskName("Main"),
-			TestEntity.class,
-			AbstractMongoDriverTest::initialState,
-			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
-
-		TestEntity expected = initialRoot(refurbishBosk).withValues(Optional.of(distinctiveValues));
-		TestEntity actual;
-		try (var _ = refurbishBosk.readSession()) {
-			actual = refurbishBosk.rootReference().value();
-		}
-		assertEquals(expected, actual);
-
-		LOGGER.debug("Verify manifest document still has legacy ID");
-		var legacyManifest = assertUniqueManifest(collection, LEGACY_MANIFEST_ID);
-		assertEquals(new BsonInt32(1), legacyManifest.getInt32("version"), "Legacy manifest should have version 1");
-
-		LOGGER.debug("Create bystander bosk");
-		Bosk<TestEntity> bystanderBosk = new Bosk<>(
-			boskName("Bystander"),
-			TestEntity.class,
-			AbstractMongoDriverTest::initialState,
-			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
-
-		LOGGER.debug("Refurbish");
-		MongoDriver refurbishDriver = refurbishBosk.getDriver(MongoDriver.class);
-		refurbishDriver.refurbish();
-
-		LOGGER.debug("Verify manifest ID has been updated and state is intact");
-		var refurbishedManifest = assertUniqueManifest(collection, MANIFEST_ID);
-		assertEquals(new BsonInt32(2), refurbishedManifest.getInt32("version"), "Manifest version should have been bumped to 2");
-		for (String format: List.of("sequoia", "pando")) {
-			// Note: technically this is not the contract here:
-			// refurbish should change the format to be the preferred format, not leave it unchanged.
-			// However, since initializeBosk uses the same preferred format, the format is in fact unchanged.
-			assertEquals(
-				legacyManifest.get(format),
-				refurbishedManifest.get(format),
-				"Refurbish should not have changed the " + format + " field");
-		}
-
-		LOGGER.debug("Refurbish again to verify drivers can consume their own manifest update events");
-		refurbishBosk.driver().flush(); // Make sure we've already seen the first update
-		refurbishDriver.refurbish();
-		refurbishBosk.driver().flush(); // Make sure we've seen the second update
-		errorRecorder.assertAllClear("after second refurbish");
-
-		LOGGER.debug("Verify bystander's state");
-		try (var _ = bystanderBosk.readSession()) {
-			actual = bystanderBosk.rootReference().value();
-			assertEquals(expected, actual);
-		}
-
-		LOGGER.debug("Update state to make sure both bosks are still live");
-		var refurbishRefs = refurbishBosk.buildReferences(Refs.class);
-		refurbishBosk.driver().submitReplacement(refurbishRefs.valuesString(), "new string");
-		refurbishBosk.driver().flush();
-		var expected2 = expected.withValues(Optional.of(expected.values().get().withString("new string")));
-		try (var _ = refurbishBosk.readSession()) {
-			assertEquals(expected2, refurbishBosk.rootReference().value(), "Refurbish bosk should see the change");
-		}
-		bystanderBosk.driver().flush();
-		try (var _ = bystanderBosk.readSession()) {
-			assertEquals(expected2, bystanderBosk.rootReference().value(), "Bystander bosk should see the change");
-		}
-		errorRecorder.assertAllClear("after update");
-
-	}
-
-	private static BsonDocument assertUniqueManifest(MongoCollection<BsonDocument> collection, String expectedID) {
-		try (MongoCursor<BsonDocument> cursor = findManifestDocs(collection)) {
-			assertTrue(cursor.hasNext(), "Manifest document must exist");
-			BsonDocument manifestDoc = cursor.next();
-			assertEquals(expectedID, manifestDoc.getString("_id").getValue(),
-				"Manifest document must still have legacy ID");
-			assertFalse(cursor.hasNext(), "Must be just one manifest");
-			return manifestDoc;
-		}
-	}
-
-	private static @NonNull MongoCursor<BsonDocument> findManifestDocs(MongoCollection<BsonDocument> collection) {
-		List<BsonString> manifestIDs = Stream.of(MANIFEST_ID, LEGACY_MANIFEST_ID).map(BsonString::new).toList();
-		return collection.find(new BsonDocument("_id",
-			new BsonDocument("$in", new BsonArray(manifestIDs))
-		)).cursor();
 	}
 
 	private void deleteFields(MongoCollection<Document> collection, Formatter.DocumentFields... fields) {

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -20,6 +20,7 @@ import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
-import works.bosk.BoskConfig.TenancyModel;
 import works.bosk.BoskDriver;
 import works.bosk.BoskDriver.EntireState;
 import works.bosk.Catalog;
@@ -116,19 +116,6 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		).map(b -> b.applyDriverSettings(s -> s
 			.timescaleMS(SHORT_TIMESCALE) // Note that some tests can take as long as 25x this
 		)).toList();
-	}
-
-	@Test
-	void multitenant_notSupported() {
-		assertThrows(IllegalArgumentException.class, ()-> new Bosk<>(
-			boskName("multitenant"),
-			TestEntity.class,
-			AbstractMongoDriverTest::initialState,
-			BoskConfig.<TestEntity>builder()
-				.tenancyModel(TenancyModel.PERSISTENT)
-				.driverFactory(driverFactory)
-				.build()
-		));
 	}
 
 	@Test
@@ -661,12 +648,12 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	@Test
 	void unrelatedDatabase_ignored() throws InvalidTypeException, IOException, InterruptedException {
 		tearDownActions.addFirst(mongoService.client().getDatabase("unrelated")::drop);
-		doUnrelatedChangeTest("unrelated", MainDriver.COLLECTION_NAME, rootDocumentID().getValue());
+		doUnrelatedChangeTest("unrelated", MainDriver.COLLECTION_NAME, plausibleRootDocumentID().getValue());
 	}
 
 	@Test
 	void unrelatedCollection_ignored() throws InvalidTypeException, IOException, InterruptedException {
-		doUnrelatedChangeTest(driverSettings.database(), "unrelated", rootDocumentID().getValue());
+		doUnrelatedChangeTest(driverSettings.database(), "unrelated", plausibleRootDocumentID().getValue());
 	}
 
 	@Test
@@ -771,7 +758,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		);
 		// Must also bump the revision number or else flush rightly does nothing
 		collection.updateOne(
-			new BsonDocument("_id", rootDocumentID()),
+			rootDocumentsFilter(),
 			new BsonDocument("$inc", new BsonDocument("revision", new BsonInt64(1)))
 		);
 
@@ -797,7 +784,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		MongoCollection<Document> collection = mongoService.client()
 			.getDatabase(driverSettings.database())
 			.getCollection(MainDriver.COLLECTION_NAME);
-		deleteFields(collection, Formatter.DocumentFields.path, Formatter.DocumentFields.revision);
+		deleteFields(collection, Formatter.DocumentFields.revision);
 
 		// Make the bosk whose refurbish operation we want to test
 		Bosk<TestEntity> bosk = new Bosk<>(
@@ -816,20 +803,18 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		deleteFields(collection, Formatter.DocumentFields.revision);
 
 		// Verify that the fields are indeed gone
-		BsonDocument filterDoc = new BsonDocument("_id", rootDocumentID());
+		BsonDocument filterDoc = rootDocumentsFilter();
 		try (MongoCursor<Document> cursor = collection.find(filterDoc).cursor()) {
 			Document doc = cursor.next();
-			assertNull(doc.get(Formatter.DocumentFields.path.name()));
 			assertNull(doc.get(Formatter.DocumentFields.revision.name()));
 		}
 
 		// Refurbish
 		bosk.getDriver(MongoDriver.class).refurbish();
 
-		// Verify the fields are all now there
+		// Verify the fields are now there
 		try (MongoCursor<Document> cursor = collection.find(filterDoc).cursor()) {
 			Document doc = cursor.next();
-			assertEquals("/", doc.get(Formatter.DocumentFields.path.name()));
 			assertEquals(1L, doc.getLong(Formatter.DocumentFields.revision.name()));
 		}
 
@@ -952,7 +937,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		for (Formatter.DocumentFields field: fields) {
 			fieldsToUnset.append(field.name(), BsonNull.VALUE); // Value is ignored
 		}
-		BsonDocument filterDoc = new BsonDocument("_id", rootDocumentID());
+		BsonDocument filterDoc = rootDocumentsFilter();
 		collection.updateOne(
 			filterDoc,
 			new BsonDocument("$unset", fieldsToUnset));
@@ -968,11 +953,15 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		errorRecorder.assertAllClear("after test");
 	}
 
+	private @NonNull BsonDocument rootDocumentsFilter() {
+		return new BsonDocument("path", new BsonString("/"));
+	}
+
 	@NotNull
-	private BsonString rootDocumentID() {
+	private BsonString plausibleRootDocumentID() {
 		return (MongoDriverSettings.DatabaseFormat.SEQUOIA == driverSettings.preferredDatabaseFormat())
 			? SequoiaFormatDriver.DOCUMENT_ID
-			: PandoFormatDriver.ROOT_DOCUMENT_ID;
+			: new BsonString("|"); // Not every PANDO mode uses this, but hey, it's plausible
 	}
 
 	/**

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/SchemaEvolutionTest.java
@@ -20,6 +20,7 @@ import works.bosk.Reference;
 import works.bosk.annotations.ReferencePath;
 import works.bosk.drivers.mongo.MongoDriver;
 import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.drivers.mongo.internal.MainDriver.ManifestInfo;
 import works.bosk.drivers.mongo.internal.SchemaEvolutionTest.ConfigInjector;
@@ -33,9 +34,6 @@ import works.bosk.testing.junit.Slow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
-import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestDocumentIdMode.LEGACY;
-import static works.bosk.drivers.mongo.MongoDriverSettings.ManifestDocumentIdMode.STANDARD;
-import static works.bosk.drivers.mongo.internal.MainDriver.LEGACY_MANIFEST_ID;
 import static works.bosk.drivers.mongo.internal.MainDriver.MANIFEST_ID;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
@@ -234,23 +232,17 @@ public class SchemaEvolutionTest {
 		);
 	}
 
-	record Configuration(
-		MongoDriverSettings.DatabaseFormat preferredFormat,
-		MongoDriverSettings.ManifestDocumentIdMode manifestDocumentIdMode
-	) {
+	record Configuration(DatabaseFormat preferredFormat) {
 		public ManifestInfo expectedManifestInfo() {
 			return new ManifestInfo(
 				Manifest.forFormat(preferredFormat),
-				switch (manifestDocumentIdMode) {
-					case LEGACY -> LEGACY_MANIFEST_ID;
-					case STANDARD -> MANIFEST_ID;
-				}
+				MANIFEST_ID
 			);
 		}
 
 		@Override
 		public String toString() {
-			return manifestDocumentIdMode.toString() + "+" + preferredFormat.toString();
+			return preferredFormat.toString();
 		}
 	}
 
@@ -270,10 +262,7 @@ public class SchemaEvolutionTest {
 		SEQUOIA,
 		PandoFormat.oneBigDocument(),
 		PandoFormat.withGraftPoints("/catalog", "/sideTable")
-	).flatMap(format -> Stream.of(
-		new Configuration(format, LEGACY),
-		new Configuration(format, STANDARD)
-	)).toList();
+	).map(Configuration::new).toList();
 
 	static final class Helper extends AbstractMongoDriverTest {
 		final String name;
@@ -282,7 +271,6 @@ public class SchemaEvolutionTest {
 			super(MongoDriverSettings.builder()
 				.database(SchemaEvolutionTest.class.getSimpleName() + "_" + dbCounter)
 				.preferredDatabaseFormat(config.preferredFormat())
-				.manifestDocumentIdMode(config.manifestDocumentIdMode())
 			);
 			this.name = config.preferredFormat().toString().toLowerCase(Locale.ROOT);
 		}

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -52,13 +52,13 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			actual = latecomer.entireState();
 		}
 		if (scenario.tenancyModel instanceof Fixed(var id)) {
-			// With Fixed tenancy, the same state can be represented as either
-			// SingleTree or MultiTree; normalize before comparing.
+			// Either a single tenant or NoTenant is ok. Normalize before comparing
 			TenantId tenantId = Tenant.setTo(id);
 			var e = PerTenant.from(expected, identity()).asNoTenant(tenantId);
 			var a = PerTenant.from(actual, identity()).asNoTenant(tenantId);
 			assertEquals(e, a);
 		} else {
+			// Must be exactly equal
 			assertEquals(expected, actual);
 		}
 	}


### PR DESCRIPTION
This is arranged in three commits:
1. Drop support for legacy manifests. That becomes increasingly annoying once we need to deal with the variety of documents introduced by this PR.
2. Add ceremony around multiple tenants, but don't actually store them in the database yet.
3. Store multiple tenants in the database.

## Breaking change

**This drops support for legacy manifest formats**. I've created release 0.2.150 as a compatibility release: its `refurbish()` operation can move an existing database to the modern manifest format as preparation for an upgrade that includes this PR.