### PR TITLE
Wait for logback to initialize before RecordingTurboFilterCaptureTest

### DIFF
--- a/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterCaptureTest.java
+++ b/bosk-logback/src/test/java/works/bosk/logback/RecordingTurboFilterCaptureTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.slf4j.helpers.SubstituteLoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,8 +19,11 @@ public class RecordingTurboFilterCaptureTest {
 	private RecordingTurboFilter filter;
 
 	@BeforeAll
-	static void initializeLogging() {
-		LoggerFactory.getLogger(RecordingTurboFilterCaptureTest.class);
+	static void initializeLogging() throws InterruptedException {
+		// Logback offers no known way to wait for initialization to finish before running tests!
+		while (LoggerFactory.getILoggerFactory() instanceof SubstituteLoggerFactory) {
+			Thread.sleep(100);
+		}
 	}
 
 	@BeforeEach


### PR DESCRIPTION
Logback seems pretty flaky when it comes to initialization.