### PR TITLE
Test tweaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ The usual Gradle commands, plus:
 - Tabs for indentation, except in formats like Markdown and YAML where tabs and spaces are not equivalent.
 - No wildcard imports.
 - Always use curly braces for conditionals and loops.
+  - Conditional guarded statements should be on their own line to facilitate breakpoints
 - Prefer if-then-else over early returns (to make subsequent refactoring easier) except in specific situations:
   - If there's an especially simple case, like errors or "already computed" one-liner cases, those can return early to avoid mixing with complex logic
 

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverStateVerifier.java
@@ -3,7 +3,9 @@ package works.bosk.testing.drivers;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,6 +26,7 @@ import works.bosk.StateTreeNode;
 import works.bosk.drivers.ContextScopeDriver;
 import works.bosk.drivers.ReplicaSet;
 import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.exceptions.NoSuchTenantException;
 import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.testing.drivers.operations.DriverOperation;
 import works.bosk.testing.drivers.operations.FlushOperation;
@@ -123,56 +126,70 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 		if (!(op.boskContext().tenant() instanceof Tenant.Established tenant)) {
 			throw new AssertionError("Missing tenant on update: " + op);
 		}
+		Object before;
+		Object after;
 		try (var _ = stateTrackingBosk.context().withTenant(tenant)) {
-			Object before = currentStateBefore(op);
-			Object after = hypotheticalStateAfter(op);
-			LOGGER.trace("\t\tbefore: {}", before);
-			LOGGER.trace("\t\t after: {}", after);
+			before = currentStateBefore(op);
+			after = newStateAfter(op);
+		} catch (IOException | InterruptedException e) {
+			throw new NotYetImplementedException(e);
+		}
+		LOGGER.trace("\t\tbefore: {}", before);
+		LOGGER.trace("\t\t after: {}", after);
 
