### PR TITLE
Fix mongo multitenancy with unchanged diagnostics

### DIFF
--- a/bosk-mongo/DEVELOPERS.md
+++ b/bosk-mongo/DEVELOPERS.md
@@ -34,6 +34,11 @@ since the change stream will include all updates from all drivers; and
 persistence is achieved by having
 `MongoDriver` read the initial bosk state from the database during `Bosk` initialization (in the `initialRoot` method).
 
+Note in particular that there must be no direct connection between the `MongoDriver` update methods and the downstream driver:
+updates are always propagated downstream driven by change stream events.
+(The `initialState` and `flush` methods are different: they're not update methods
+and they are inherently synchronous.)
+
 While conceptually simple, the real complexity lies in fault tolerance.
 An important goal of `MongoDriver` is that if the database is somehow damaged and then repaired,
 `MongoDriver` should recover and resume normal operation without any intervention.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -75,6 +75,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 */
 	final AtomicReference<PerTenant<FlushLock>> flushLocks = new AtomicReference<>(null);
 
+	final DocumentFieldTracker fieldTracker = new DocumentFieldTracker();
 	final FlushLock contentsFlushLock;
 
 	public AbstractFormatDriver(
@@ -101,7 +102,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	@Override
 	public MongoStatus readStatus() {
 		try {
-			PerTenant<BsonStateAndMetadata> dbStates = loadBsonStateAndMetadata();
+			PerTenant<BsonStateAndMetadata> dbStates = readBsonStateAndMetadata();
 			var entireState = entireStateSupplier.get();
 			var inMemoryBsonValues = PerTenant.from(entireState,
 				r -> formatter.object2bsonValue(r, rootRef.targetType()));
@@ -135,12 +136,14 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	@Override
 	public PerTenant<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException {
 		try {
-			PerTenant<BsonStateAndMetadata> bsonStateAndMetadata = loadBsonStateAndMetadata();
+			PerTenant<BsonStateAndMetadata> bsonStateAndMetadata = readBsonStateAndMetadata();
 			ensureFlushLocksInitialized(bsonStateAndMetadata);
 			return bsonStateAndMetadata.map((Established _, BsonStateAndMetadata bsm) -> {
 				if (bsm.state() == null) {
 					throw new TunneledCheckedException(new IOException("No existing state in document"));
 				}
+
+				fieldTracker.process(bsm);
 
 				R root = formatter.document2object(bsm.state(), rootRef);
 				BsonInt64 revision = bsm.revision() == null ? REVISION_ZERO : bsm.revision();
@@ -217,7 +220,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * @return the contents of the database; fields of the returned
 	 * record can be null if they don't exist in the database.
 	 */
-	abstract PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() throws InvalidCollectionContentsException;
+	abstract PerTenant<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException;
 
 	protected BsonDocument blankUpdateDoc() {
 		return new BsonDocument()
@@ -446,6 +449,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * Low-level version of {@link StateAndMetadata}.
 	 */
 	record BsonStateAndMetadata(
+		BsonString _id,
 		BsonDocument state,
 		BsonInt64 revision,
 		BsonDocument diagnosticAttributes

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
@@ -292,7 +292,7 @@ class ChangeReceiver implements Closeable {
 		}
 	}
 
-	private synchronized void processEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
+	private void processEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		if (settings.testing().eventDelayMS() > 0) {
 			LOGGER.debug("| eventDelayMS {}ms ", settings.testing().eventDelayMS());
 			try {
@@ -308,7 +308,9 @@ class ChangeReceiver implements Closeable {
 				case UPDATE:
 				case REPLACE:
 				case DELETE:
-					listener.onEvent(event);
+					synchronized (this) {
+						listener.onEvent(event);
+					}
 					break;
 				case RENAME:
 				case DROP:

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
@@ -38,7 +38,14 @@ import static works.bosk.logging.MappedDiagnosticContext.setupMDC;
  * Houses a background thread that repeatedly initializes, processes, and closes a change stream cursor.
  * Ideally, the opening and closing happen just once, but they're done in a loop for fault tolerance,
  * so that the driver can reinitialize if certain unusual conditions arise.
- *
+ * <p>
+ * This object's monitor is acquired while processing each event,
+ * so other operations that must occur atomically with respect to event processing
+ * can synchronize on this object.
+ * Note that when the monitor is released, event processing will resume with an event
+ * received before or during that other operation,
+ * so the other operation must leave the driver in a state where such events are
+ * correctly handled or ignored.
  * <p>
  * We're maintaining an in-memory replica of database state, and so
  * the loading of database state and the subsequent handling of events are inherently coupled.
@@ -285,7 +292,7 @@ class ChangeReceiver implements Closeable {
 		}
 	}
 
-	private void processEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
+	private synchronized void processEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
 		if (settings.testing().eventDelayMS() > 0) {
 			LOGGER.debug("| eventDelayMS {}ms ", settings.testing().eventDelayMS());
 			try {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/ChangeReceiver.java
@@ -4,6 +4,7 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInterruptedException;
 import com.mongodb.MongoTimeoutException;
+import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
@@ -54,10 +55,10 @@ class ChangeReceiver implements Closeable {
 	private final Identifier boskID;
 	private final ChangeListener listener;
 	private final MongoDriverSettings settings;
-	private final MongoCollection<BsonDocument> collection;
 	private final Thread.Builder threadBuilder = Thread.ofPlatform().name("bosk-mongo-change-receiver");
 	private final ScheduledExecutorService ex = Executors.newScheduledThreadPool(1, threadBuilder::unstarted);
 	private final Exception creationPoint;
+	private final ChangeStreamIterable<BsonDocument> changeStreamIterable;
 	private volatile @Nullable Thread thread = null;
 	private volatile boolean isClosed = false;
 
@@ -66,8 +67,8 @@ class ChangeReceiver implements Closeable {
 		this.boskID = boskID;
 		this.listener = listener;
 		this.settings = settings;
-		this.collection = collection;
 		this.creationPoint = new Exception("Additional context: ChangeReceiver creation stack trace:");
+		this.changeStreamIterable = collection.watch();
 		if (settings.initialDatabaseUnavailableMode() == FAIL_FAST) {
 			// User requested fail-fast behaviour; try to open the cursor right away
 			// to ensure the database is set up for change streams.
@@ -240,9 +241,7 @@ class ChangeReceiver implements Closeable {
 	}
 
 	private MongoChangeStreamCursor<ChangeStreamDocument<BsonDocument>> openCursor() {
-		MongoChangeStreamCursor<ChangeStreamDocument<BsonDocument>> result = collection
-			.watch()
-			.cursor();
+		var result = changeStreamIterable.cursor();
 		LOGGER.debug("Cursor is open");
 		return result;
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DocumentFieldTracker.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DocumentFieldTracker.java
@@ -1,0 +1,112 @@
+package works.bosk.drivers.mongo.internal;
+
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.UpdateDescription;
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import works.bosk.drivers.mongo.internal.AbstractFormatDriver.BsonStateAndMetadata;
+
+import static works.bosk.drivers.mongo.internal.DocumentFieldTracker.TrackedField.DIAGNOSTICS;
+
+/**
+ * Tracks certain document fields across change stream events for a single collection.
+ * <p>
+ * MongoDB does not include unchanged fields in change stream events.
+ * For fields that we need even when they haven't changed, we must keep track of them ourselves.
+ */
+@NullMarked
+final class DocumentFieldTracker {
+	private final ConcurrentHashMap<BsonValue, EnumMap<TrackedField, BsonValue>> fieldsByDocId = new ConcurrentHashMap<>();
+
+	enum TrackedField {
+		DIAGNOSTICS;
+
+		final String fieldName;
+		TrackedField() { this.fieldName = name().toLowerCase(Locale.ROOT); }
+	}
+
+	@Nullable BsonValue getField(BsonValue documentId, TrackedField field) {
+		var fields = fieldsByDocId.get(documentId);
+		return fields == null ? null : fields.get(field);
+	}
+
+	@Nullable BsonDocument getFieldAsDocument(BsonValue documentId, TrackedField field) {
+		var fields = fieldsByDocId.get(documentId);
+		if (fields == null) {
+			return null;
+		}
+		BsonValue result = fields.get(field);
+		if (result == null) {
+			return null;
+		}
+		return result.asDocument();
+	}
+
+	/**
+	 * Infers the latest values of tracked fields from a change stream event.
+	 */
+	public void processEvent(ChangeStreamDocument<BsonDocument> event) {
+		if (event.getDocumentKey() == null) {
+			return;
+		}
+		BsonValue rawId = event.getDocumentKey().get("_id");
+		switch (event.getOperationType()) {
+			case INSERT, REPLACE -> trackFields(rawId, event.getFullDocument());
+			case UPDATE -> processUpdateEvent(rawId, event);
+			case DELETE -> fieldsByDocId.remove(rawId);
+			case DROP, DROP_DATABASE -> fieldsByDocId.clear();
+			case null, default -> { /* OTHER, INVALIDATE — ignore */ }
+		}
+	}
+
+	/**
+	 * Infers the latest values of tracked fields from the containing document.
+	 */
+	public void processDocument(BsonDocument fullDocument) {
+		trackFields(fullDocument.get("_id"), fullDocument);
+	}
+
+	public void process(BsonStateAndMetadata bsm) {
+		// The easiest way to deal with a BsonStateAndMetadata is to fake up a document with the fields we care about
+		processDocument(new BsonDocument()
+			.append("_id", bsm._id())
+			.append(DIAGNOSTICS.fieldName, bsm.diagnosticAttributes())
+		);
+	}
+
+	private void processUpdateEvent(BsonValue docId, ChangeStreamDocument<BsonDocument> event) {
+		UpdateDescription updateDescription = event.getUpdateDescription();
+		if (updateDescription != null) {
+			trackFields(docId, updateDescription.getUpdatedFields());
+			var toRemove = updateDescription.getRemovedFields();
+			var fields = fieldsByDocId.get(docId);
+			if (toRemove != null && fields != null) {
+				toRemove.forEach(fieldName -> {
+					for (var field : TrackedField.values()) {
+						if (field.fieldName.equals(fieldName)) {
+							fields.remove(field);
+						}
+					}
+				});
+			}
+		}
+	}
+
+	private void trackFields(BsonValue docId, @Nullable BsonDocument fieldsDocument) {
+		if (fieldsDocument == null) {
+			return;
+		}
+		EnumMap<DocumentFieldTracker.TrackedField, BsonValue> fields = fieldsByDocId.computeIfAbsent(docId, _ -> new EnumMap<>(TrackedField.class));
+		for (var field : TrackedField.values()) {
+			BsonValue value = fieldsDocument.get(field.fieldName, null);
+			if (value != null) {
+				fields.put(field, value);
+			}
+		}
+	}
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -43,9 +43,22 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 * updates the driver's internal state in the expectation that the loaded state
 	 * is to be considered the "current" state with respect to subsequent change stream events.
 	 * <p>
+	 * This method should be called from the {@link ChangeReceiver} thread so that
+	 * the ordering with respect to change stream events is well-defined.
+	 * Otherwise, use the receiver's monitor to ensure the appropriate logic
+	 * occurs atomically with respect to change stream event processing.
+	 * <p>
 	 * This method can assume the manifest exists and indicates the appropriate format;
 	 * manifest creation/validation is handled elsewhere, and if this assumption is violated for whatever
 	 * reason, {@code InvalidCollectionContentsException} is an acceptable exception to throw.
+	 * <p>
+	 * <em>Maintenance note:</em> This method's contract is pretty weird,
+	 * especially with its side effect. It's a struggle to make a clean separation
+	 * between the format driver and the main driver, and this particular compromise
+	 * was a consequence of encapsulating the revision number logic inside the format driver.
+	 * Hopefully some day we can arrive at a cleaner interface.
+	 * In the meantime, we've tried to hint at the significance by
+	 * calling this operation "load" instead of just "read".
 	 *
 	 * @throws InvalidCollectionContentsException if the collection contents don't match the declared format
 	 */

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -39,7 +39,9 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException;
 
 	/**
-	 * Loads the entire collection contents.
+	 * Reads all state documents in the entire collection and, as a side effect,
+	 * updates the driver's internal state in the expectation that the loaded state
+	 * is to be considered the "current" state with respect to subsequent change stream events.
 	 * <p>
 	 * This method can assume the manifest exists and indicates the appropriate format;
 	 * manifest creation/validation is handled elsewhere, and if this assumption is violated for whatever

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
@@ -44,12 +44,6 @@ import static works.bosk.ReferenceUtils.rawClass;
  */
 final class Formatter extends BsonFormatter {
 
-	/**
-	 * If the diagnostic attributes are identical from one update to the next,
-	 * MongoDB won't send them. This field retains the last value so we can
-	 * always set the correct context for each downstream operation.
-	 */
-	private volatile MapValue<String> lastEventDiagnosticAttributes = MapValue.empty();
 	private final Codec<?> manifestCodec = codecFor(Manifest.class);
 
 	Formatter(BoskInfo<?> boskInfo, BsonSerializer bsonSerializer) {
@@ -211,10 +205,6 @@ final class Formatter extends BsonFormatter {
 		return fullDocument.getInt64(DocumentFields.revision.name(), null);
 	}
 
-	@NonNull MapValue<String> eventDiagnosticAttributesFromFullDocument(BsonDocument fullDocument) {
-		return getOrSetEventDiagnosticAttributes(getDiagnosticAttributesFromFullDocument(fullDocument));
-	}
-
 	MapValue<String> getDiagnosticAttributesFromFullDocument(BsonDocument fullDocument) {
 		BsonDocument diagnostics = getDiagnosticAttributesIfAny(fullDocument);
 		return diagnostics == null ? null : decodeDiagnosticAttributes(diagnostics);
@@ -226,10 +216,6 @@ final class Formatter extends BsonFormatter {
 			return null;
 		}
 		return updatedFields.getInt64(DocumentFields.revision.name(), null);
-	}
-
-	@NonNull MapValue<String> eventDiagnosticAttributesFromUpdate(ChangeStreamDocument<BsonDocument> event) {
-		return getOrSetEventDiagnosticAttributes(getDiagnosticAttributesFromUpdateEvent(event));
 	}
 
 	MapValue<String> getDiagnosticAttributesFromUpdateEvent(ChangeStreamDocument<BsonDocument> event) {
@@ -270,16 +256,6 @@ final class Formatter extends BsonFormatter {
 			return null;
 		}
 		return fullDocument.getDocument(DocumentFields.diagnostics.name(), null);
-	}
-
-	@NonNull private MapValue<String> getOrSetEventDiagnosticAttributes(MapValue<String> fromEvent) {
-		if (fromEvent == null) {
-			LOGGER.debug("No diagnostic attributes in event; assuming they are unchanged");
-			return lastEventDiagnosticAttributes;
-		} else {
-			lastEventDiagnosticAttributes = fromEvent;
-			return fromEvent;
-		}
 	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Formatter.class);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -367,27 +367,35 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	 * Refurbish is the one operation that always <em>must</em> happen in a transaction,
 	 * or else we could fail after deleting the existing contents but before rewriting them,
 	 * which would be catastrophic.
+	 *
+	 * <em<>Design note:</em> This operation shouldn't do any special coordination with
+	 * the receiver/listener system, because other replicas won't.
+	 * That system needs to cope with refurbish operations without any help.
 	 */
 	private void refurbishTransaction() throws IOException {
 		queryCollection.ensureTransactionStarted();
 		LOGGER.debug("Refurbishing to {}", driverSettings.preferredDatabaseFormat());
 		try {
-			// Design note: this operation shouldn't do any special coordination with
-			// the receiver/listener system, because other replicas won't.
-			// That system needs to cope with refurbish operations without any help.
-			PerTenant<StateAndMetadata<R>> result = formatDriver.loadAllState();
-			FormatDriver<R> newFormatDriver = newPreferredFormatDriver();
+			FormatDriver<R> newFormatDriver;
 
-			// initializeCollection is required to replace the manifest anyway,
-			// so deleting it has no value; and if we do delete it, then every
-			// FormatDriver must cope with deletions of the manifest document
-			// to avoid disconnection during refurbish operations,
-			// which is a burden. Let's just not.
-			BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
-			LOGGER.trace("Deleting state documents: {}", deletionFilter);
-			queryCollection.deleteMany(deletionFilter);
+			// The calls to loadAllState and initializeCollection must occur atomically
+			// with respect to event processing, because both of them have side effects
+			// that affect event processing (field tracking and flush locks, respectively).
+			synchronized (receiver) {
+				PerTenant<StateAndMetadata<R>> result = formatDriver.loadAllState();
+				newFormatDriver = newPreferredFormatDriver();
 
-			newFormatDriver.initializeCollection(result);
+				// initializeCollection is required to replace the manifest anyway,
+				// so deleting it has no value; and if we do delete it, then every
+				// FormatDriver must cope with deletions of the manifest document
+				// to avoid disconnection during refurbish operations,
+				// which is a burden. Let's just not.
+				BsonDocument deletionFilter = new BsonDocument("_id", new BsonDocument("$ne", MANIFEST_ID));
+				LOGGER.trace("Deleting state documents: {}", deletionFilter);
+				queryCollection.deleteMany(deletionFilter);
+
+				newFormatDriver.initializeCollection(result);
+			}
 
 			// We must rudely commit the transaction here, since correctness requires that
 			// the database updates commit before we publish newFormatDriver.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -73,6 +73,7 @@ import static org.bson.BsonBoolean.TRUE;
 import static works.bosk.Path.parseParameterized;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.docBsonPath;
 import static works.bosk.drivers.mongo.internal.BsonSurgeon.BSON_PATH_FIELD;
+import static works.bosk.drivers.mongo.internal.DocumentFieldTracker.TrackedField.DIAGNOSTICS;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_BEFORE_ANY;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
 import static works.bosk.drivers.mongo.internal.Formatter.getTenantFromDocumentId;
@@ -174,7 +175,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	PerTenant<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		// Read the !contents document to get the authoritative tenant list
 		Set<TenantId> contentsTenants = readContentsTenants();
 
@@ -202,7 +203,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// Pull what we need from the parts before gather() mutates them
 					BsonInt64 revision = lastPart.getInt64(DocumentFields.revision.name(), null);
 					BsonDocument diagnosticAttributes = Formatter.getDiagnosticAttributesIfAny(lastPart);
-					Established documentTenant = getTenantFromDocumentId(lastPart.getString("_id"));
+					BsonString id = lastPart.getString("_id");
+					Established documentTenant = getTenantFromDocumentId(id);
 
 					// Skip tenants that are not in the !contents list (they've been deleted)
 					if (documentTenant instanceof TenantId tid && !contentsTenants.contains(tid)) {
@@ -219,6 +221,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// but that's ok because we're not going to use it as the tenant ID anyway.
 					// This is just a way of describing what we've found in the database.
 					states.put(documentTenant, new BsonStateAndMetadata(
+						id,
 						state,
 						revision,
 						diagnosticAttributes
@@ -470,6 +473,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	 */
 	@Override
 	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
+		fieldTracker.processEvent(event);
 		assert event.getDocumentKey() != null;
 		BsonValue bsonDocumentID = event.getDocumentKey().get("_id");
 		if (isManifestID(bsonDocumentID)) {
@@ -556,7 +560,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 				// Grab the tenant and diagnostics early. If we're supposed to skip this event,
 				// we still need to stash the tenant for later events.
-				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
+				BsonString docId = finalEvent.getDocumentKey().getString("_id");
+				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
+				MapValue<String> diagnosticAttributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
 
 				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
 				if (shouldSkip(tenant, revision)) {
@@ -592,7 +598,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					LOGGER.debug("Skipping revision {}", revision.longValue());
 					return;
 				}
-				MapValue<String> attributes = formatter.eventDiagnosticAttributesFromUpdate(finalEvent);
+				BsonString docId = finalEvent.getDocumentKey().getString("_id");
+				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
+				MapValue<String> attributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
 				try (
 					var _ = context.withTenant(tenant);
 					var _ = context.withOnly(attributes)
@@ -665,7 +673,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			var event = tenantEvents.get(i);
 			BsonValue id = event.getDocumentKey().get("_id");
 			if (id instanceof BsonString s && s.getValue().startsWith(tenantPrefix)) {
-				return formatter.eventDiagnosticAttributesFromUpdate(event);
+				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(s, DIAGNOSTICS);
+				return attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
 			}
 		}
 		return MapValue.empty();

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -112,7 +112,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	PerTenant<BsonStateAndMetadata> loadBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	PerTenant<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
 			.find(documentFilter())
@@ -120,16 +120,15 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			.cursor()
 		) {
 			BsonDocument document = cursor.next();
-			// Saves the tenant info for subsequent events
-			tenantFor(document.getString("_id"));
 			var bsm = new BsonStateAndMetadata(
+				document.getString("_id"),
 				document.getDocument(DocumentFields.state.name(), null),
 				document.getInt64(DocumentFields.revision.name(), null),
 				Formatter.getDiagnosticAttributesIfAny(document)
 			);
 			return switch (tenancyModel) {
 				case None _ -> NoTenant.just(bsm);
-				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), bsm);
+				case Fixed(var tenantId) -> MultiTenant.singleton(Tenant.setTo(tenantId), bsm);
 				case Explicit _ -> throw new NotYetImplementedException();
 			};
 		} catch (NoSuchElementException e) {
@@ -194,6 +193,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	 */
 	@Override
 	public void onEvent(ChangeStreamDocument<BsonDocument> event) throws UnprocessableEventException {
+		fieldTracker.processEvent(event);
 		assert event.getDocumentKey() != null;
 		if (isManifestID(event.getDocumentKey().get("_id"))) {
 			/* We're required to cope with anything we might ourselves do in {@link #initializeCollection},
@@ -222,7 +222,9 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					// also REPLACE. That would imply that this case is impossible.
 					throw new UnprocessableEventException("Missing fullDocument", event.getOperationType());
 				}
-				MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromFullDocument(fullDocument);
+				BsonString docId = event.getDocumentKey().getString("_id");
+				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DocumentFieldTracker.TrackedField.DIAGNOSTICS);
+				MapValue<String> diagnosticAttributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
 				try (
 					var _ = context.withTenant(tenant);
 					var _ = context.withOnly(diagnosticAttributes)
@@ -246,7 +248,9 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				if (updateDescription != null) {
 					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
 					if (!shouldSkip(tenant, revision)) {
-						MapValue<String> diagnosticAttributes = formatter.eventDiagnosticAttributesFromUpdate(event);
+						BsonString updateDocId = event.getDocumentKey().getString("_id");
+						BsonDocument updateAttrsBson = fieldTracker.getFieldAsDocument(updateDocId, DocumentFieldTracker.TrackedField.DIAGNOSTICS);
+						MapValue<String> diagnosticAttributes = updateAttrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(updateAttrsBson);
 						try (
 							var _ = context.withTenant(tenant);
 							var _ = context.withOnly(diagnosticAttributes)

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
@@ -16,11 +16,13 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.BoskConfig;
+import works.bosk.BoskConfig.TenancyModel.Explicit;
 import works.bosk.BoskConfig.TenancyModel.Implicit;
 import works.bosk.BoskContext;
 import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.BoskDriver;
+import works.bosk.BoskDriver.EntireState;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
 import works.bosk.DriverFactory;
@@ -58,8 +60,10 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
 import static works.bosk.util.Classes.listValue;
 import static works.bosk.util.Classes.mapValue;
@@ -85,6 +89,9 @@ import static works.bosk.util.ReflectionHelpers.boxedClass;
 public abstract class DriverConformanceTest extends AbstractDriverTest {
 	// Subclass can initialize this as desired
 	protected DriverFactory<TestEntity> driverFactory;
+
+	final TenantId tenant1 = Tenant.setTo(TENANT1);
+	final TenantId tenant2 = Tenant.setTo(TENANT2);
 
 	public interface Refs {
 		@ReferencePath("/id") Reference<Identifier> rootID();
@@ -722,6 +729,60 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 			}
 		}
 		assertCorrectBoskContents();
+	}
+
+	@Test
+	void multiTenant_keepsTenantStateSeparate() throws Exception {
+		setupBosksAndReferences(driverFactory);
+
+		// Note: do this assume after the setup is done, or cleanup will crash!
+		assumeTrue(scenario.tenancyModel instanceof Explicit);
+
+		closeTenantScope();
+
+		EntireState.MultiTree<TestEntity> expectedState = (EntireState.MultiTree<TestEntity>) initialState(bosk);
+		assertNotEquals(
+			expectedState.tenantRoots().get(tenant1),
+			expectedState.tenantRoots().get(tenant2),
+			"Meta-assertion: the tests won't detect problems if the tenant states are indistinguishable");
+
+		try (var _ = bosk.readSession()) {
+			assertEquals(expectedState, bosk.entireState(), "Entire state should be correct");
+
+			// Check that each tenant has its own state
+			try (var _ = bosk.context().withTenant(tenant1)) {
+				var expected = expectedState.tenantRoots().get(tenant1);
+				assertEquals(expected, bosk.rootReference().value());
+			}
+
+			try (var _ = bosk.context().withTenant(tenant2)) {
+				var expected = expectedState.tenantRoots().get(tenant2);
+				assertEquals(expected, bosk.rootReference().value());
+			}
+		}
+
+		// Change them in different ways
+
+		Refs refs = bosk.buildReferences(Refs.class);
+		try (var _ = bosk.context().withTenant(tenant1)) {
+			driver.submitReplacement(refs.string(), "new tenant1 string");
+		}
+		try (var _ = bosk.context().withTenant(tenant2)) {
+			driver.submitReplacement(refs.string(), "new tenant2 string");
+		}
+		driver.flush();
+
+		// Ensure each tenant sees its own change
+
+		try (var _ = bosk.readSession()) {
+			try (var _ = bosk.context().withTenant(tenant1)) {
+				assertEquals("new tenant1 string", refs.string().value());
+			}
+
+			try (var _ = bosk.context().withTenant(tenant2)) {
+				assertEquals("new tenant2 string", refs.string().value());
+			}
+		}
 	}
 
 	private Reference<TestValues> initializeBoskWithBlankValues(@EnclosingCatalog Path enclosingCatalogPath) throws InvalidTypeException {

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -1,5 +1,6 @@
 package works.bosk.testing.drivers;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import works.bosk.Bosk;
 import works.bosk.BoskConfig;
@@ -14,7 +15,6 @@ import works.bosk.util.PerTenant;
 
 import static java.util.function.Function.identity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
@@ -26,9 +26,6 @@ import static works.bosk.testing.BoskTestUtils.boskName;
  * the assertion.
  */
 public abstract class SharedDriverConformanceTest extends DriverConformanceTest {
-	final TenantId tenant1 = Tenant.setTo(TENANT1);
-	final TenantId tenant2 = Tenant.setTo(TENANT2);
-
 	Bosk<TestEntity> remoteBosk;
 
 	@Override
@@ -89,58 +86,55 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 		}
 	}
 
+	/**
+	 * Don't get confused! This test has two bosks <em>and</em> two tenants.
+	 * <p>
+	 * The single-bosk version of this test would also be valid,
+	 * but this particular one is a regression test for a bug that required two bosks.
+	 */
 	@Test
-	void multiTenant_replicatesStateAcrossTenants() throws Exception {
+	void multiTenant_unchangedDiagnostics_propagateCorrectly() throws Exception {
 		setupBosksAndReferences(driverFactory);
-		Refs refs = bosk.buildReferences(Refs.class);
-
-		// Note: do this assume after the setup is done, or cleanup will crash!
 		assumeTrue(scenario.tenancyModel instanceof Explicit);
+		closeTenantScope();
 
-		tenantScope.close();
-		tenantScope = null;
+		Refs refs = bosk.buildReferences(Refs.class);
+		Refs remoteRefs = remoteBosk.buildReferences(Refs.class);
+		AtomicBoolean hooksArmed = new AtomicBoolean(false);
 
-		EntireState.MultiTree<TestEntity> expectedState = (EntireState.MultiTree<TestEntity>) initialState(bosk);
-		assertNotEquals(
-			expectedState.tenantRoots().get(tenant1),
-			expectedState.tenantRoots().get(tenant2),
-			"Meta-assertion: the tests won't detect problems if the tenant states are indistinguishable");
-
-		try (var _ = bosk.readSession()) {
-			assertEquals(expectedState, bosk.entireState(), "Entire state should be correct");
-
-			// Check that each tenant has its own state
-			try (var _ = bosk.context().withTenant(tenant1)) {
-				var expected = expectedState.tenantRoots().get(tenant1);
-				assertEquals(expected, bosk.rootReference().value());
+		bosk.hookRegistrar().registerHook("Verify attribute value", refs.string(), _ -> {
+			if (hooksArmed.get()) {
+				var tenant = bosk.context().getTenantId();
+				assertEquals(tenant.tenant().toString(), bosk.context().getAttribute("testKey"));
 			}
-
-			try (var _ = bosk.context().withTenant(tenant2)) {
-				var expected = expectedState.tenantRoots().get(tenant2);
-				assertEquals(expected, bosk.rootReference().value());
+		});
+		remoteBosk.hookRegistrar().registerHook("Verify attribute value", remoteRefs.string(), _ -> {
+			if (hooksArmed.get()) {
+				var tenant = remoteBosk.context().getTenantId();
+				assertEquals(tenant.tenant().toString(), remoteBosk.context().getAttribute("testKey"));
 			}
-		}
+		});
 
-		// Change them in different ways
+		hooksArmed.set(true);
 
-		try (var _ = bosk.context().withTenant(tenant1)) {
-			driver.submitReplacement(refs.string(), "new tenant1 string");
-		}
-		try (var _ = bosk.context().withTenant(tenant2)) {
-			driver.submitReplacement(refs.string(), "new tenant2 string");
-		}
-		driver.flush();
-
-		// Ensure each tenant sees its own change
-
-		try (var _ = bosk.readSession()) {
-			try (var _ = bosk.context().withTenant(tenant1)) {
-				assertEquals("new tenant1 string", refs.string().value());
+		for (int i = 1; i <= 3; i++) {
+			try (
+				var _ = bosk.context().withTenant(tenant1);
+				var _ = bosk.context().withAttribute("testKey", tenant1.tenant().toString())
+			) {
+				driver.submitReplacement(refs.string(), "tenant1-update" + i);
 			}
-
-			try (var _ = bosk.context().withTenant(tenant2)) {
-				assertEquals("new tenant2 string", refs.string().value());
+			try (
+				var _ = bosk.context().withTenant(tenant2);
+				var _ = bosk.context().withAttribute("testKey", tenant2.tenant().toString())
+			) {
+				driver.submitReplacement(refs.string(), "tenant2-update" + i);
 			}
 		}
+		bosk.driver().flush();
+		remoteBosk.driver().flush();
+
+		assertCorrectBoskContents();
 	}
+
 }


### PR DESCRIPTION
### Background
When two successive updates arrive with the same diagnostic attributes, the second change event will not have any diagnostic attributes because MongoDB doesn't send unchanged fields. This has been the case since the inception of diagnostic attributes, and we solved it by hacking a `lastEventDiagnosticAttributes` field into `Formatter` that remembers the attributes from the previous update.

### Problem
With multitenancy, each tenant can have its own diagnostic attributes, so a single `lastEventDiagnosticAttributes` field is insufficient. The effect was that attributes would get mixed up across tenants.

### Fix
1. Add `DocumentFieldTracker`: a low-level component that tracks certain fields (currently just `diagnostics`) in MongoDB documents and can supply them when they're missing.
2. Use this instead of the `lastEventDiagnosticAttributes` field to keep track of the `diagnostics` field separately for each document. This naturally handles multiple tenants because each tenant has its own documents.
3. Use the `ChangeReceiver` mutex to update both the diagnostics and the flush locks (ie. the `revision` fields) atomically with respect to event processing.

### Concerns

#### Mutexes
We have an ever growing list of mutexes. We now hold the `ChangeReceiver` mutex during event processing and the `Bosk.LocalDriver` mutex during the graft-and-queue-hooks logic. We currently have no discipline to prevent deadlock. The more mutexes we add, the more likely we are to introduce deadlock.

#### Field tracking
I may have overgeneralized the solution here: I've made a `DocumentFieldTracker` that can track any field, but at the moment we only actually need diagnostic attributes. Tracking attributes at a higher abstraction level would allow us to move that logic into `MainDriver` which could simplify things; right now, being a low-level database document concept, `DocumentFieldTracker` goes into the `FormatDriver` layer and complicates the `FormatDriver` interface. If attribute tracking were in `MainDriver` then `loadAllState` would not need side effects, and we might not even need the `ChangeReceiver` mutex anymore.