-			String threadID = threadId(op);
-			if (threadID == null) {
-				LOGGER.debug("\tMissing " + THREAD_ID + " diagnostic attribute");
+		String threadID = threadId(op);
+		if (threadID == null) {
+			LOGGER.debug("\tMissing " + THREAD_ID + " diagnostic attribute");
+		} else {
+			Deque<UpdateOperation> q = pendingOperationsByThreadID.get(threadID);
+			if (q == null) {
+				LOGGER.debug("\tNo queued events for thread \"{}\"", threadID);
 			} else {
-				Deque<UpdateOperation> q = pendingOperationsByThreadID.get(threadID);
-				if (q == null) {
-					LOGGER.debug("\tNo queued events for thread \"{}\"", threadID);
-				} else {
-					LOGGER.trace("\tThread \"{}\" has {} queued operations", threadID, q.size());
-					for (UpdateOperation expected : q) {
-						Object expectedBefore = currentStateBefore(expected); // May not equal `before` if the two operations have different targets
-						Object expectedAfter = hypotheticalStateAfter(expected);
-						LOGGER.trace("\t\texpectedAfter: {}", expectedAfter);
-						if (op.matchesIfApplied(expected) && Objects.equals(after, expectedAfter)) {
-							LOGGER.debug("\tConclusion: found match: {}", expected);
-							var expectedTenant = expected.boskContext().tenant();
-							if (!(expectedTenant.equals(tenant))) {
-								throw new AssertionError(
-									"Operation has incorrect tenant " + tenant
-									+ "; expected " + expectedTenant);
-							}
-							UpdateOperation discarded;
-							while ((discarded = q.removeFirst()) != expected) {
-								LOGGER.trace("\t\tdiscard preceding no-op: {}", discarded);
-							}
-							expected.submitTo(stateTrackingDriver);
-							return;
-						} else if (Objects.equals(expectedBefore, expectedAfter)) {
-							LOGGER.trace("\t\tSkip queued no-op: {}", expected);
-						} else {
-							LOGGER.trace("\t\tNo match for: {}", expected);
-							break;
+				LOGGER.trace("\tThread \"{}\" has {} queued operations", threadID, q.size());
+				for (Iterator<UpdateOperation> it = q.iterator(); it.hasNext();) {
+					UpdateOperation expected = it.next();
+
+					if (op.matchesIfApplied(expected)) {
+						LOGGER.debug("\tConclusion: found match: {}", expected);
+						var expectedTenant = expected.boskContext().tenant();
+						if (!(expectedTenant.equals(tenant))) {
+							throw new AssertionError(
+								"Operation has incorrect tenant " + tenant
+								+ "; expected " + expectedTenant);
 						}
+						// expected is already the first element — preceding no-ops
+						// were removed via it.remove() above
+						q.removeFirst();
+						return;
 					}
+
+					// Not a match. Check if expected is a no-op.
+					Object expectedBefore;
+					Object expectedAfter;
+					try {
+						expectedBefore = currentStateBefore(expected);
+						expectedAfter = newStateAfter(expected);
+					} catch (IOException | InterruptedException e) {
+						throw new NotYetImplementedException(e);
+					}
+					if (Objects.equals(expectedBefore, expectedAfter)) {
+						LOGGER.trace("\t\tSkip queued no-op: {}", expected);
+						it.remove();
+						continue;
+					}
+
+					LOGGER.trace("\tNo match for: {}", expected);
+					break;
 				}
 			}
+		}
 
+		try (var _ = stateTrackingBosk.context().withTenant(tenant)) {
 			if (Objects.equals(before, after)) {
 				LOGGER.debug("\tConclusion: spontaneous no-op: {}", op);
 			} else {
 				throw new AssertionError("No matching operation\n\t" + op);
 			}
-		} catch (IOException | InterruptedException e) {
-			throw new NotYetImplementedException(e);
 		}
 	}
 
@@ -180,15 +197,18 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 	 * Before calling the downstream flush, the subject driver must first have sent
 	 * all the previous updates, so there should be no pending operations on any thread.
 	 */
-	private void preOutgoingFlush(FlushOperation op) {
+	private void preOutgoingFlush(FlushOperation op) throws IOException, InterruptedException {
 		LOGGER.debug("preOutgoingFlush()");
-		pendingOperationsByThreadID.forEach((thread, q) -> {
+		for (Entry<String, Deque<UpdateOperation>> entry : pendingOperationsByThreadID.entrySet()) {
+			String thread = entry.getKey();
+			Deque<UpdateOperation> q = entry.getValue();
+
 			discardLeadingNops(q);
 			if (!q.isEmpty()) {
 				throw new AssertionError(q.size() + " pending operations remain on thread " + thread
 					+ "\n\tFirst is: " + q.getFirst());
 			}
-		});
+		}
 
 		// Leave evidence that the flush indeed happened.
 		flushObservedByThreadID.add(threadId(op));
@@ -205,23 +225,19 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 		}
 	}
 
-	private void discardLeadingNops(Deque<UpdateOperation> q) {
-		try {
-			UpdateOperation op;
-			while ((op = q.peekFirst()) != null) {
-				Object before = currentStateBefore(op);
-				Object after = hypotheticalStateAfter(op);
-				if (Objects.equals(before, after)) {
-					LOGGER.debug("\tDiscarding nop: {}", op);
-					var removed = q.removeFirst();
-					assert op == removed;
-				} else {
-					LOGGER.trace("\tNext operation is not a nop: {}", op);
-					break;
-				}
+	private void discardLeadingNops(Deque<UpdateOperation> q) throws IOException, InterruptedException {
+		UpdateOperation op;
+		while ((op = q.peekFirst()) != null) {
+			Object before = currentStateBefore(op);
+			Object after = newStateAfter(op);
+			if (Objects.equals(before, after)) {
+				LOGGER.debug("\tDiscarding nop: {}", op);
+				var removed = q.removeFirst();
+				assert op == removed;
+			} else {
+				LOGGER.trace("\tNext operation is not a nop: {}", op);
+				break;
 			}
-		} catch (InterruptedException | IOException e) {
-			throw new NotYetImplementedException(e);
 		}
 	}
 
@@ -231,26 +247,23 @@ public final class DriverStateVerifier<R extends StateTreeNode> {
 			Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
 			stateTrackingBosk.driver().flush();
 			try (var _ = stateTrackingBosk.readSession()) {
-				return stateTrackingRef.valueIfExists();
+				try {
+					return stateTrackingRef.valueIfExists();
+				} catch (NoSuchTenantException e) {
+					return null;
+				}
 			}
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T> T hypotheticalStateAfter(UpdateOperation op) throws IOException, InterruptedException {
+	private <T> T newStateAfter(UpdateOperation op) throws IOException, InterruptedException {
 		try (var _ = stateTrackingBosk.context().withMaybeTenant(op.boskContext().tenant())) {
-			R originalState;
 			Reference<T> stateTrackingRef = (Reference<T>) stateTrackingRef(op.target());
-			stateTrackingBosk.driver().flush();
-			try (var _ = stateTrackingBosk.readSession()) {
-				originalState = stateTrackingBosk.rootReference().value();
-			}
 			op.submitTo(stateTrackingDriver);
 			stateTrackingBosk.driver().flush();
 			try (var _ = stateTrackingBosk.readSession()) {
 				return stateTrackingRef.valueIfExists();
-			} finally {
-				stateTrackingBosk.driver().submitReplacement(stateTrackingBosk.rootReference(), originalState);
 			}
 		}
 	}

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/ReportingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/ReportingDriver.java
@@ -37,17 +37,17 @@ public class ReportingDriver implements BoskDriver {
 	final BoskDriver downstream;
 	final BoskContext context;
 	final Consumer<? super UpdateOperation> updateListener;
-	final Consumer<? super FlushOperation> preFlushListener;
-	final Consumer<? super FlushOperation> postFlushListener;
+	final FlushOperation.Consumer preFlushListener;
+	final FlushOperation.Consumer postFlushListener;
 
 	/**
 	 * Builds a driver that reports all updates and flushes to the given listener before sending them to the downstream driver.
 	 */
 	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<? super DriverOperation> listener) {
-		return (b,d) -> new ReportingDriver(d, b.context(), listener, listener, _->{});
+		return (b,d) -> new ReportingDriver(d, b.context(), listener, listener::accept, _->{});
 	}
 
-	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<? super UpdateOperation> updateListener, Consumer<? super FlushOperation> preFlushListener, Consumer<? super FlushOperation> postFlushListener) {
+	public static <RR extends StateTreeNode> DriverFactory<RR> factory(Consumer<? super UpdateOperation> updateListener, FlushOperation.Consumer preFlushListener, FlushOperation.Consumer postFlushListener) {
 		return (b,d) -> new ReportingDriver(d, b.context(), updateListener, preFlushListener, postFlushListener);
 	}
 

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -8,7 +8,7 @@ import works.bosk.BoskConfig.TenancyModel.Persistent;
 import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.BoskDriver.EntireState;
-import works.bosk.testing.BoskTestUtils;
+import works.bosk.DriverFactory;
 import works.bosk.testing.drivers.state.TestEntity;
 import works.bosk.util.PerTenant;
 
@@ -16,27 +16,53 @@ import static java.util.function.Function.identity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static works.bosk.testing.BoskTestUtils.boskName;
 
 /**
- * Tests the ability of a driver to share state between two bosks.
+ * Tests the ability of a driver to share state between multiple Bosks.
+ * <p>
+ * Each call to {@link #assertCorrectBoskContents()} checks two additional
+ * bosks: one long-lived one, and one that is newly created immediately before
+ * the assertion.
  */
 public abstract class SharedDriverConformanceTest extends DriverConformanceTest {
 	final TenantId tenant1 = Tenant.setTo(TENANT1);
 	final TenantId tenant2 = Tenant.setTo(TENANT2);
 
+	Bosk<TestEntity> remoteBosk;
+
 	@Override
-	protected void assertCorrectBoskContents() {
-		super.assertCorrectBoskContents();
-		var latecomer = new Bosk<>(
-			BoskTestUtils.boskName("latecomer"),
+	protected void setupBosksAndReferences(DriverFactory<TestEntity> driverFactory) {
+		super.setupBosksAndReferences(driverFactory);
+		remoteBosk = new Bosk<>(
+			boskName("remote"),
 			TestEntity.class,
 			this::initialState,
 			BoskConfig.<TestEntity>builder()
 				.driverFactory(driverFactory)
 				.tenancyModel(scenario.tenancyModel)
 				.build());
+	}
+
+	@Override
+	protected void assertCorrectBoskContents() {
+		super.assertCorrectBoskContents();
+		assertSameBoskContents(remoteBosk);
+
+		var latecomer = new Bosk<>(
+			boskName("latecomer"),
+			TestEntity.class,
+			this::initialState,
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(driverFactory)
+				.tenancyModel(scenario.tenancyModel)
+				.build());
+		assertSameBoskContents(latecomer);
+	}
+
+	private void assertSameBoskContents(Bosk<TestEntity> otherBosk) {
 		try {
-			latecomer.driver().flush();
+			otherBosk.driver().flush();
 		} catch (Exception e) {
 			throw new AssertionError("Unexpected exception", e);
 		}
@@ -47,9 +73,9 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			expected = canonicalBosk.entireState();
 		}
 		try (
-			var _ = latecomer.readSession()
+			var _ = otherBosk.readSession()
 		) {
-			actual = latecomer.entireState();
+			actual = otherBosk.entireState();
 		}
 		if (scenario.tenancyModel instanceof Fixed(var id)) {
 			// Either a single tenant or NoTenant is ok. Normalize before comparing

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/FlushOperation.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/operations/FlushOperation.java
@@ -11,4 +11,8 @@ public record FlushOperation(
 	public void submitTo(BoskDriver driver) throws IOException, InterruptedException {
 		driver.flush();
 	}
+
+	public interface Consumer {
+		void accept(FlushOperation op) throws IOException, InterruptedException;
+	}
 }


### PR DESCRIPTION
- Change `DriverStateVerifier` so it doesn't rely on rollback, making its interactions with the Bosk simpler
- Add a long-lived remote bosk to `SharedDriverConformanceTest` adding coverage of the common case (long-lived state sharing) and not just the "latecomer" scenario