### PR TITLE
Fixes to Pando flush() implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/bosk-mongo/src/test/resources"
+    directory: "/"
     schedule:
       interval: "weekly"
     groups:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ The usual Gradle commands, plus:
   - The overarching goal of Bosk is to reduce the behaviour gap between local development and production. If your code works, you probably did things right.
 
 ### Code ordering
-- Generally, in a class, instance fields come first, followed by constructors, then methods in use-before-declaration order
-- Static final constants go at the bottom, including any logger
+- Generally, in a class, instance fields come first, followed by shared mutable state (i.e. static fields, even if the reference is final), then constructors, then methods in use-before-declaration order
+- Internal constants (static final) and the logger go at the bottom
 
 ### Formatting
 
@@ -84,6 +84,8 @@ where `throws` clauses have no real downside.
 
 We put exceptions for a module into a sub-package that ends with `.exceptions`
 so they don't clutter up other packages.
+
+When declaring `throws` on a method, use the specific exception type(s), not a superclass like `Exception`. This applies to test methods too — declaring `throws Exception` is not a good habit and we don't want examples of that in the code.
 
 ### Javadocs
 
@@ -122,7 +124,7 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
 - Each commit should have correct spotless formatting.
 - Each commit should pass all tests unless it's marked as WIP or is explicitly doing test-driven development.
 
-## Testing Patterns
+## Test Coding Patterns
 
 - Tests use JUnit 5
 - For parameterizing test methods, use the `@InjectedTest` annotation: `bosk-junit/src/main/java/works/bosk/junit/InjectedTest.java`
@@ -154,16 +156,18 @@ Wrangler interfaces (e.g. `OneMemberWrangler`, `MemberWrangler`, `Gatherer`) mus
 - "Meta-tests" verify that a test is working correctly, like `bosk-testing/src/test/java/works/bosk/testing/drivers/ConformanceMetaTest.java`
 - Tests should be deterministic, and they should not rely on timing except in rare cases where there is no alternative, or where timeout behaviour is specifically being tested
   - Where components have timeout settings, tests should adjust those settings to be very short or very long as appropriate to make spurious failures vanishingly rare
+- Prefer building the entire expected data structure and using `assertEquals` over checking individual fields one-by-one. Tests with per-field assertions get stale when the object acquires new fields.
+- Assertion message strings should state what was expected (e.g. `"Set must have the new item"`), not describe the error (e.g. `"Set does not contain the new item"`).
 
 ## Hints
 
 ### Testing
 
+- Use gradle's `--fail-fast` option to save time
 - When developing a bug fix, write the test first and verify it fails against the unfixed code. Then apply the fix and confirm the test passes. This ensures the test would actually catch the bug.
-- Prefer building the entire expected data structure and using `assertEquals` over checking individual fields one-by-one. Tests with per-field assertions get stale when the object acquires new fields.
-- Assertion message strings should state what was expected (e.g. `"Set must have the new item"`), not describe the error (e.g. `"Set does not contain the new item"`).
 - Use `./gradlew <task> --rerun` (not `--rerun-tasks`) to force Gradle to re-execute a task when cached results exist.
 - Java assertions (-ea) are enabled for tests
+- Do not dismiss test failures as "pre-existing". We must fix all failures. Pre-existing failures can be deferred until after the main work, but we must ultimately fix them.
 
 ### Miscellaneous
 

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -146,7 +146,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			case Fixed(var id) -> () -> new Context(new TenantId(id), MapValue.empty());
 			case Explicit _ -> Context::empty;
 		};
-		context = new BoskContext(initialContextSupplier, name);
+		context = new BoskContext(initialContextSupplier, name, tenancyModel);
 		Info<R> boskInfo = new Info<>(
 			name, instanceID, rootRef, context, tenancyModel, new AtomicReference<>());
 

--- a/bosk-core/src/main/java/works/bosk/BoskConfig.java
+++ b/bosk-core/src/main/java/works/bosk/BoskConfig.java
@@ -104,10 +104,8 @@ public record BoskConfig<R extends StateTreeNode> (
 		record Fixed(Identifier id) implements Implicit {}
 
 		/**
-		 * Tenant information is stored in the bosk state, and is propagated into hooks.
-		 * <p>
-		 * This is useful in a multi-tree system, where each tenant has its own state,
-		 * since tenant information is essential for disambiguating reads and updates.
+		 * {@link TenantId} must be established on a thread before reading or updating the bosk state,
+		 * and each tenant has its own state tree.
 		 */
 		record Explicit() implements TenancyModel {}
 

--- a/bosk-core/src/main/java/works/bosk/BoskContext.java
+++ b/bosk-core/src/main/java/works/bosk/BoskContext.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import works.bosk.BoskConfig.TenancyModel;
 import works.bosk.BoskContext.Tenant.TenantId;
 
 import static java.util.Objects.requireNonNull;
@@ -24,10 +25,16 @@ public final class BoskContext {
 	private final ThreadLocal<Context> currentContext;
 
 	private final String boskName; // For diagnostics
+	private final TenancyModel tenancyModel;
 
-	BoskContext(Supplier<Context> initialContextSupplier, String boskName) {
+	BoskContext(Supplier<Context> initialContextSupplier, String boskName, TenancyModel tenancyModel) {
 		currentContext = ThreadLocal.withInitial(initialContextSupplier);
 		this.boskName = boskName;
+		this.tenancyModel = tenancyModel;
+	}
+
+	public TenancyModel tenancyModel() {
+		return tenancyModel;
 	}
 
 	ContextScope newContextScope(Context newContext) {

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.stream.Collector;
+import org.jspecify.annotations.NullMarked;
 import org.pcollections.TreePMap;
 import works.bosk.Bosk.ReadSession;
 import works.bosk.BoskContext.Tenant.TenantId;
@@ -179,6 +180,7 @@ public interface BoskDriver {
 		 * This bosk has zero or more tenants,
 		 * but they all share the same state tree whose node is {@code rootNode}.
 		 */
+		@NullMarked
 		record SingleTree<R extends StateTreeNode>(R rootNode) implements EntireState<R> {
 			public SingleTree {
 				requireNonNull(rootNode);
@@ -195,6 +197,7 @@ public interface BoskDriver {
 			}
 		}
 
+		@NullMarked
 		record MultiTree<R extends StateTreeNode>(SortedMap<TenantId, R> tenantRoots) implements EntireState<R> {
 			public MultiTree {
 				requireNonNull(tenantRoots);

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -254,7 +254,7 @@ public interface BoskDriver {
 			}
 
 			public static <IN, OUT extends StateTreeNode> Collector<Entry<TenantId, IN>, ?, MultiTree<OUT>> withValues(Function<IN, OUT> valueMapper) {
-				// TODO: Common with PerTenant?
+				// TODO: Common with PerTenantValue?
 				class Accumulator {
 					TreePMap<TenantId, OUT> map = org.pcollections.TreePMap.empty();
 					void accumulate(Entry<TenantId, IN> e) { map = map.plus(e.getKey(), valueMapper.apply(e.getValue())); }

--- a/bosk-core/src/main/java/works/bosk/util/PerTenantValue.java
+++ b/bosk-core/src/main/java/works/bosk/util/PerTenantValue.java
@@ -25,11 +25,11 @@ import static works.bosk.BoskContext.Tenant.NONE;
 /**
  * A data structure that needs separate versions in multitenant situations.
  */
-public sealed interface PerTenant<T> {
+public sealed interface PerTenantValue<T> {
 	T get(Tenant.Established tenant);
 	void forEach(BiConsumer<? super Established, ? super T> consumer);
 	boolean allMatch(Predicate<? super T> predicate);
-	<U> PerTenant<U> map(BiFunction<Tenant.Established, T,U> mapping);
+	<U> PerTenantValue<U> map(BiFunction<Tenant.Established, T,U> mapping);
 
 	/**
 	 * @throws IllegalArgumentException if this can't be represented as a {@link NoTenant}
@@ -37,11 +37,11 @@ public sealed interface PerTenant<T> {
 	 */
 	NoTenant<T> asNoTenant(TenantId expectedTenant);
 
-	default <U> PerTenant<U> map(Function<T,U> mapping) {
+	default <U> PerTenantValue<U> map(Function<T,U> mapping) {
 		return map((_, x) -> mapping.apply(x));
 	}
 
-	static <R extends StateTreeNode, V> PerTenant<V> from(EntireState<R> state, Function<R, V> valueMapper) {
+	static <R extends StateTreeNode, V> PerTenantValue<V> from(EntireState<R> state, Function<R, V> valueMapper) {
 		return switch (state) {
 			case SingleTree<R>(var root) -> new NoTenant<>(valueMapper.apply(root));
 			case MultiTree<R>(var roots)-> roots.entrySet().stream()
@@ -53,7 +53,7 @@ public sealed interface PerTenant<T> {
 	 * Not a multitenant situation: the {@link Tenant} is {@link Tenant#NONE NONE}
 	 * and there's exactly one {@code value}.
 	 */
-	record NoTenant<T>(T value) implements PerTenant<T> {
+	record NoTenant<T>(T value) implements PerTenantValue<T> {
 		@Override
 		public T get(Established tenant) {
 			if (tenant == NONE) {
@@ -74,7 +74,7 @@ public sealed interface PerTenant<T> {
 		}
 
 		@Override
-		public <U> PerTenant<U> map(BiFunction<Established, T, U> mapping) {
+		public <U> PerTenantValue<U> map(BiFunction<Established, T, U> mapping) {
 			return new NoTenant<>(mapping.apply(NONE, value));
 		}
 
@@ -94,7 +94,7 @@ public sealed interface PerTenant<T> {
 	 * <p>
 	 * Tenants are ordered by their ID.
 	 */
-	record MultiTenant<T>(SortedMap<TenantId, T> values) implements PerTenant<T> {
+	record MultiTenant<T>(SortedMap<TenantId, T> values) implements PerTenantValue<T> {
 		public MultiTenant {
 			requireNonNull(values);
 			// The values should always be a TreePMap so that we can do efficient
@@ -139,7 +139,7 @@ public sealed interface PerTenant<T> {
 		}
 
 		@Override
-		public <U> PerTenant<U> map(BiFunction<Established, T, U> mapping) {
+		public <U> PerTenantValue<U> map(BiFunction<Established, T, U> mapping) {
 			return values.entrySet().stream().collect(MultiTenant.multiTenant(
 				Entry::getKey,
 				e -> mapping.apply(e.getKey(), e.getValue())));

--- a/bosk-core/src/main/java/works/bosk/util/PerTenantValue.java
+++ b/bosk-core/src/main/java/works/bosk/util/PerTenantValue.java
@@ -27,6 +27,7 @@ import static works.bosk.BoskContext.Tenant.NONE;
  */
 public sealed interface PerTenantValue<T> {
 	T get(Tenant.Established tenant);
+	T getOrDefault(Tenant.Established tenant, T defaultValue);
 	void forEach(BiConsumer<? super Established, ? super T> consumer);
 	boolean allMatch(Predicate<? super T> predicate);
 	<U> PerTenantValue<U> map(BiFunction<Tenant.Established, T,U> mapping);
@@ -61,6 +62,11 @@ public sealed interface PerTenantValue<T> {
 			} else {
 				throw new IllegalStateException("No such tenant: " + tenant);
 			}
+		}
+
+		@Override
+		public T getOrDefault(Established tenant, T defaultValue) {
+			return tenant == NONE ? value : defaultValue;
 		}
 
 		@Override
@@ -117,13 +123,19 @@ public sealed interface PerTenantValue<T> {
 
 		@Override
 		public T get(Established tenant) {
+			T value = getOrDefault(tenant, null);
+			if (value == null) {
+				throw new IllegalStateException("No such tenant: " + tenant);
+			} else {
+				return value;
+			}
+		}
+
+		@Override
+		public T getOrDefault(Established tenant, T defaultValue) {
 			if (tenant instanceof TenantId tenantId) {
 				T value = values.get(tenantId);
-				if (value == null) {
-					throw new IllegalStateException("No such tenant: " + tenant);
-				} else {
-					return value;
-				}
+				return value == null ? defaultValue : value;
 			}
 			throw new IllegalStateException("Invalid tenant: " + tenant);
 		}

--- a/bosk-core/src/main/java/works/bosk/util/TenantLocal.java
+++ b/bosk-core/src/main/java/works/bosk/util/TenantLocal.java
@@ -1,0 +1,163 @@
+package works.bosk.util;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.jspecify.annotations.NonNull;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskConfig.TenancyModel.Implicit;
+import works.bosk.BoskContext;
+import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.Established;
+import works.bosk.BoskContext.Tenant.NotEstablished;
+import works.bosk.util.PerTenantValue.MultiTenant;
+
+/**
+ * A variable that is specific to an {@link Tenant.Established established tenant}.
+ * <p>
+ * When a tenant is established in the {@link BoskContext}, only that tenant's value is accessible.
+ * Attempts to access another tenant's value will throw an {@link IllegalStateException}.
+ * If the tenant is {@link NotEstablished not established}, then all tenant values are accessible;
+ * in other words, establishing a tenant means dropping privileges.
+ * <p>
+ * A result of this permission system is that the access checks are a bit complex.
+ * It would be simple if we simply required no established tenant for the {@code For} methods,
+ * but in the {@link works.bosk.BoskConfig.TenancyModel.Implicit implicit} tenancy models,
+ * the tenant is established automatically, and the user has no way to shed that and regain privilege.
+ * <p>
+ * Methods that access a specific tenant's value typically have {@code For} in the name,
+ * except for {@link #replaceWith(PerTenantValue) replaceWith}.
+ * Other methods like {@link #get()} access the value for the currently established tenant.
+ * <p>
+ * This is inspired by {@link ThreadLocal}, but don't take the analogy too far:
+ * this class is not thread-local so users must take into account concurrent access;
+ * for example, consecutive calls to {@link #get()} can return different values.
+ * The methods are atomic, though.
+ *
+ * @param <T>
+ */
+public final class TenantLocal<T> {
+	final BoskContext context;
+	final AtomicReference<ConcurrentHashMap<Established, T>> values = new AtomicReference<>(new ConcurrentHashMap<>());
+
+	private TenantLocal(BoskContext context) {
+		this.context = context;
+	}
+
+	public static <T> TenantLocal<T> in(BoskContext context) {
+		return new TenantLocal<>(context);
+	}
+
+	public T get() {
+		return values.get().get(context.getEstablishedTenant());
+	}
+
+	public T set(T newValue) {
+		return values.get().put(context.getEstablishedTenant(), newValue);
+	}
+
+	public boolean replace(T expected, T newValue) {
+		return values.get().replace(context.getEstablishedTenant(), expected, newValue);
+	}
+
+	public T computeIfAbsent(Function<Tenant.Established, T> mappingFunction) {
+		return values.get().computeIfAbsent(context.getEstablishedTenant(), mappingFunction);
+	}
+
+	public T remove() {
+		return values.get().remove(context.getEstablishedTenant());
+	}
+
+	/**
+	 * Affects all tenants, and so the permission model is a little different from the {@code For} methods:
+	 * the permitted access depends on the {@link works.bosk.BoskConfig.TenancyModel tenancy model}.
+	 * <p>
+	 * Note that, for {@link TenancyModel.Fixed},
+	 * {@code newValues} must be a singleton {@link PerTenantValue.MultiTenant MultiTenant} value
+	 * for the tenant that is automatically established by that model.
+	 * {@link PerTenantValue.NoTenant NoTenant} is not allowed.
+	 */
+	public void replaceWith(PerTenantValue<T> newValues) {
+		checkReplacementAccess(newValues);
+		var newMap = new ConcurrentHashMap<Established, T>();
+		newValues.forEach(newMap::put);
+		values.set(newMap);
+	}
+
+	public T getFor(Tenant.Established tenant) {
+		checkTenantAccess(tenant);
+		return values.get().get(tenant);
+	}
+
+	public T setFor(Tenant.Established tenant, T newValue) {
+		checkTenantAccess(tenant);
+		return values.get().put(tenant, newValue);
+	}
+
+	public T computeIfAbsentFor(Established tenant, Function<? super Established, ? extends T> mappingFunction) {
+		checkTenantAccess(tenant);
+		return values.get().computeIfAbsent(tenant, mappingFunction);
+	}
+
+	public void forEach(BiConsumer<? super Established, ? super T> action) {
+		checkAllAccess();
+		values.get().forEach(action);
+	}
+
+	@Override
+	public String toString() {
+		return "TenantLocal{" + values + "}";
+	}
+
+	/**
+	 * The "For" methods are called from "management" code that is aware of tenants and needs to
+	 * change a particular tenant's state. We allow this only if there is no established tenant
+	 * (ie. we haven't dropped privileges) or if the established tenant is the one we're trying to access.
+	 * Either way, we're good.
+	 *
+	 * @param requestedTenant is null if there's no specific tenant whose state we're trying to access
+	 */
+	private void checkTenantAccess(Tenant.@NonNull Established requestedTenant) {
+		switch (context.getTenant()) {
+			case NotEstablished _ -> { /* all is well */ }
+			case Established t when t.equals(requestedTenant) -> { /* all is well */ }
+			case Established _ ->
+				throw new IllegalStateException("Cannot access " + requestedTenant + " when tenant is " + context.getTenant());
+		}
+	}
+
+	private void checkAllAccess() {
+		if (context.tenancyModel() instanceof Implicit) {
+			return; // there are no forbidden tenants in implicit models
+		}
+		final Tenant contextTenant = context.getTenant();
+		if (!(contextTenant instanceof NotEstablished)) {
+			throw new IllegalStateException("Cannot access all tenants when tenant is " + contextTenant);
+		}
+	}
+
+	/**
+	 * Replacement generally affects all tenants, so it's only allowed if
+	 * (1) there's no established tenant in the {@link BoskContext},
+	 * or (2) the tenancy model is {@link Implicit} and {@code newValues} are for the tenant that is automatically established by that model.
+	 * (The old values are assumed to be for the right tenant, since they were validated when they were set,
+	 * and the tenancy model can't change.)
+	 */
+	private void checkReplacementAccess(PerTenantValue<T> newValues) {
+		final Tenant contextTenant = context.getTenant();
+		switch (context.tenancyModel()) {
+			case TenancyModel _
+				when contextTenant instanceof NotEstablished _ -> { /* always ok */ }
+			case TenancyModel.None _
+				when newValues instanceof PerTenantValue.NoTenant<T> -> { /* ok */ }
+			case TenancyModel.Fixed(var id)
+				when newValues instanceof MultiTenant<T>(var map)
+				&& map.keySet().equals(Set.of(Tenant.setTo(id))) -> { /* ok */ }
+			default ->
+				throw new IllegalStateException("Cannot replace value when tenant is " + contextTenant);
+		}
+	}
+
+}

--- a/bosk-core/src/main/java/works/bosk/util/TenantLocal.java
+++ b/bosk-core/src/main/java/works/bosk/util/TenantLocal.java
@@ -101,6 +101,11 @@ public final class TenantLocal<T> {
 		return values.get().computeIfAbsent(tenant, mappingFunction);
 	}
 
+	public T removeFor(Tenant.Established tenant) {
+		checkTenantAccess(tenant);
+		return values.get().remove(tenant);
+	}
+
 	public void forEach(BiConsumer<? super Established, ? super T> action) {
 		checkAllAccess();
 		values.get().forEach(action);

--- a/bosk-core/src/test/java/works/bosk/BoskContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskContextTest.java
@@ -162,7 +162,10 @@ public class BoskContextTest extends AbstractDriverTest {
 		// in the correct order even after trying to close them in the wrong order.)
 	}
 
-	public static BoskContext newContext(Supplier<Context> initialContextSupplier, String boskName) {
-		return new BoskContext(initialContextSupplier, boskName);
+	/**
+	 * Expose the BoskContext constructor for tests
+	 */
+	public static BoskContext newContext(Supplier<Context> initialContextSupplier, String boskName, Explicit tenancyModel) {
+		return new BoskContext(initialContextSupplier, boskName, tenancyModel);
 	}
 }

--- a/bosk-core/src/test/java/works/bosk/BoskContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskContextTest.java
@@ -6,10 +6,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import works.bosk.BoskConfig.TenancyModel.Explicit;
 import works.bosk.BoskConfig.TenancyModel.Implicit;
+import works.bosk.BoskContext.Context;
 import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.annotations.ReferencePath;
@@ -27,7 +29,7 @@ import static works.bosk.testing.BoskTestUtils.boskName;
 /**
  * Note that context propagation for driver operations is tested by {@link DriverConformanceTest}.
  */
-class BoskContextTest extends AbstractDriverTest {
+public class BoskContextTest extends AbstractDriverTest {
 	final TenantId tenant1 = Tenant.setTo(Identifier.from("tenant1"));
 	final TenantId tenant2 = Tenant.setTo(Identifier.from("tenant2"));
 
@@ -158,5 +160,9 @@ class BoskContextTest extends AbstractDriverTest {
 
 		// (If we made it to this point, we were able to close the scopes
 		// in the correct order even after trying to close them in the wrong order.)
+	}
+
+	public static BoskContext newContext(Supplier<Context> initialContextSupplier, String boskName) {
+		return new BoskContext(initialContextSupplier, boskName);
 	}
 }

--- a/bosk-core/src/test/java/works/bosk/util/PerTenantValueTest.java
+++ b/bosk-core/src/test/java/works/bosk/util/PerTenantValueTest.java
@@ -12,18 +12,18 @@ import works.bosk.BoskContext.Tenant;
 import works.bosk.Identifier;
 import works.bosk.junit.InjectFrom;
 import works.bosk.junit.InjectedTest;
-import works.bosk.util.PerTenant.MultiTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue.MultiTenant;
+import works.bosk.util.PerTenantValue.NoTenant;
 
 import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static works.bosk.BoskContext.Tenant.NONE;
 import static works.bosk.BoskContext.Tenant.TenantId;
-import static works.bosk.util.PerTenant.MultiTenant.multiTenant;
+import static works.bosk.util.PerTenantValue.MultiTenant.multiTenant;
 
-@InjectFrom(PerTenantTest.Scenario.Injector.class)
-class PerTenantTest {
+@InjectFrom(PerTenantValueTest.Scenario.Injector.class)
+class PerTenantValueTest {
 	static final TenantId t1 = new TenantId(Identifier.from("t1"));
 	static final TenantId t2 = new TenantId(Identifier.from("t2"));
 	static final TenantId t3 = new TenantId(Identifier.from("t3"));
@@ -33,7 +33,7 @@ class PerTenantTest {
 		MULTI_TENANT,
 		;
 
-		PerTenant<String> perTenant() {
+		PerTenantValue<String> perTenant() {
 			return switch (this) {
 				case NO_TENANT -> NoTenant.just("sole");
 				case MULTI_TENANT -> Stream.of(t1,t2,t3)
@@ -77,7 +77,7 @@ class PerTenantTest {
 
 	@InjectedTest
 	void map(Scenario scenario) {
-		PerTenant<String> mapped = scenario.perTenant().map(s -> s.toUpperCase(Locale.ROOT));
+		PerTenantValue<String> mapped = scenario.perTenant().map(s -> s.toUpperCase(Locale.ROOT));
 		List<Seen> actual = new ArrayList<>();
 		mapped.forEach((tenant, value) -> actual.add(new Seen(tenant, value)));
 

--- a/bosk-core/src/test/java/works/bosk/util/TenantLocalTest.java
+++ b/bosk-core/src/test/java/works/bosk/util/TenantLocalTest.java
@@ -1,0 +1,77 @@
+package works.bosk.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskContext;
+import works.bosk.BoskContext.Context;
+import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.TenantId;
+import works.bosk.BoskContextTest;
+import works.bosk.Identifier;
+import works.bosk.MapValue;
+import works.bosk.junit.Ante;
+import works.bosk.junit.RunAnteTestsFirst;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@RunAnteTestsFirst
+class TenantLocalTest {
+	BoskContext context;
+	TenantLocal<String> tenantLocal;
+
+	final TenantId tenant1 = Tenant.setTo(Identifier.from("tenant1"));
+	final TenantId tenant2 = Tenant.setTo(Identifier.from("tenant2"));
+
+	@BeforeEach
+	void setup() {
+		context = BoskContextTest.newContext(()->new Context(
+			Tenant.NOT_ESTABLISHED,
+			MapValue.empty()), "testBoskName", TenancyModel.EXPLICIT
+		);
+		tenantLocal = TenantLocal.in(context);
+	}
+
+	@Ante
+	@Test
+	void basicFunctionality() {
+		assertThrows(IllegalStateException.class, () -> tenantLocal.set("test"),
+			"Cannot set value when tenant is not established");
+
+		try (var _ = context.withTenant(tenant1)) {
+			tenantLocal.set("value1");
+			assertEquals("value1", tenantLocal.get());
+		}
+		try (var _ = context.withTenant(tenant2)) {
+			tenantLocal.set("value2");
+			assertEquals("value2", tenantLocal.get());
+		}
+		try (var _ = context.withTenant(tenant1)) {
+			assertEquals("value1", tenantLocal.get());
+		}
+	}
+
+	@Test
+	void testAllTheThings() {
+		try (var _ = context.withTenant(tenant1)) {
+			assertNull(tenantLocal.get());
+			tenantLocal.set("value1");
+			assertEquals("value1", tenantLocal.get());
+			tenantLocal.replace("value1", "value2");
+			assertEquals("value2", tenantLocal.get());
+			tenantLocal.replace("value1", "value1");
+			assertEquals("value2", tenantLocal.get(),
+				"replace does nothing when expected value doesn't match");
+			tenantLocal.remove();
+			assertNull(tenantLocal.get());
+			tenantLocal.computeIfAbsent(_ -> "value1");
+			assertEquals("value1", tenantLocal.get());
+			tenantLocal.computeIfAbsent(_ -> "value2");
+			assertEquals("value1", tenantLocal.get(),
+				"computeIfAbsent does nothing when value is already present");
+		}
+	}
+
+}

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
@@ -20,9 +20,9 @@ import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.jackson.JsonNodeSurgeon.NodeInfo;
 import works.bosk.jackson.JsonNodeSurgeon.NodeLocation.Root;
-import works.bosk.util.PerTenant;
-import works.bosk.util.PerTenant.MultiTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue;
+import works.bosk.util.PerTenantValue.MultiTenant;
+import works.bosk.util.PerTenantValue.NoTenant;
 
 /**
  * Maintains an in-memory representation of the bosk state
@@ -33,7 +33,7 @@ public class JsonNodeDriver implements BoskDriver {
 	final BoskContext context;
 	final ObjectMapper mapper;
 	final JsonNodeSurgeon surgeon;
-	PerTenant<JsonNode> contents;
+	PerTenantValue<JsonNode> contents;
 	int updateNumber = 0;
 
 	public static <R extends StateTreeNode> DriverFactory<R> factory(JacksonSerializer jacksonSerializer) {
@@ -140,8 +140,8 @@ public class JsonNodeDriver implements BoskDriver {
 		if (nodeInfo.replacementLocation() instanceof Root) {
 			JsonNode replacement = mapper.convertValue(newValue, JsonNode.class);
 			contents = switch (contents) {
-				case PerTenant.NoTenant<JsonNode> _ -> NoTenant.just(replacement);
-				case PerTenant.MultiTenant<JsonNode> m -> m.with(context.getTenantId(), replacement);
+				case PerTenantValue.NoTenant<JsonNode> _ -> NoTenant.just(replacement);
+				case PerTenantValue.MultiTenant<JsonNode> m -> m.with(context.getTenantId(), replacement);
 			};
 		} else {
 			JsonNode replacement = surgeon.replacementNode(nodeInfo, lastSegment.get(), () -> mapper.convertValue(newValue, JsonNode.class));

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeDriverConformanceTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JsonNodeDriverConformanceTest.java
@@ -7,9 +7,9 @@ import works.bosk.BoskDriver.EntireState.MultiTree;
 import works.bosk.BoskDriver.EntireState.SingleTree;
 import works.bosk.testing.drivers.DriverConformanceTest;
 import works.bosk.testing.drivers.state.TestEntity;
-import works.bosk.util.PerTenant;
-import works.bosk.util.PerTenant.MultiTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue;
+import works.bosk.util.PerTenantValue.MultiTenant;
+import works.bosk.util.PerTenantValue.NoTenant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -28,7 +28,7 @@ class JsonNodeDriverConformanceTest extends DriverConformanceTest {
 	@Override
 	protected void assertCorrectBoskContents() {
 		super.assertCorrectBoskContents();
-		PerTenant<JsonNode> expected, actual;
+		PerTenantValue<JsonNode> expected, actual;
 		try (var _ = bosk.readSession()) {
 			var state = bosk.entireState();
 			expected = switch (state) {

--- a/bosk-mongo/DEVELOPERS.md
+++ b/bosk-mongo/DEVELOPERS.md
@@ -104,6 +104,8 @@ However, there are three major differences between `refurbish` and this read-the
 
 The implementation of `refurbish` uses a multi-document transaction to read, deserialize, re-serialize, and write the database contents atomically.
 
+ **Format-specific document IDs**: Races with a concurrent `refurbish` can cause a write from one format to be interpreted under another format's semantics, corrupting the database. To prevent this, formats should only write to document IDs whose meaning is the same in all formats (like `!Manifest`).
+
 #### `close`
 
 The `close` method shuts down a `MongoDriver` when the application is finished with it.

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/PandoFormat.java
@@ -14,6 +14,7 @@ import static works.bosk.drivers.mongo.MongoDriverSettings.TenancyFormat.NONE;
 /**
  * A scalable format that stores the bosk state in multiple documents,
  * thereby overcoming MongoDB's 16MB document size limit.
+ * Also supports {@link works.bosk.BoskConfig.TenancyModel#EXPLICIT multitenancy}.
  * <p>
  * Reconstructing the state tree from the documents is not dependent
  * on the graft point configuration because the documents are self-describing:

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -230,10 +230,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 					DocumentFields.diagnostics.name(),
 					formatter.encodeDiagnostics(context.getAttributes())
 				)
-				.append(
-					DocumentFields.tenant.name(),
-					formatter.encodeTenant(context.getEstablishedTenant())
-				)
 			);
 	}
 
@@ -412,7 +408,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		fieldValues.put(DocumentFields.path.name(), new BsonString("/"));
 		fieldValues.put(DocumentFields.state.name(), initialState);
 		fieldValues.put(DocumentFields.revision.name(), revision);
-		fieldValues.put(DocumentFields.tenant.name(), formatter.encodeMaybeTenant(context.getTenant()));
 		fieldValues.put(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(context.getAttributes()));
 
 		return fieldValues;

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -44,7 +44,6 @@ import works.bosk.util.PerTenantValue.MultiTenant;
 import works.bosk.util.PerTenantValue.NoTenant;
 import works.bosk.util.TunneledCheckedException;
 
-import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.changestream.OperationType.INSERT;
@@ -335,8 +334,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 */
 	protected MongoCursor<BsonDocument> revisionDocumentCursor() {
 		return collection
-			.withReadConcern(LOCAL)
-			.find(rootDocumentsFilter())
+			.findLatest(rootDocumentsFilter())
 			.projection(fields(include("_id", DocumentFields.revision.name())))
 			.cursor();
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -165,7 +165,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public void hasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
+	public void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
 		contents.forEach((tenant, stateAndMetadata) ->
 			finishedRevision(tenant, stateAndMetadata.revision()));
 	}
@@ -189,7 +189,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	/**
-	 * Must be called before {@link #hasBeenApplied} or any event processing.
+	 * Must be called before {@link #onHasBeenApplied} or any event processing.
 	 */
 	protected void ensureFlushLocksInitialized(PerTenant<?> contents) {
 		flushLocks.compareAndSet(null, switch (contents) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -18,6 +18,7 @@ import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.BoskConfig.TenancyModel;
@@ -101,7 +102,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	@Override
 	public MongoStatus readStatus() {
 		try {
-			PerTenantValue<BsonStateAndMetadata> dbStates = readBsonStateAndMetadata();
+			PerTenantValue<BsonStateAndMetadata> dbStates = readBsonStateAndMetadata().contents();
 			var entireState = entireStateSupplier.get();
 			var inMemoryBsonValues = PerTenantValue.from(entireState,
 				r -> formatter.object2bsonValue(r, rootRef.targetType()));
@@ -133,11 +134,11 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public PerTenantValue<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException {
+	public AllState<R> loadAllState() throws IOException, InvalidCollectionContentsException {
 		try {
-			PerTenantValue<BsonStateAndMetadata> bsonStateAndMetadata = readBsonStateAndMetadata();
-			ensureFlushLocksInitialized(bsonStateAndMetadata);
-			return bsonStateAndMetadata.map((Established _, BsonStateAndMetadata bsm) -> {
+			BsonAllState bsonAllState = readBsonStateAndMetadata();
+			ensureFlushLocksInitialized(bsonAllState.contents());
+			PerTenantValue<StateAndMetadata<R>> contents = bsonAllState.contents().map((Established _, BsonStateAndMetadata bsm) -> {
 				if (bsm.state() == null) {
 					throw new TunneledCheckedException(new IOException("No existing state in document"));
 				}
@@ -152,6 +153,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 
 				return new StateAndMetadata<>(root, revision, diagnosticAttributes);
 			});
+			return new AllState<>(contents, bsonAllState.contentsRevision());
 		} catch (TunneledCheckedException e) {
 			try {
 				throw e.getCause();
@@ -164,8 +166,8 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents) {
-		contents.forEach((tenant, stateAndMetadata) ->
+	public void onHasBeenApplied(AllState<R> allState) {
+		allState.contents().forEach((tenant, stateAndMetadata) ->
 			finishedRevision(tenant, stateAndMetadata.revision()));
 	}
 
@@ -219,7 +221,12 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * @return the contents of the database; fields of the returned
 	 * record can be null if they don't exist in the database.
 	 */
-	abstract PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException;
+	static record BsonAllState(
+		PerTenantValue<BsonStateAndMetadata> contents,
+		@Nullable BsonInt64 contentsRevision
+	) {}
+
+	abstract BsonAllState readBsonStateAndMetadata() throws InvalidCollectionContentsException;
 
 	protected BsonDocument blankUpdateDoc() {
 		return new BsonDocument()

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -39,9 +39,9 @@ import works.bosk.drivers.mongo.status.MongoStatus;
 import works.bosk.drivers.mongo.status.StateStatus;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
-import works.bosk.util.PerTenant;
-import works.bosk.util.PerTenant.MultiTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue;
+import works.bosk.util.PerTenantValue.MultiTenant;
+import works.bosk.util.PerTenantValue.NoTenant;
 import works.bosk.util.TunneledCheckedException;
 
 import static com.mongodb.ReadConcern.LOCAL;
@@ -73,7 +73,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * (Therefore, there's no need for null tests before using this:
 	 * an NPE is an acceptable outcome if someone ever violates these rules.)
 	 */
-	final AtomicReference<PerTenant<FlushLock>> flushLocks = new AtomicReference<>(null);
+	final AtomicReference<PerTenantValue<FlushLock>> flushLocks = new AtomicReference<>(null);
 
 	final DocumentFieldTracker fieldTracker = new DocumentFieldTracker();
 	final FlushLock contentsFlushLock;
@@ -102,9 +102,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	@Override
 	public MongoStatus readStatus() {
 		try {
-			PerTenant<BsonStateAndMetadata> dbStates = readBsonStateAndMetadata();
+			PerTenantValue<BsonStateAndMetadata> dbStates = readBsonStateAndMetadata();
 			var entireState = entireStateSupplier.get();
-			var inMemoryBsonValues = PerTenant.from(entireState,
+			var inMemoryBsonValues = PerTenantValue.from(entireState,
 				r -> formatter.object2bsonValue(r, rootRef.targetType()));
 			BsonComparator comp = new BsonComparator();
 			var stateStatuses = dbStates.map((Established tenant, BsonStateAndMetadata dbState) -> {
@@ -134,9 +134,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public PerTenant<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException {
+	public PerTenantValue<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException {
 		try {
-			PerTenant<BsonStateAndMetadata> bsonStateAndMetadata = readBsonStateAndMetadata();
+			PerTenantValue<BsonStateAndMetadata> bsonStateAndMetadata = readBsonStateAndMetadata();
 			ensureFlushLocksInitialized(bsonStateAndMetadata);
 			return bsonStateAndMetadata.map((Established _, BsonStateAndMetadata bsm) -> {
 				if (bsm.state() == null) {
@@ -165,18 +165,18 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	@Override
-	public void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
+	public void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents) {
 		contents.forEach((tenant, stateAndMetadata) ->
 			finishedRevision(tenant, stateAndMetadata.revision()));
 	}
 
 	/**
-	 * Converts a {@link PerTenant} to the variant appropriate for the {@link #tenancyModel}.
+	 * Converts a {@link PerTenantValue} to the variant appropriate for the {@link #tenancyModel}.
 	 * For {@code None} tenancy, {@code NoTenant} is returned as-is.
 	 * For {@code Fixed} tenancy, {@code NoTenant} is converted to
 	 * {@link MultiTenant} with the fixed tenant ID.
 	 */
-	protected <T> PerTenant<T> normalizePerTenant(PerTenant<T> contents) {
+	protected <T> PerTenantValue<T> normalizePerTenant(PerTenantValue<T> contents) {
 		return switch (contents) {
 			case NoTenant<T>(var value) -> switch (tenancyModel) {
 				case None _ -> contents;
@@ -191,7 +191,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	/**
 	 * Must be called before {@link #onHasBeenApplied} or any event processing.
 	 */
-	protected void ensureFlushLocksInitialized(PerTenant<?> contents) {
+	protected void ensureFlushLocksInitialized(PerTenantValue<?> contents) {
 		flushLocks.compareAndSet(null, switch (contents) {
 			case NoTenant<?> _ -> switch (tenancyModel) {
 				case None _ -> NoTenant.just(newFlushLock());
@@ -220,7 +220,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * @return the contents of the database; fields of the returned
 	 * record can be null if they don't exist in the database.
 	 */
-	abstract PerTenant<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException;
+	abstract PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException;
 
 	protected BsonDocument blankUpdateDoc() {
 		return new BsonDocument()
@@ -265,7 +265,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	protected boolean shouldSkip(Established tenant, BsonInt64 revision) {
-		PerTenant<FlushLock> f = flushLocks.get();
+		PerTenantValue<FlushLock> f = flushLocks.get();
 		FlushLock lock = (f instanceof MultiTenant<FlushLock> m && tenant instanceof TenantId tid)
 			? m.values().get(tid) : f.get(tenant);
 		// When lock is null, we don't have a lock for this tenant, so this revision is always interesting.
@@ -299,7 +299,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	protected void finishedRevision(Established tenant, BsonInt64 revision) {
-		PerTenant<FlushLock> f = flushLocks.get();
+		PerTenantValue<FlushLock> f = flushLocks.get();
 		if (f instanceof MultiTenant<FlushLock> m && tenant instanceof TenantId tid) {
 			FlushLock lock = m.values().get(tid);
 			if (lock == null) {
@@ -349,7 +349,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 * @return all potentially relevant revision numbers found in the database
 	 * @throws RevisionFieldDisruptedException if unexpected database contents make it impossible to determine the revision number
 	 */
-	abstract @NonNull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException;
+	abstract @NonNull PerTenantValue<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException;
 
 	@Override
 	public void flush() throws IOException, InterruptedException {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -320,25 +320,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		}
 	}
 
-	protected void finishedContentsRevision(BsonInt64 revision) {
-		if (revision != null) {
-			contentsFlushLock.finishedRevision(revision);
-		}
-	}
-
-	protected BsonInt64 readContentsRevision() {
-		try (MongoCursor<BsonDocument> cursor = collection
-			.withReadConcern(LOCAL)
-			.find(new BsonDocument("_id", CONTENTS_ID))
-			.projection(fields(include("_id", DocumentFields.revision.name())))
-			.cursor()) {
-			if (cursor.hasNext()) {
-				return cursor.next().getInt64(DocumentFields.revision.name(), REVISION_ZERO);
-			}
-			return REVISION_ZERO;
-		}
-	}
-
 	/**
 	 * @return the {@link Tenant} that should be established before processing
 	 * a document with the given {@code id}
@@ -441,10 +422,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		return MANIFEST_ID.equals(documentId);
 	}
 
-	protected boolean isContentsID(BsonValue documentId) {
-		return CONTENTS_ID.equals(documentId);
-	}
-
 	/**
 	 * Low-level version of {@link StateAndMetadata}.
 	 */
@@ -456,7 +433,6 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	){}
 
 	private static final Set<String> ALREADY_WARNED = newSetFromMap(new ConcurrentHashMap<>());
-	static final BsonString CONTENTS_ID = new BsonString("!contents");
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFormatDriver.class);
 
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -427,9 +427,9 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 */
 	record BsonStateAndMetadata(
 		BsonString _id,
-		BsonDocument state,
 		BsonInt64 revision,
-		BsonDocument diagnosticAttributes
+		BsonDocument diagnosticAttributes,
+		BsonDocument state
 	){}
 
 	private static final Set<String> ALREADY_WARNED = newSetFromMap(new ConcurrentHashMap<>());

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -1,16 +1,12 @@
 package works.bosk.drivers.mongo.internal;
 
-import com.mongodb.ReadConcern;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
 import java.io.IOException;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
@@ -28,7 +24,6 @@ import works.bosk.BoskConfig.TenancyModel.None;
 import works.bosk.BoskContext;
 import works.bosk.BoskContext.Tenant;
 import works.bosk.BoskContext.Tenant.Established;
-import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.BoskDriver;
 import works.bosk.MapValue;
 import works.bosk.Reference;
@@ -43,12 +38,14 @@ import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.util.PerTenantValue;
 import works.bosk.util.PerTenantValue.MultiTenant;
 import works.bosk.util.PerTenantValue.NoTenant;
+import works.bosk.util.TenantLocal;
 import works.bosk.util.TunneledCheckedException;
 
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.changestream.OperationType.INSERT;
 import static com.mongodb.client.model.changestream.OperationType.REPLACE;
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
@@ -67,13 +64,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	final long flushTimeoutMS;
 	final Supplier<EntireState<R>> entireStateSupplier;
 
-	/**
-	 * Null only during initialization, until {@link #ensureFlushLocksInitialized},
-	 * and only used after that point.
-	 * (Therefore, there's no need for null tests before using this:
-	 * an NPE is an acceptable outcome if someone ever violates these rules.)
-	 */
-	final AtomicReference<PerTenantValue<FlushLock>> flushLocks = new AtomicReference<>(null);
+	final TenantLocal<FlushLock> flushLocks;
 
 	final DocumentFieldTracker fieldTracker = new DocumentFieldTracker();
 	final FlushLock contentsFlushLock;
@@ -97,6 +88,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		this.flushTimeoutMS = flushTimeoutMS;
 		this.entireStateSupplier = entireStateSupplier;
 		this.contentsFlushLock = new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS);
+		this.flushLocks = TenantLocal.in(context);
 	}
 
 	@Override
@@ -137,7 +129,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	public AllState<R> loadAllState() throws IOException, InvalidCollectionContentsException {
 		try {
 			BsonAllState bsonAllState = readBsonStateAndMetadata();
-			ensureFlushLocksInitialized(bsonAllState.contents());
+			replaceFlushLocks(bsonAllState.contents().map(BsonStateAndMetadata::revision));
 			PerTenantValue<StateAndMetadata<R>> contents = bsonAllState.contents().map((Established _, BsonStateAndMetadata bsm) -> {
 				if (bsm.state() == null) {
 					throw new TunneledCheckedException(new IOException("No existing state in document"));
@@ -192,26 +184,8 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	/**
 	 * Must be called before {@link #onHasBeenApplied} or any event processing.
 	 */
-	protected void ensureFlushLocksInitialized(PerTenantValue<?> contents) {
-		flushLocks.compareAndSet(null, switch (contents) {
-			case NoTenant<?> _ -> switch (tenancyModel) {
-				case None _ -> NoTenant.just(newFlushLock());
-				case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), newFlushLock());
-				case Explicit _ -> throw new AssertionError(
-					"Should not have NoTenant contents with Explicit tenancy");
-			};
-			case MultiTenant<?> m -> {
-				SortedMap<TenantId, FlushLock> locks = new TreeMap<>();
-				for (var tenantId : m.values().keySet()) {
-					locks.put(tenantId, newFlushLock());
-				}
-				yield new MultiTenant<>(locks);
-			}
-		});
-	}
-
-	private @NonNull FlushLock newFlushLock() {
-		return new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS);
+	protected void replaceFlushLocks(PerTenantValue<BsonInt64> revisionNumbers) {
+		flushLocks.replaceWith(revisionNumbers.map(n -> new FlushLock(n.longValue(), flushTimeoutMS)));
 	}
 
 	/**
@@ -266,10 +240,8 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		return blankUpdateDoc().append("$unset", new BsonDocument(key, BsonNull.VALUE));
 	}
 
-	protected boolean shouldSkip(Established tenant, BsonInt64 revision) {
-		PerTenantValue<FlushLock> f = flushLocks.get();
-		FlushLock lock = (f instanceof MultiTenant<FlushLock> m && tenant instanceof TenantId tid)
-			? m.values().get(tid) : f.get(tenant);
+	protected boolean shouldSkip(BsonInt64 revision) {
+		FlushLock lock = flushLocks.get();
 		// When lock is null, we don't have a lock for this tenant, so this revision is always interesting.
 		return lock != null && lock.alreadySeen(revision);
 	}
@@ -300,26 +272,17 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		LOGGER.debug("Ignoring benign manifest change event");
 	}
 
+	protected void finishedRevision(BsonInt64 revision) {
+		flushLocks.computeIfAbsent(
+			_ -> new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS)
+		).finishedRevision(revision);
+	}
+
 	protected void finishedRevision(Established tenant, BsonInt64 revision) {
-		PerTenantValue<FlushLock> f = flushLocks.get();
-		if (f instanceof MultiTenant<FlushLock> m && tenant instanceof TenantId tid) {
-			FlushLock lock = m.values().get(tid);
-			if (lock == null) {
-				flushLocks.compareAndSet(f, m.with(tid, new FlushLock(revision.longValue(), flushTimeoutMS)));
-			} else {
-				lock.finishedRevision(revision);
-			}
-		} else {
-			FlushLock lock = f.get(tenant);
-			if (lock == null) {
-				flushLocks.compareAndSet(f, switch (f) {
-					case NoTenant<FlushLock> nt -> NoTenant.just(new FlushLock(revision.longValue(), flushTimeoutMS));
-					default -> throw new IllegalStateException("Cannot add tenant " + tenant);
-				});
-			} else {
-				lock.finishedRevision(revision);
-			}
-		}
+		flushLocks.computeIfAbsentFor(
+			tenant,
+			_ -> new FlushLock(REVISION_BEFORE_ANY.longValue(), flushTimeoutMS)
+		).finishedRevision(revision);
 	}
 
 	/**
@@ -336,8 +299,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 
 	/**
 	 * @return cursor giving the {@code _id} and {@code revision}
-	 * for all documents that have a revision field,
-	 * read using read concern {@link ReadConcern#LOCAL LOCAL}.
+	 * for all root documents that have a revision field.
 	 */
 	protected MongoCursor<BsonDocument> revisionDocumentCursor() {
 		return collection
@@ -347,24 +309,38 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	/**
+	 * If there's any other waiting to be done besides the per-tenant revision number waiting,
+	 * this method must do that before returning.
 	 * @return all potentially relevant revision numbers found in the database
 	 * @throws RevisionFieldDisruptedException if unexpected database contents make it impossible to determine the revision number
 	 */
-	abstract @NonNull PerTenantValue<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException;
+	abstract @NonNull PerTenantValue<BsonInt64> readRevisionNumbersToFlush() throws FlushFailureException, InterruptedException;
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		var revisions = readRevisionNumbers();
+		var revisions = readRevisionNumbersToFlush();
+
+		// Don't hold a database transaction while waiting for the flush locks
+		// or flushing downstream.
+		collection.commitTransactionIfAny();
+
+		LOGGER.debug("Revisions to flush: {}", revisions);
+
+		// Wait for tenants that are present in flushLocks.
+		// Any tenant missing from flushLocks must have been deleted after
+		// the flush point, so we have no obligation to wait for it.
 		try {
-			flushLocks.get().forEach((tenant, lock) -> {
-				BsonInt64 revision = revisions.get(tenant);
+			LOGGER.debug("flushLocks: {}", flushLocks);
+			flushLocks.forEach((tenant, lock) -> {
+				BsonInt64 revision = revisions.getOrDefault(tenant, null);
+				if (revision == null) {
+					// Tenant is not present at the flush point so it must have been created after.
+					// No obligation to wait.
+					LOGGER.debug("Skipping {} for {}", revision, tenant);
+					return;
+				}
 				try {
-					if (revision == null) {
-						// Tenant has been deleted from the database; nothing to flush
-						return;
-					} else {
-						lock.awaitRevision(revision);
-					}
+					lock.awaitRevision(revision);
 				} catch (InterruptedException | FlushFailureException e) {
 					throw new TunneledCheckedException(e);
 				}
@@ -378,23 +354,24 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 				throw e;
 			}
 		}
-		additionalFlushWaits();
 		LOGGER.debug("| Flush downstream");
 		downstream.flush();
-	}
-
-	/**
-	 * Override in subclasses to add additional waits during {@link #flush()}.
-	 */
-	protected void additionalFlushWaits() throws IOException, InterruptedException {
-		// Default: no additional waits
 	}
 
 	@Override
 	public void close() {
 		LOGGER.debug("+ close()");
-		flushLocks.get().forEach((_, flushLock) -> flushLock.close());
 		contentsFlushLock.close();
+		try {
+			// Jailbreak! Disconnection affects all tenants, but it can be triggered by
+			// an operation with an established tenant context.
+			// Close the flush locks on a thread without the tenant restriction.
+			Thread.startVirtualThread(()->
+				flushLocks.forEach((_, flushLock) -> flushLock.close())
+			).join();
+		} catch (InterruptedException e) {
+			currentThread().interrupt();
+		}
 	}
 
 	protected void writeManifest(Manifest manifest) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AllState.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AllState.java
@@ -1,0 +1,12 @@
+package works.bosk.drivers.mongo.internal;
+
+import org.bson.BsonInt64;
+import org.jspecify.annotations.Nullable;
+import works.bosk.StateTreeNode;
+import works.bosk.util.PerTenantValue;
+
+record AllState<R extends StateTreeNode>(
+	PerTenantValue<StateAndMetadata<R>> contents,
+	@Nullable BsonInt64 contentsRevision
+) {
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonFormatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonFormatter.java
@@ -312,11 +312,6 @@ public class BsonFormatter {
 		revision,
 
 		/**
-		 * The contents of {@link BoskContext#getTenant()} corresponding to this document's last update.
-		 */
-		tenant,
-
-		/**
 		 * The contents of {@link BoskContext#getAttributes()} corresponding to this
 		 * document's last update.
 		 */

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
@@ -8,7 +8,7 @@ import works.bosk.Reference;
 import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.exceptions.DisconnectedException;
 import works.bosk.drivers.mongo.status.MongoStatus;
-import works.bosk.util.PerTenant;
+import works.bosk.util.PerTenantValue;
 
 @RequiredArgsConstructor
 final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<R> {
@@ -63,12 +63,12 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public PerTenant<StateAndMetadata<R>> loadAllState() {
+	public PerTenantValue<StateAndMetadata<R>> loadAllState() {
 		throw disconnected();
 	}
 
 	@Override
-	public void initializeCollection(PerTenant<StateAndMetadata<R>> priorContents) {
+	public void initializeCollection(PerTenantValue<StateAndMetadata<R>> priorContents) {
 		throw disconnected();
 	}
 
@@ -78,7 +78,7 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
+	public void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents) {
 		throw disconnected();
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
@@ -78,7 +78,7 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public void hasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
+	public void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
 		throw disconnected();
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/DisconnectedDriver.java
@@ -63,7 +63,7 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public PerTenantValue<StateAndMetadata<R>> loadAllState() {
+	public AllState<R> loadAllState() {
 		throw disconnected();
 	}
 
@@ -78,7 +78,7 @@ final class DisconnectedDriver<R extends StateTreeNode> implements FormatDriver<
 	}
 
 	@Override
-	public void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents) {
+	public void onHasBeenApplied(AllState<R> allState) {
 		throw disconnected();
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FlushLock.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FlushLock.java
@@ -1,6 +1,5 @@
 package works.bosk.drivers.mongo.internal;
 
-import java.io.Closeable;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Lock;
@@ -49,7 +48,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * it within the {@link FormatDriver}. Once that happens, we can easily evolve
  * that logic to include an epoch concept without touching other components.
  */
-class FlushLock implements Closeable {
+class FlushLock {
 	private final long flushTimeoutMS;
 	private final Lock queueLock = new ReentrantLock();
 	private final PriorityBlockingQueue<Waiter> queue = new PriorityBlockingQueue<>();
@@ -148,7 +147,6 @@ class FlushLock implements Closeable {
 		}
 	}
 
-	@Override
 	public void close() {
 		try {
 			queueLock.lock();

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -8,7 +8,7 @@ import org.bson.BsonDocument;
 import works.bosk.BoskContext;
 import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.MongoDriver;
-import works.bosk.util.PerTenant;
+import works.bosk.util.PerTenantValue;
 
 /**
  * Additional {@link MongoDriver} functionality that the format-specific drivers must implement.
@@ -62,7 +62,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 *
 	 * @throws InvalidCollectionContentsException if the collection contents don't match the declared format
 	 */
-	PerTenant<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException;
+	PerTenantValue<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException;
 
 	/**
 	 * Initializes the collection to the given state.
@@ -78,7 +78,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 * "prior" state of the database; in particular, the revision number should be incremented
 	 * so that a {@link #flush} after a {@link #refurbish} succeeds in waiting for the new state.
 	 */
-	void initializeCollection(PerTenant<StateAndMetadata<R>> priorContents);
+	void initializeCollection(PerTenantValue<StateAndMetadata<R>> priorContents);
 
 	/**
 	 * @return a query filter that returns documents corresponding to the roots of the state tree,
@@ -90,7 +90,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 * Indicates that the given contents have been {@link #flush() flushed} to the downstream driver already,
 	 * or are otherwise known to have been applied to the bosk state.
 	 */
-	void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents);
+	void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents);
 
 	@Override
 	default <RR extends StateTreeNode> EntireState<RR> initialState(Class<RR> rootType) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -90,7 +90,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 * Indicates that the given contents have been {@link #flush() flushed} to the downstream driver already,
 	 * or are otherwise known to have been applied to the bosk state.
 	 */
-	void hasBeenApplied(PerTenant<StateAndMetadata<R>> contents);
+	void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents);
 
 	@Override
 	default <RR extends StateTreeNode> EntireState<RR> initialState(Class<RR> rootType) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -62,7 +62,7 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 *
 	 * @throws InvalidCollectionContentsException if the collection contents don't match the declared format
 	 */
-	PerTenantValue<StateAndMetadata<R>> loadAllState() throws IOException, InvalidCollectionContentsException;
+	AllState<R> loadAllState() throws IOException, InvalidCollectionContentsException;
 
 	/**
 	 * Initializes the collection to the given state.
@@ -87,10 +87,10 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	BsonDocument rootDocumentsFilter();
 
 	/**
-	 * Indicates that the given contents have been {@link #flush() flushed} to the downstream driver already,
+	 * Indicates that the given allState have been {@link #flush() flushed} to the downstream driver already,
 	 * or are otherwise known to have been applied to the bosk state.
 	 */
-	void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents);
+	void onHasBeenApplied(AllState<R> allState);
 
 	@Override
 	default <RR extends StateTreeNode> EntireState<RR> initialState(Class<RR> rootType) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -316,8 +316,8 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		EntireState<R> entireState;
 		try (var _ = queryCollection.newReadOnlySession()){
 			FormatDriver<R> detectedDriver = detectFormat();
-			PerTenantValue<StateAndMetadata<R>> loadedState = detectedDriver.loadAllState();
-			entireState = switch (loadedState.map(StateAndMetadata::state)) {
+			AllState<R> loadedState = detectedDriver.loadAllState();
+			entireState = switch (loadedState.contents().map(StateAndMetadata::state)) {
 				case NoTenant<R>(R root) -> EntireState.just(root);
 				case PerTenantValue.MultiTenant<R> v -> v.values().entrySet().stream().collect(MultiTree.collector());
 			};
@@ -382,7 +382,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// with respect to event processing, because both of them have side effects
 			// that affect event processing (field tracking and flush locks, respectively).
 			synchronized (receiver) {
-				PerTenantValue<StateAndMetadata<R>> result = formatDriver.loadAllState();
+				AllState<R> result = formatDriver.loadAllState();
 				newFormatDriver = newPreferredFormatDriver();
 
 				// initializeCollection is required to replace the manifest anyway,
@@ -394,7 +394,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				LOGGER.trace("Deleting state documents: {}", deletionFilter);
 				queryCollection.deleteMany(deletionFilter);
 
-				newFormatDriver.initializeCollection(result);
+				newFormatDriver.initializeCollection(result.contents());
 			}
 
 			// We must rudely commit the transaction here, since correctness requires that
@@ -525,12 +525,12 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			LOGGER.debug("onConnectionSucceeded");
 			if (initialStateTask.isDone()) {
 				FormatDriver<R> newDriver;
-				PerTenantValue<StateAndMetadata<R>> contents;
+				AllState<R> allState;
 				try (var _ = queryCollection.newReadOnlySession()) {
 					LOGGER.debug("Loading database state to submit to downstream driver");
 					newDriver = detectFormat();
-					contents = newDriver.loadAllState();
-					LOGGER.trace("Loaded state: {}", contents);
+					allState = newDriver.loadAllState();
+					LOGGER.trace("Loaded state: {}", allState);
 				} catch (UninitializedCollectionException e) {
 					// We don't auto-initialize after the initialStateTask is done
 					throw new DatabaseLoadException("Cannot reload state from database", e);
@@ -548,6 +548,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 				publishFormatDriver(newDriver);
 
+				PerTenantValue<StateAndMetadata<R>> contents = allState.contents();
 				if (contents instanceof PerTenantValue.NoTenant<StateAndMetadata<R>>(var soleContents)) {
 					downstream.submitReplacement(boskInfo.rootReference(), soleContents.state());
 					LOGGER.debug("Done submitting downstream");
@@ -568,7 +569,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				}
 
 				downstream.flush();
-				newDriver.onHasBeenApplied(contents);
+				newDriver.onHasBeenApplied(allState);
 			} else {
 				LOGGER.debug("Running initialStateTask");
 				try {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -382,7 +382,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// with respect to event processing, because both of them have side effects
 			// that affect event processing (field tracking and flush locks, respectively).
 			synchronized (receiver) {
-				AllState<R> result = formatDriver.loadAllState();
+				AllState<R> allState = formatDriver.loadAllState();
 				newFormatDriver = newPreferredFormatDriver();
 
 				// initializeCollection is required to replace the manifest anyway,
@@ -394,7 +394,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				LOGGER.trace("Deleting state documents: {}", deletionFilter);
 				queryCollection.deleteMany(deletionFilter);
 
-				newFormatDriver.initializeCollection(result.contents());
+				newFormatDriver.initializeCollection(allState.contents());
 			}
 
 			// We must rudely commit the transaction here, since correctness requires that
@@ -453,11 +453,14 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	@Override
 	public void flush() throws IOException, InterruptedException {
 		try {
+			// TODO: This could use a read-only session, but doRetryableDriverOperation uses a normal read-write session
+			//  because it was designed for updates rather than flushes.
 			this.<InterruptedException, IOException>doRetryableDriverOperation(() -> {
 				formatDriver.flush();
 			}, "flush");
 		} catch (DisconnectedException | IOException e) {
 			// Callers are expecting a FlushFailureException in these cases
+			// TODO: Is this true for IOException? Why is flush() declared to throw IOException then?
 			throw new FlushFailureException(e);
 		}
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -399,7 +399,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 			// We must rudely commit the transaction here, since correctness requires that
 			// the database updates commit before we publish newFormatDriver.
-			queryCollection.commitTransaction();
+			queryCollection.commitTransactionIfAny();
 
 			publishFormatDriver(newFormatDriver);
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -46,8 +46,8 @@ import works.bosk.drivers.mongo.status.MongoStatus;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.logging.MappedDiagnosticContext.MDCScope;
-import works.bosk.util.PerTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue;
+import works.bosk.util.PerTenantValue.NoTenant;
 
 import static com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL;
 import static com.mongodb.client.model.Sorts.ascending;
@@ -316,10 +316,10 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 		EntireState<R> entireState;
 		try (var _ = queryCollection.newReadOnlySession()){
 			FormatDriver<R> detectedDriver = detectFormat();
-			PerTenant<StateAndMetadata<R>> loadedState = detectedDriver.loadAllState();
+			PerTenantValue<StateAndMetadata<R>> loadedState = detectedDriver.loadAllState();
 			entireState = switch (loadedState.map(StateAndMetadata::state)) {
 				case NoTenant<R>(R root) -> EntireState.just(root);
-				case PerTenant.MultiTenant<R> v -> v.values().entrySet().stream().collect(MultiTree.collector());
+				case PerTenantValue.MultiTenant<R> v -> v.values().entrySet().stream().collect(MultiTree.collector());
 			};
 
 			// Hasn't technically been applied, but we're still initializing the Bosk, and its constructor won't return until the state has been applied
@@ -335,7 +335,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				var session = queryCollection.newSession()
 			) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
-				PerTenant<StateAndMetadata<R>> priorContents = PerTenant.from(entireState, root ->
+				PerTenantValue<StateAndMetadata<R>> priorContents = PerTenantValue.from(entireState, root ->
 					new StateAndMetadata<>(root, REVISION_ZERO, diagnosticAttributes));
 				preferredDriver.initializeCollection(priorContents);
 				session.commitTransactionIfAny();
@@ -382,7 +382,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			// with respect to event processing, because both of them have side effects
 			// that affect event processing (field tracking and flush locks, respectively).
 			synchronized (receiver) {
-				PerTenant<StateAndMetadata<R>> result = formatDriver.loadAllState();
+				PerTenantValue<StateAndMetadata<R>> result = formatDriver.loadAllState();
 				newFormatDriver = newPreferredFormatDriver();
 
 				// initializeCollection is required to replace the manifest anyway,
@@ -525,7 +525,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			LOGGER.debug("onConnectionSucceeded");
 			if (initialStateTask.isDone()) {
 				FormatDriver<R> newDriver;
-				PerTenant<StateAndMetadata<R>> contents;
+				PerTenantValue<StateAndMetadata<R>> contents;
 				try (var _ = queryCollection.newReadOnlySession()) {
 					LOGGER.debug("Loading database state to submit to downstream driver");
 					newDriver = detectFormat();
@@ -548,7 +548,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 				publishFormatDriver(newDriver);
 
-				if (contents instanceof PerTenant.NoTenant<StateAndMetadata<R>>(var soleContents)) {
+				if (contents instanceof PerTenantValue.NoTenant<StateAndMetadata<R>>(var soleContents)) {
 					downstream.submitReplacement(boskInfo.rootReference(), soleContents.state());
 					LOGGER.debug("Done submitting downstream");
 				} else {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -323,7 +323,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			};
 
 			// Hasn't technically been applied, but we're still initializing the Bosk, and its constructor won't return until the state has been applied
-			detectedDriver.hasBeenApplied(loadedState);
+			detectedDriver.onHasBeenApplied(loadedState);
 
 			publishFormatDriver(detectedDriver);
 		} catch (UninitializedCollectionException e) {
@@ -404,7 +404,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			publishFormatDriver(newFormatDriver);
 
 			// Refurbish doesn't actually change what state has been applied to the bosk.
-			// No need to do any downstream submit/flush, nor call hasBeenApplied.
+			// No need to do any downstream submit/flush, nor call onHasBeenApplied.
 		} catch (InvalidCollectionContentsException e) {
 			throw new IOException("Unable to refurbish database collection with invalid contents", e);
 		}
@@ -568,7 +568,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				}
 
 				downstream.flush();
-				newDriver.hasBeenApplied(contents);
+				newDriver.onHasBeenApplied(contents);
 			} else {
 				LOGGER.debug("Running initialStateTask");
 				try {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -1224,8 +1224,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	public void hasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
-		super.hasBeenApplied(contents);
+	public void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
+		super.onHasBeenApplied(contents);
 		finishedContentsRevision(readContentsRevision());
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -10,7 +10,6 @@ import com.mongodb.client.model.changestream.UpdateDescription;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -53,7 +52,6 @@ import works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode;
 import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.drivers.mongo.exceptions.FormatMisconfigurationException;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
-import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.util.PerTenantValue;
@@ -266,8 +264,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	@NonNull PerTenantValue<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
-		LOGGER.debug("readRevisionNumbers");
+	@NonNull PerTenantValue<BsonInt64> readRevisionNumbersToFlush() throws RevisionFieldDisruptedException {
+		LOGGER.debug("readRevisionNumbersToFlush");
 		try {
 			return switch (format.tenancyFormat()) {
 				case NONE -> {
@@ -348,7 +346,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	@Override
 	public void initializeCollection(PerTenantValue<StateAndMetadata<R>> priorContentsArg) {
 		var allPriorContents = normalizePerTenant(validateAndNormalize(priorContentsArg));
-		ensureFlushLocksInitialized(allPriorContents);
+		replaceFlushLocks(allPriorContents.map(StateAndMetadata::revision));
 		allPriorContents.forEach((tenant, priorContents) -> {
 			BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
 			BsonInt64 revision = nextRevision(priorContents.revision());
@@ -528,15 +526,15 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				MapValue<String> diagnosticAttributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
 
 				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
-				if (shouldSkip(tenant, revision)) {
-					LOGGER.debug("Skipping revision {}", revision.longValue());
-					return;
-				}
-
 				try (
 					var _ = context.withTenant(tenant);
 					var _ = context.withOnly(diagnosticAttributes)
 				) {
+					if (shouldSkip(revision)) {
+						LOGGER.debug("Skipping revision {}", revision.longValue());
+						return;
+					}
+
 					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
 					if (state == null) {
 						// Final event has only the new revision number; the previous event is the main event.
@@ -556,18 +554,19 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			} break;
 			case UPDATE: {
 				// TODO: Combine code with INSERT and REPLACE events
-				BsonInt64 revision = formatter.getRevisionFromUpdateEvent(finalEvent);
-				if (shouldSkip(tenant, revision)) {
-					LOGGER.debug("Skipping revision {}", revision.longValue());
-					return;
-				}
 				BsonString docId = finalEvent.getDocumentKey().getString("_id");
 				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
 				MapValue<String> attributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
+				BsonInt64 revision;
 				try (
 					var _ = context.withTenant(tenant);
 					var _ = context.withOnly(attributes)
 				) {
+					revision = formatter.getRevisionFromUpdateEvent(finalEvent);
+					if (shouldSkip(revision)) {
+						LOGGER.debug("Skipping revision {}", revision.longValue());
+						return;
+					}
 					boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
 					if (mainEventIsFinalEvent) {
 						LOGGER.debug("Main event is final event");
@@ -1252,16 +1251,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	public void onHasBeenApplied(AllState<R> allState) {
 		super.onHasBeenApplied(allState);
 		finishedContentsRevision(readContentsRevision());
-	}
-
-	@Override
-	protected void additionalFlushWaits() throws IOException, InterruptedException {
-		BsonInt64 contentsRevision = readContentsRevision();
-		try {
-			contentsFlushLock.awaitRevision(contentsRevision);
-		} catch (FlushFailureException e) {
-			throw new IOException("Timed out waiting for !contents revision", e);
-		}
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -62,6 +62,8 @@ import works.bosk.util.PerTenant.NoTenant;
 
 import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Filters.regex;
+import static com.mongodb.client.model.Projections.fields;
+import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.changestream.OperationType.DELETE;
 import static com.mongodb.client.model.changestream.OperationType.INSERT;
 import static com.mongodb.client.model.changestream.OperationType.UPDATE;
@@ -92,6 +94,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	private final List<Reference<? extends EnumerableByIdentifier<?>>> graftPoints;
 
 	private static final BsonString ROOT_PATH = new BsonString("/");
+	private static final BsonString CONTENTS_ID = new BsonString("!contents");
+
 
 	PandoFormatDriver(
 		BoskInfo<R> boskInfo,
@@ -263,24 +267,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		};
 	}
 
-	private Set<TenantId> readContentsTenants() {
-		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
-		try (MongoCursor<BsonDocument> cursor = collection.find(filter).limit(1).cursor()) {
-			if (cursor.hasNext()) {
-				BsonDocument doc = cursor.next();
-				BsonDocument tenants = doc.getDocument("tenants", null);
-				if (tenants != null) {
-					Set<TenantId> result = new HashSet<>();
-					for (String key : tenants.keySet()) {
-						result.add(new TenantId(Identifier.from(key)));
-					}
-					return result;
-				}
-			}
-		}
-		return Set.of();
-	}
-
 	@Override
 	@NonNull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
 		LOGGER.debug("readRevisionNumbers");
@@ -401,27 +387,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		LOGGER.trace("| Options: {}", options);
 		UpdateResult result = collection.updateOne(filter, update, options);
 		LOGGER.debug("| Result: {}", result);
-	}
-
-	private @NonNull BsonInt64 writeContentsDocument(PerTenant<?> contents) {
-		collection.ensureTransactionStarted();
-		BsonInt64 revision = nextRevision(REVISION_ZERO);
-		BsonDocument tenantsDoc = new BsonDocument();
-		contents.forEach((tenant, _) -> {
-			switch (tenant) {
-				case None _ -> {}
-				case TenantId tid -> tenantsDoc.put(tid.tenant().toString(), TRUE);
-			}
-		});
-		BsonDocument contentsDoc = new BsonDocument("_id", CONTENTS_ID);
-		contentsDoc.put(DocumentFields.revision.name(), revision);
-		if (!tenantsDoc.isEmpty()) {
-			contentsDoc.put("tenants", tenantsDoc);
-		}
-		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
-		LOGGER.debug("| Write !contents document with revision {} and tenants {}", revision.longValue(), tenantsDoc.keySet());
-		collection.replaceOne(filter, contentsDoc, new ReplaceOptions().upsert(true));
-		return revision;
 	}
 
 	private static @NonNull BsonInt64 nextRevision(BsonInt64 priorRevision) {
@@ -1175,6 +1140,67 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 	}
 
+	private BsonInt64 readContentsRevision() {
+		try (MongoCursor<BsonDocument> cursor = collection
+			.withReadConcern(LOCAL)
+			.find(new BsonDocument("_id", CONTENTS_ID))
+			.projection(fields(include("_id", DocumentFields.revision.name())))
+			.cursor()) {
+			if (cursor.hasNext()) {
+				return cursor.next().getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+			}
+			return REVISION_ZERO;
+		}
+	}
+
+	private Set<TenantId> readContentsTenants() {
+		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
+		try (MongoCursor<BsonDocument> cursor = collection.find(filter).limit(1).cursor()) {
+			if (cursor.hasNext()) {
+				BsonDocument doc = cursor.next();
+				BsonDocument tenants = doc.getDocument("tenants", null);
+				if (tenants != null) {
+					Set<TenantId> result = new HashSet<>();
+					for (String key : tenants.keySet()) {
+						result.add(new TenantId(Identifier.from(key)));
+					}
+					return result;
+				}
+			}
+		}
+		return Set.of();
+	}
+
+	private @NonNull BsonInt64 writeContentsDocument(PerTenant<?> contents) {
+		collection.ensureTransactionStarted();
+		BsonInt64 revision = nextRevision(REVISION_ZERO);
+		BsonDocument tenantsDoc = new BsonDocument();
+		contents.forEach((tenant, _) -> {
+			switch (tenant) {
+				case None _ -> {}
+				case TenantId tid -> tenantsDoc.put(tid.tenant().toString(), TRUE);
+			}
+		});
+		BsonDocument contentsDoc = new BsonDocument("_id", CONTENTS_ID);
+		contentsDoc.put(DocumentFields.revision.name(), revision);
+		if (!tenantsDoc.isEmpty()) {
+			contentsDoc.put("tenants", tenantsDoc);
+		}
+		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
+		LOGGER.debug("| Write !contents document with revision {} and tenants {}", revision.longValue(), tenantsDoc.keySet());
+		collection.replaceOne(filter, contentsDoc, new ReplaceOptions().upsert(true));
+		return revision;
+	}
+
+	private void addTenantToContents(TenantId tenant) {
+		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
+		BsonDocument update = new BsonDocument()
+			.append("$inc", new BsonDocument(DocumentFields.revision.name(), new BsonInt64(1)))
+			.append("$set", new BsonDocument("tenants." + tenant.tenant(), TRUE));
+		LOGGER.debug("| Add tenant {} to !contents", tenant.tenant());
+		collection.updateOne(filter, update, new UpdateOptions().upsert(true));
+	}
+
 	private void removeTenantFromContents() {
 		switch (context.getEstablishedTenant()) {
 			case None _ -> {
@@ -1191,14 +1217,16 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 	}
 
-	private void addTenantToContents(TenantId tenant) {
-		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
-		BsonDocument update = new BsonDocument()
-			.append("$inc", new BsonDocument(DocumentFields.revision.name(), new BsonInt64(1)))
-			.append("$set", new BsonDocument("tenants." + tenant.tenant(), TRUE));
-		LOGGER.debug("| Add tenant {} to !contents", tenant.tenant());
-		collection.updateOne(filter, update, new UpdateOptions().upsert(true));
+	private void finishedContentsRevision(BsonInt64 revision) {
+		if (revision != null) {
+			contentsFlushLock.finishedRevision(revision);
+		}
 	}
+
+	private boolean isContentsID(BsonValue documentId) {
+		return CONTENTS_ID.equals(documentId);
+	}
+
 
 	/**
 	 * @param value is mutated to stub-out the parts written to the database

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -614,13 +614,19 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	/**
 	 * Handles a change event for the {@code !contents} document.
 	 * <p>
-	 * The {@code !contents} document is bookkeeping only: it records which tenants exist and
-	 * carries the {@code contentsFlushLock} revision. The actual tenant creations and deletions
-	 * are driven entirely by the tenants' own state-document events (see {@link #processTree}),
-	 * so this method does <em>not</em> propagate anything downstream. Its responsibilities are:
+	 * The {@code !contents} document is the authoritative record of which tenants currently exist:
+	 * {@link #readBsonStateAndMetadata} consults it to ignore stale state documents of tenants that
+	 * have been deleted (which, in {@link OrphanDocumentMode#HASTY HASTY} mode, may linger in the
+	 * database). It also carries a revision number that advances on every tenant creation or
+	 * deletion, giving {@link #flush} a single point to wait on ({@link #contentsFlushLock}) to know
+	 * the change stream has caught up with the tenant set.
+	 * <p>
+	 * What {@code !contents} is <em>not</em> is a source of downstream updates: the actual tenant
+	 * creations and deletions are driven entirely by the tenants' own state-document events (see
+	 * {@link #processTree}), so this method never propagates anything downstream. It only keeps the
+	 * flush machinery in step:
 	 * <ol><li>
-	 *     Advance {@link #contentsFlushLock} so that {@link #readRevisionNumbersToFlush} can tell
-	 *     when the change stream has caught up with tenant creations and deletions.
+	 *     Advance {@link #contentsFlushLock} to the new revision.
 	 * </li><li>
 	 *     Drop any removed tenants from {@link #flushLocks}. A tenant's flush lock tracks a
 	 *     monotonically increasing revision number for as long as the tenant exists; removing the
@@ -633,15 +639,48 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	 * own state-document events, so by now the state-driven deletion has already been applied and
 	 * the lock has already advanced to its final revision.
 	 */
-	private void handleContentsEvent(ChangeStreamDocument<BsonDocument> contentsEvent) {
-		if (contentsEvent.getOperationType() != UPDATE) {
-			// INSERT/REPLACE happen only during initializeCollection, which advances
-			// contentsFlushLock directly, so there's nothing to do here.
-			LOGGER.debug("Ignoring non-UPDATE !contents event: {}", contentsEvent.getOperationType());
-			return;
+	private void handleContentsEvent(ChangeStreamDocument<BsonDocument> contentsEvent) throws UnprocessableEventException {
+		BsonInt64 revision;
+		switch (contentsEvent.getOperationType()) {
+			case UPDATE -> {
+				revision = formatter.getRevisionFromUpdateEvent(contentsEvent);
+				// End the revision-tracking lifecycle of any tenants removed from !contents.
+				UpdateDescription updateDescription = contentsEvent.getUpdateDescription();
+				if (updateDescription != null) {
+					List<String> removedFields = updateDescription.getRemovedFields();
+					if (removedFields != null) {
+						for (String removedField : removedFields) {
+							if (removedField.startsWith("tenants.")) {
+								String tenantIdStr = removedField.substring("tenants.".length());
+								TenantId removedTenant = new TenantId(Identifier.from(tenantIdStr));
+								LOGGER.debug("| Drop flush lock for removed tenant {}", removedTenant);
+								flushLocks.removeFor(removedTenant);
+							}
+						}
+					}
+				}
+			}
+			case INSERT -> {
+				// initializeCollection (initialState and refurbish) writes the whole !contents
+				// document at once. We can't diff the tenant set from an insert, but we don't need
+				// to: tenant creations and deletions are driven by state-document events, so all we
+				// do here is pick up the new revision.
+				BsonDocument fullDocument = contentsEvent.getFullDocument();
+				if (fullDocument == null) {
+					throw new UnprocessableEventException("Missing fullDocument on !contents insert", contentsEvent.getOperationType());
+				}
+				revision = fullDocument.getInt64(DocumentFields.revision.name(), null);
+			}
+			case DELETE -> {
+				// refurbish() deletes every non-manifest document (including !contents) and then
+				// re-creates them in the same transaction, so this delete is immediately followed
+				// by an insert that re-establishes the revision. There's nothing to do for the
+				// delete itself.
+				return;
+			}
+			default -> throw new UnprocessableEventException("Unexpected !contents event", contentsEvent.getOperationType());
 		}
 
-		BsonInt64 revision = formatter.getRevisionFromUpdateEvent(contentsEvent);
 		if (revision == null) {
 			return;
 		}
@@ -649,22 +688,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		if (contentsFlushLock.alreadySeen(revision)) {
 			LOGGER.debug("Skipping !contents revision {}", revision.longValue());
 			return;
-		}
-
-		// End the revision-tracking lifecycle of any tenants removed from !contents.
-		UpdateDescription updateDescription = contentsEvent.getUpdateDescription();
-		if (updateDescription != null) {
-			List<String> removedFields = updateDescription.getRemovedFields();
-			if (removedFields != null) {
-				for (String removedField : removedFields) {
-					if (removedField.startsWith("tenants.")) {
-						String tenantIdStr = removedField.substring("tenants.".length());
-						TenantId removedTenant = new TenantId(Identifier.from(tenantIdStr));
-						LOGGER.debug("| Drop flush lock for removed tenant {}", removedTenant);
-						flushLocks.removeFor(removedTenant);
-					}
-				}
-			}
 		}
 
 		// TODO: Use the tenant set in this event as a consistency check against the tenants

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -862,8 +862,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			if (target.isRoot() && format.tenancyFormat() == MongoDriverSettings.TenancyFormat.ID_PREFIX && !isTenantInContents()) {
 				// Tenant was removed (e.g. via submitDeletion); re-create it
 				var tid = context.getTenantId();
-				addTenantToContents(tid);
 				initializeTenant(tid, value, nextRevision(REVISION_ZERO));
+				addTenantToContents(tid);
 
 				// For newly created tenants, we use the change stream event to
 				// update the downstream driver. We could manually stuff it downstream,
@@ -884,8 +884,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			} catch (NoSuchTenantException e) {
 				var tid = context.getTenantId();
 				if (target.isRoot()) {
-					addTenantToContents(tid);
 					initializeTenant(tid, value, nextRevision(REVISION_ZERO));
+					addTenantToContents(tid);
 
 					// For newly created tenants, we use the change stream event to
 					// update the downstream driver. We could manually stuff it downstream,

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -226,9 +226,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// This is just a way of describing what we've found in the database.
 					states.put(documentTenant, new BsonStateAndMetadata(
 						id,
-						state,
 						revision,
-						diagnosticAttributes
+						diagnosticAttributes,
+						state
 					));
 
 					partsBuffer.clear();

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -12,7 +12,7 @@ import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -52,6 +52,7 @@ import works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode;
 import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.drivers.mongo.exceptions.FormatMisconfigurationException;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
+import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.util.PerTenantValue;
@@ -139,15 +140,23 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	@Override
 	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
 		collection.ensureTransactionStarted();
-		Reference<?> mainRef = mainRef(target);
-		BsonDocument filter = documentFilter(mainRef)
-			.append(BsonFormatter.dottedFieldNameOf(target, mainRef), new BsonDocument("$exists", TRUE));
-		if (documentExists(filter)) {
-			LOGGER.debug("Already exists: {}", filter);
-			collection.abortTransaction();
+		if (target.isRoot() && format.tenancyFormat() == MongoDriverSettings.TenancyFormat.ID_PREFIX) {
+			if (isTenantInContents()) {
+				LOGGER.debug("Already exists: tenant {} is in !contents", context.getEstablishedTenant());
+				collection.abortTransaction();
+				return;
+			}
 		} else {
-			doReplacement(target, newValue);
+			Reference<?> mainRef = mainRef(target);
+			BsonDocument filter = documentFilter(mainRef)
+				.append(BsonFormatter.dottedFieldNameOf(target, mainRef), new BsonDocument("$exists", TRUE));
+			if (documentExists(filter)) {
+				LOGGER.debug("Already exists: {}", filter);
+				collection.abortTransaction();
+				return;
+			}
 		}
+		doReplacement(target, newValue);
 	}
 
 	@Override
@@ -162,6 +171,10 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			collection.abortTransaction();
 			return;
 		}
+		if (format.tenancyFormat() == MongoDriverSettings.TenancyFormat.ID_PREFIX && !isTenantInContents()) {
+			collection.abortTransaction();
+			return;
+		}
 		doReplacement(target, newValue);
 	}
 
@@ -172,13 +185,19 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			collection.abortTransaction();
 			return;
 		}
+		if (format.tenancyFormat() == MongoDriverSettings.TenancyFormat.ID_PREFIX && !isTenantInContents()) {
+			collection.abortTransaction();
+			return;
+		}
 		doDelete(target);
 	}
 
 	@Override
 	BsonAllState readBsonStateAndMetadata() throws InvalidCollectionContentsException {
-		// Read the !contents document to get the authoritative tenant list
-		Set<TenantId> contentsTenants = readContentsTenants();
+		// Read the !contents document to get the authoritative tenant list and revision
+		ContentsDoc contentsDoc = readContents();
+		Set<TenantId> contentsTenants = contentsDoc.tenants();
+		BsonInt64 contentsRevision = contentsDoc.revision();
 
 		// Look for runs of state documents with the same tenant info.
 		// Make a BsonStateAndMetadata for each run.
@@ -222,9 +241,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// This is just a way of describing what we've found in the database.
 					states.put(documentTenant, new BsonStateAndMetadata(
 						id,
-						revision,
-						diagnosticAttributes,
-						state
+						revision, diagnosticAttributes, state
 					));
 
 					partsBuffer.clear();
@@ -260,11 +277,11 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			case ID_PREFIX -> states.entrySet().stream()
 				.filter(e -> e.getKey() != Tenant.NONE)
 				.collect(multiTenant(e -> (TenantId) e.getKey(), Entry::getValue));
-		}, null);
+		}, contentsRevision);
 	}
 
 	@Override
-	@NonNull PerTenantValue<BsonInt64> readRevisionNumbersToFlush() throws RevisionFieldDisruptedException {
+	@NonNull PerTenantValue<BsonInt64> readRevisionNumbersToFlush() throws FlushFailureException, InterruptedException {
 		LOGGER.debug("readRevisionNumbersToFlush");
 		try {
 			return switch (format.tenancyFormat()) {
@@ -291,10 +308,21 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 						while (cursor.hasNext()) {
 							BsonDocument doc = cursor.next();
 							if (getTenantFromDocumentId(doc.getString("_id")) instanceof TenantId tid) {
-								revisions.put(tid, doc.getInt64(DocumentFields.revision.name(), REVISION_ZERO));
+								revisions.put(tid, doc.getInt64(DocumentFields.revision.name()));
 							}
 						}
 					}
+
+					var contents = readContents();
+					// Wait for !contents so we've seen all the necessary tenant management events.
+					LOGGER.debug("Await !contents revision {}", contents.revision());
+					contentsFlushLock.awaitRevision(contents.revision());
+
+					// Only include tenants that existed at the !contents point-in-time.
+					// Any tenant missing from !contents was deleted concurrently,
+					// so we have no obligation to wait for it.
+					revisions.keySet().retainAll(contents.tenants());
+
 					yield new MultiTenant<>(revisions);
 				}
 			};
@@ -361,7 +389,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				finishedRevision(tenant, revision);
 			}
 		});
-		BsonInt64 contentsRevision = writeContentsDocument(allPriorContents);
+		BsonInt64 priorContentsRevision = readContentsRevision();
+		BsonInt64 contentsRevision = writeContentsDocument(allPriorContents, priorContentsRevision);
 		finishedContentsRevision(contentsRevision);
 		writeManifest(Manifest.forPando(format));
 	}
@@ -502,108 +531,118 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 
 		// Handle !contents events (tenant removals and additions)
+		BsonInt64 contentsRevision = null;
 		for (var contentsEvent : contentsEvents) {
-			handleContentsEvent(contentsEvent, tenantEvents);
-		}
-
-		if (tenantEvents.isEmpty()) {
-			return;
-		}
-
-		ChangeStreamDocument<BsonDocument> finalEvent = tenantEvents.getLast();
-		Established tenant = tenantFor(finalEvent.getDocumentKey().getString("_id"));
-		switch (finalEvent.getOperationType()) {
-			case INSERT: case REPLACE: {
-				BsonDocument fullDocument = finalEvent.getFullDocument();
-				if (fullDocument == null) {
-					throw new UnprocessableEventException("Missing fullDocument on final event", finalEvent.getOperationType());
-				}
-
-				// Grab the tenant and diagnostics early. If we're supposed to skip this event,
-				// we still need to stash the tenant for later events.
-				BsonString docId = finalEvent.getDocumentKey().getString("_id");
-				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
-				MapValue<String> diagnosticAttributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
-
-				BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
-				try (
-					var _ = context.withTenant(tenant);
-					var _ = context.withOnly(diagnosticAttributes)
-				) {
-					if (shouldSkip(revision)) {
-						LOGGER.debug("Skipping revision {}", revision.longValue());
-						return;
-					}
-
-					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
-					if (state == null) {
-						// Final event has only the new revision number; the previous event is the main event.
-						// A standalone INSERT/REPLACE always has a state field; lacking one is nonsensical
-						// and implies a programming error or an unexpected database state.
-						assert tenantEvents.size() >= 2 : "INSERT/REPLACE without state needs a prior main event";
-						ChangeStreamDocument<BsonDocument> mainEvent = tenantEvents.get(tenantEvents.size() - 2);
-						LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
-						propagateDownstream(mainEvent, tenantEvents.subList(0, tenantEvents.size() - 2));
-					} else {
-						LOGGER.debug("Main event is final event");
-						propagateDownstream(finalEvent, tenantEvents.subList(0, tenantEvents.size() - 1));
-					}
-				}
-
-				finishedRevision(tenant, revision);
-			} break;
-			case UPDATE: {
-				// TODO: Combine code with INSERT and REPLACE events
-				BsonString docId = finalEvent.getDocumentKey().getString("_id");
-				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
-				MapValue<String> attributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
-				BsonInt64 revision;
-				try (
-					var _ = context.withTenant(tenant);
-					var _ = context.withOnly(attributes)
-				) {
-					revision = formatter.getRevisionFromUpdateEvent(finalEvent);
-					if (shouldSkip(revision)) {
-						LOGGER.debug("Skipping revision {}", revision.longValue());
-						return;
-					}
-					boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
-					if (mainEventIsFinalEvent) {
-						LOGGER.debug("Main event is final event");
-						propagateDownstream(finalEvent, tenantEvents.subList(0, tenantEvents.size() - 1));
-					} else if (tenantEvents.size() < 2) {
-						LOGGER.debug("Main event is a no-op");
-					} else {
-						ChangeStreamDocument<BsonDocument> mainEvent = tenantEvents.get(tenantEvents.size() - 2);
-						LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
-						propagateDownstream(mainEvent, tenantEvents.subList(0, tenantEvents.size() - 2));
-					}
-				}
-				finishedRevision(tenant, revision);
-			} break;
-			case DELETE: {
-				finishedRevision(tenant, REVISION_ZERO);
-			} break;
-			default: {
-				throw new UnprocessableEventException("Cannot process event", finalEvent.getOperationType());
+			BsonInt64 revision = handleContentsEvent(contentsEvent, tenantEvents);
+			if (revision != null) {
+				contentsRevision = revision;
 			}
+		}
+
+		if (!tenantEvents.isEmpty()) {
+			ChangeStreamDocument<BsonDocument> finalEvent = tenantEvents.getLast();
+			Established tenant = tenantFor(finalEvent.getDocumentKey().getString("_id"));
+			switch (finalEvent.getOperationType()) {
+				case INSERT: case REPLACE: {
+					BsonDocument fullDocument = finalEvent.getFullDocument();
+					if (fullDocument == null) {
+						throw new UnprocessableEventException("Missing fullDocument on final event", finalEvent.getOperationType());
+					}
+
+					// Grab the tenant and diagnostics early. If we're supposed to skip this event,
+					// we still need to stash the tenant for later events.
+					BsonString docId = finalEvent.getDocumentKey().getString("_id");
+					BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
+					MapValue<String> diagnosticAttributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
+
+					BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
+					try (
+						var _ = context.withTenant(tenant);
+						var _ = context.withOnly(diagnosticAttributes)
+					) {
+						if (shouldSkip(revision)) {
+							LOGGER.debug("Skipping revision {}", revision.longValue());
+							return;
+						}
+
+						BsonDocument state = fullDocument.getDocument(DocumentFields.state.name());
+						if (state == null) {
+							// Final event has only the new revision number; the previous event is the main event.
+							// A standalone INSERT/REPLACE always has a state field; lacking one is nonsensical
+							// and implies a programming error or an unexpected database state.
+							assert tenantEvents.size() >= 2 : "INSERT/REPLACE without state needs a prior main event";
+							ChangeStreamDocument<BsonDocument> mainEvent = tenantEvents.get(tenantEvents.size() - 2);
+							LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
+							propagateDownstream(mainEvent, tenantEvents.subList(0, tenantEvents.size() - 2));
+						} else {
+							LOGGER.debug("Main event is final event");
+							propagateDownstream(finalEvent, tenantEvents.subList(0, tenantEvents.size() - 1));
+						}
+					}
+
+					finishedRevision(tenant, revision);
+				} break;
+				case UPDATE: {
+					// TODO: Combine code with INSERT and REPLACE events
+					BsonString docId = finalEvent.getDocumentKey().getString("_id");
+					BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
+					MapValue<String> attributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
+					BsonInt64 revision;
+					try (
+						var _ = context.withTenant(tenant);
+						var _ = context.withOnly(attributes)
+					) {
+						revision = formatter.getRevisionFromUpdateEvent(finalEvent);
+						if (shouldSkip(revision)) {
+							LOGGER.debug("Skipping revision {}", revision.longValue());
+							return;
+						}
+						boolean mainEventIsFinalEvent = updateEventHasField(finalEvent, DocumentFields.state); // If the final update changes only the revision field, then it's not the main event
+						if (mainEventIsFinalEvent) {
+							LOGGER.debug("Main event is final event");
+							propagateDownstream(finalEvent, tenantEvents.subList(0, tenantEvents.size() - 1));
+						} else if (tenantEvents.size() < 2) {
+							LOGGER.debug("Main event is a no-op");
+						} else {
+							ChangeStreamDocument<BsonDocument> mainEvent = tenantEvents.get(tenantEvents.size() - 2);
+							LOGGER.debug("Main event is {} on {}", mainEvent.getOperationType(), mainEvent.getDocumentKey());
+							propagateDownstream(mainEvent, tenantEvents.subList(0, tenantEvents.size() - 2));
+						}
+					}
+					finishedRevision(tenant, revision);
+				} break;
+				case DELETE: {
+					finishedRevision(tenant, REVISION_ZERO);
+				} break;
+				default: {
+					throw new UnprocessableEventException("Cannot process event", finalEvent.getOperationType());
+				}
+			}
+		}
+
+		// Signal the contents flush lock after all state updates are complete.
+		// This must happen after propagateDownstream and finishedRevision so
+		// that the per-tenant flush lock is in the flushLocks map before the
+		// contentsFlushLock signals "caught up".
+		if (contentsRevision != null) {
+			finishedContentsRevision(contentsRevision);
 		}
 	}
 
-	private void handleContentsEvent(ChangeStreamDocument<BsonDocument> contentsEvent, List<ChangeStreamDocument<BsonDocument>> tenantEvents) throws UnprocessableEventException {
+	private @Nullable BsonInt64 handleContentsEvent(ChangeStreamDocument<BsonDocument> contentsEvent, List<ChangeStreamDocument<BsonDocument>> tenantEvents) throws UnprocessableEventException {
 		if (contentsEvent.getOperationType() != UPDATE) {
 			LOGGER.debug("Ignoring non-UPDATE !contents event: {}", contentsEvent.getOperationType());
-			return;
+			return null;
 		}
 
 		BsonInt64 revision = formatter.getRevisionFromUpdateEvent(contentsEvent);
 		if (revision == null) {
-			return;
+			return null;
 		}
 
 		if (contentsFlushLock.alreadySeen(revision)) {
 			LOGGER.debug("Skipping !contents revision {}", revision.longValue());
-			return;
+			return null;
 		}
 
 		// Extract removed tenants and submit deletions
@@ -626,7 +665,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			}
 		}
 
-		finishedContentsRevision(revision);
+		return revision;
 	}
 
 	private MapValue<String> findDiagnosticsForTenant(List<ChangeStreamDocument<BsonDocument>> tenantEvents, String tenantIdStr) {
@@ -820,6 +859,19 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 		if (rootRef.equals(mainRef)) {
 			LOGGER.debug("| Root ref is main ref");
+			if (target.isRoot() && format.tenancyFormat() == MongoDriverSettings.TenancyFormat.ID_PREFIX && !isTenantInContents()) {
+				// Tenant was removed (e.g. via submitDeletion); re-create it
+				var tid = context.getTenantId();
+				addTenantToContents(tid);
+				initializeTenant(tid, value, nextRevision(REVISION_ZERO));
+
+				// For newly created tenants, we use the change stream event to
+				// update the downstream driver. We could manually stuff it downstream,
+				// but the change stream path needs to work for remote bosks anyway,
+				// so we might as well reduce variety and make that the only way.
+				finishedRevision(REVISION_BEFORE_ANY);
+				return;
+			}
 			LOGGER.debug("| Pre-delete on root document");
 			String key = BsonFormatter.dottedFieldNameOf(target, rootRef);
 			try {
@@ -839,7 +891,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// update the downstream driver. We could manually stuff it downstream,
 					// but the change stream path needs to work for remote bosks anyway,
 					// so we might as well reduce variety and make that the only way.
-					finishedRevision(tid, REVISION_BEFORE_ANY);
+					finishedRevision(REVISION_BEFORE_ANY);
 				}
 			}
 		} else try {
@@ -1137,6 +1189,42 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 	}
 
+	record ContentsDoc(BsonInt64 revision, Set<TenantId> tenants) { }
+
+	private ContentsDoc readContents() {
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", CONTENTS_ID))
+			.cursor()
+		) {
+			BsonDocument doc = cursor.next();
+			BsonInt64 revision = doc.getInt64(DocumentFields.revision.name());
+			Set<TenantId> tenants = new LinkedHashSet<>();
+			BsonDocument tenantsDoc = doc.getDocument("tenants");
+			for (String key : tenantsDoc.keySet()) {
+				tenants.add(new TenantId(Identifier.from(key)));
+			}
+			return new ContentsDoc(revision, tenants);
+		}
+	}
+
+	/**
+	 * Uses the current session, rather than the latest value from the database,
+	 * for better determinism and reproducibility.
+	 */
+	private boolean isTenantInContents() {
+		try (MongoCursor<BsonDocument> cursor = collection
+			.find(new BsonDocument("_id", CONTENTS_ID))
+			.cursor()
+		) {
+			if (!cursor.hasNext()) {
+				return false;
+			}
+			BsonDocument doc = cursor.next();
+			BsonDocument tenantsDoc = doc.getDocument("tenants", new BsonDocument());
+			return tenantsDoc.containsKey(((TenantId) context.getEstablishedTenant()).tenant().toString());
+		}
+	}
+
 	private BsonInt64 readContentsRevision() {
 		try (MongoCursor<BsonDocument> cursor = collection
 			.findLatest(new BsonDocument("_id", CONTENTS_ID))
@@ -1149,27 +1237,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 	}
 
-	private Set<TenantId> readContentsTenants() {
-		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
-		try (MongoCursor<BsonDocument> cursor = collection.find(filter).limit(1).cursor()) {
-			if (cursor.hasNext()) {
-				BsonDocument doc = cursor.next();
-				BsonDocument tenants = doc.getDocument("tenants", null);
-				if (tenants != null) {
-					Set<TenantId> result = new HashSet<>();
-					for (String key : tenants.keySet()) {
-						result.add(new TenantId(Identifier.from(key)));
-					}
-					return result;
-				}
-			}
-		}
-		return Set.of();
-	}
-
-	private @NonNull BsonInt64 writeContentsDocument(PerTenantValue<?> contents) {
+	private @NonNull BsonInt64 writeContentsDocument(PerTenantValue<?> contents, BsonInt64 priorRevision) {
 		collection.ensureTransactionStarted();
-		BsonInt64 revision = nextRevision(REVISION_ZERO);
+		BsonInt64 revision = nextRevision(priorRevision);
 		BsonDocument tenantsDoc = new BsonDocument();
 		contents.forEach((tenant, _) -> {
 			switch (tenant) {
@@ -1179,9 +1249,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		});
 		BsonDocument contentsDoc = new BsonDocument("_id", CONTENTS_ID);
 		contentsDoc.put(DocumentFields.revision.name(), revision);
-		if (!tenantsDoc.isEmpty()) {
-			contentsDoc.put("tenants", tenantsDoc);
-		}
+		contentsDoc.put("tenants", tenantsDoc);
 		BsonDocument filter = new BsonDocument("_id", CONTENTS_ID);
 		LOGGER.debug("| Write !contents document with revision {} and tenants {}", revision.longValue(), tenantsDoc.keySet());
 		collection.replaceOne(filter, contentsDoc, new ReplaceOptions().upsert(true));
@@ -1250,7 +1318,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	@Override
 	public void onHasBeenApplied(AllState<R> allState) {
 		super.onHasBeenApplied(allState);
-		finishedContentsRevision(readContentsRevision());
+		finishedContentsRevision(allState.contentsRevision());
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -178,7 +178,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	BsonAllState readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		// Read the !contents document to get the authoritative tenant list
 		Set<TenantId> contentsTenants = readContentsTenants();
 
@@ -241,7 +241,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 		// Note: we tolerate extra documents here, in the spirit of HASTY mode:
 		// documents are not necessarily deleted promptly, so there can be extra ones lying around.
-		return switch (format.tenancyFormat()) {
+		return new BsonAllState(switch (format.tenancyFormat()) {
 			case NONE -> {
 				var theState = states.get(Tenant.NONE);
 				if (theState == null) {
@@ -262,7 +262,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			case ID_PREFIX -> states.entrySet().stream()
 				.filter(e -> e.getKey() != Tenant.NONE)
 				.collect(multiTenant(e -> (TenantId) e.getKey(), Entry::getValue));
-		};
+		}, null);
 	}
 
 	@Override
@@ -1249,8 +1249,8 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	public void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents) {
-		super.onHasBeenApplied(contents);
+	public void onHasBeenApplied(AllState<R> allState) {
+		super.onHasBeenApplied(allState);
 		finishedContentsRevision(readContentsRevision());
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -64,7 +64,6 @@ import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.changestream.OperationType.DELETE;
 import static com.mongodb.client.model.changestream.OperationType.INSERT;
-import static com.mongodb.client.model.changestream.OperationType.UPDATE;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toCollection;
@@ -672,10 +671,21 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				revision = fullDocument.getInt64(DocumentFields.revision.name(), null);
 			}
 			case DELETE -> {
+				// We're cheating a bit here.
 				// refurbish() deletes every non-manifest document (including !contents) and then
 				// re-creates them in the same transaction, so this delete is immediately followed
 				// by an insert that re-establishes the revision. There's nothing to do for the
 				// delete itself.
+				//
+				// However, a deletion could happen for other reasons not involving a refurbish
+				// (eg. a human operator mistakenly deleting the document), so we shouldn't really
+				// be ignoring these. A better approach would be for the refurbish to avoid the
+				// DELETE event, like it already does for !Manifest, but that implies additional
+				// coupling with MainDriver that makes this awkward.
+				//
+				// Let's face it: if someone deletes the contents document, the very next thing
+				// they do (like a flush or update) is likely to fail and disconnect, which
+				// is the right response anyway.
 				return;
 			}
 			default -> throw new UnprocessableEventException("Unexpected !contents event", contentsEvent.getOperationType());

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -56,9 +56,9 @@ import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
 import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
-import works.bosk.util.PerTenant;
-import works.bosk.util.PerTenant.MultiTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue;
+import works.bosk.util.PerTenantValue.MultiTenant;
+import works.bosk.util.PerTenantValue.NoTenant;
 
 import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Filters.regex;
@@ -80,7 +80,7 @@ import static works.bosk.drivers.mongo.internal.Formatter.REVISION_BEFORE_ANY;
 import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
 import static works.bosk.drivers.mongo.internal.Formatter.getTenantFromDocumentId;
 import static works.bosk.util.Classes.enumerableByIdentifier;
-import static works.bosk.util.PerTenant.MultiTenant.multiTenant;
+import static works.bosk.util.PerTenantValue.MultiTenant.multiTenant;
 
 /**
  * Implements {@link PandoFormat}.
@@ -179,7 +179,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	PerTenant<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		// Read the !contents document to get the authoritative tenant list
 		Set<TenantId> contentsTenants = readContentsTenants();
 
@@ -268,7 +268,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	@NonNull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
+	@NonNull PerTenantValue<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
 		LOGGER.debug("readRevisionNumbers");
 		try {
 			return switch (format.tenancyFormat()) {
@@ -348,7 +348,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	public void initializeCollection(PerTenant<StateAndMetadata<R>> priorContentsArg) {
+	public void initializeCollection(PerTenantValue<StateAndMetadata<R>> priorContentsArg) {
 		var allPriorContents = normalizePerTenant(validateAndNormalize(priorContentsArg));
 		ensureFlushLocksInitialized(allPriorContents);
 		allPriorContents.forEach((tenant, priorContents) -> {
@@ -398,7 +398,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	 * where it's coerced into either a {@link NoTenant} or a {@link MultiTenant} with one tenant
 	 * depending on the {@link PandoFormat#tenancyFormat() tenancyFormat}.
 	 */
-	private PerTenant<StateAndMetadata<R>> validateAndNormalize(PerTenant<StateAndMetadata<R>> given) {
+	private PerTenantValue<StateAndMetadata<R>> validateAndNormalize(PerTenantValue<StateAndMetadata<R>> given) {
 		return switch (tenancyModel) {
 			case TenancyModel.None _ -> switch (given) {
 				case NoTenant<StateAndMetadata<R>> v -> v;
@@ -1171,7 +1171,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		return Set.of();
 	}
 
-	private @NonNull BsonInt64 writeContentsDocument(PerTenant<?> contents) {
+	private @NonNull BsonInt64 writeContentsDocument(PerTenantValue<?> contents) {
 		collection.ensureTransactionStarted();
 		BsonInt64 revision = nextRevision(REVISION_ZERO);
 		BsonDocument tenantsDoc = new BsonDocument();
@@ -1252,7 +1252,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	public void onHasBeenApplied(PerTenant<StateAndMetadata<R>> contents) {
+	public void onHasBeenApplied(PerTenantValue<StateAndMetadata<R>> contents) {
 		super.onHasBeenApplied(contents);
 		finishedContentsRevision(readContentsRevision());
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -60,7 +60,6 @@ import works.bosk.util.PerTenantValue;
 import works.bosk.util.PerTenantValue.MultiTenant;
 import works.bosk.util.PerTenantValue.NoTenant;
 
-import static com.mongodb.ReadConcern.LOCAL;
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
@@ -191,8 +190,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}));
 		List<BsonDocument> partsBuffer = new ArrayList<>();
 		try (MongoCursor<BsonDocument> cursor = collection
-			.withReadConcern(LOCAL) // The revision field needs to be the latest
-			.find(regex("_id", "^[|<]"))
+			.findLatest(regex("_id", "^[|<]")) // The revision field needs to be the latest
 			.sort(new BsonDocument("_id", new BsonInt32(-1))) // Root doc last
 			.cursor()
 		) {
@@ -1142,8 +1140,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	private BsonInt64 readContentsRevision() {
 		try (MongoCursor<BsonDocument> cursor = collection
-			.withReadConcern(LOCAL)
-			.find(new BsonDocument("_id", CONTENTS_ID))
+			.findLatest(new BsonDocument("_id", CONTENTS_ID))
 			.projection(fields(include("_id", DocumentFields.revision.name())))
 			.cursor()) {
 			if (cursor.hasNext()) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -476,7 +476,11 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		}
 		if (isContentsID(bsonDocumentID)) {
 			LOGGER.debug("Found !contents event: {} on {}", event.getOperationType(), event.getDocumentKey());
-			routeEvent(event);
+			// !contents events are handled separately from state-document events, and never
+			// enter the demultiplexer. Because we always write !contents last in every
+			// transaction, its change event arrives after the tenant's state-document events,
+			// so by the time we get here those state updates have already been processed.
+			handleContentsEvent(event);
 			return;
 		}
 		if (!(bsonDocumentID instanceof BsonString s) || !(s.getValue().contains("|"))) {
@@ -518,27 +522,9 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				&& updateEventHasField(event, DocumentFields.revision);
 	}
 
-	private void processTree(List<ChangeStreamDocument<BsonDocument>> events) throws UnprocessableEventException {
-		// Separate !contents events from tenant events
-		List<ChangeStreamDocument<BsonDocument>> contentsEvents = new ArrayList<>();
-		List<ChangeStreamDocument<BsonDocument>> tenantEvents = new ArrayList<>(events.size());
-		for (var event : events) {
-			if (isContentsID(event.getDocumentKey().get("_id"))) {
-				contentsEvents.add(event);
-			} else {
-				tenantEvents.add(event);
-			}
-		}
-
-		// Handle !contents events (tenant removals and additions)
-		BsonInt64 contentsRevision = null;
-		for (var contentsEvent : contentsEvents) {
-			BsonInt64 revision = handleContentsEvent(contentsEvent, tenantEvents);
-			if (revision != null) {
-				contentsRevision = revision;
-			}
-		}
-
+	private void processTree(List<ChangeStreamDocument<BsonDocument>> tenantEvents) throws UnprocessableEventException {
+		// This only ever sees tenant state-document events. !contents events are handled
+		// separately in handleContentsEvent and never enter the demultiplexer.
 		if (!tenantEvents.isEmpty()) {
 			ChangeStreamDocument<BsonDocument> finalEvent = tenantEvents.getLast();
 			Established tenant = tenantFor(finalEvent.getDocumentKey().getString("_id"));
@@ -612,6 +598,10 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					finishedRevision(tenant, revision);
 				} break;
 				case DELETE: {
+					// A root document is only ever deleted after its state field has already been
+					// unset (see doDelete), and that earlier $unset event is what drives the
+					// downstream deletion. By the time we see the document DELETE itself, the
+					// tenant is already gone downstream, so there's nothing to propagate here.
 					finishedRevision(tenant, REVISION_ZERO);
 				} break;
 				default: {
@@ -619,33 +609,49 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 				}
 			}
 		}
-
-		// Signal the contents flush lock after all state updates are complete.
-		// This must happen after propagateDownstream and finishedRevision so
-		// that the per-tenant flush lock is in the flushLocks map before the
-		// contentsFlushLock signals "caught up".
-		if (contentsRevision != null) {
-			finishedContentsRevision(contentsRevision);
-		}
 	}
 
-	private @Nullable BsonInt64 handleContentsEvent(ChangeStreamDocument<BsonDocument> contentsEvent, List<ChangeStreamDocument<BsonDocument>> tenantEvents) throws UnprocessableEventException {
+	/**
+	 * Handles a change event for the {@code !contents} document.
+	 * <p>
+	 * The {@code !contents} document is bookkeeping only: it records which tenants exist and
+	 * carries the {@code contentsFlushLock} revision. The actual tenant creations and deletions
+	 * are driven entirely by the tenants' own state-document events (see {@link #processTree}),
+	 * so this method does <em>not</em> propagate anything downstream. Its responsibilities are:
+	 * <ol><li>
+	 *     Advance {@link #contentsFlushLock} so that {@link #readRevisionNumbersToFlush} can tell
+	 *     when the change stream has caught up with tenant creations and deletions.
+	 * </li><li>
+	 *     Drop any removed tenants from {@link #flushLocks}. A tenant's flush lock tracks a
+	 *     monotonically increasing revision number for as long as the tenant exists; removing the
+	 *     tenant from {@code !contents} ends that lifecycle, so we must discard the stale lock.
+	 *     Otherwise, if the same tenant were re-created later (starting again at a low revision
+	 *     number), the leftover lock's higher {@code alreadySeen} value would cause the re-creation
+	 *     event to be wrongly skipped as a duplicate.
+	 * </li></ol>
+	 * Because {@code !contents} is always written last, this event is processed after the tenant's
+	 * own state-document events, so by now the state-driven deletion has already been applied and
+	 * the lock has already advanced to its final revision.
+	 */
+	private void handleContentsEvent(ChangeStreamDocument<BsonDocument> contentsEvent) {
 		if (contentsEvent.getOperationType() != UPDATE) {
+			// INSERT/REPLACE happen only during initializeCollection, which advances
+			// contentsFlushLock directly, so there's nothing to do here.
 			LOGGER.debug("Ignoring non-UPDATE !contents event: {}", contentsEvent.getOperationType());
-			return null;
+			return;
 		}
 
 		BsonInt64 revision = formatter.getRevisionFromUpdateEvent(contentsEvent);
 		if (revision == null) {
-			return null;
+			return;
 		}
 
 		if (contentsFlushLock.alreadySeen(revision)) {
 			LOGGER.debug("Skipping !contents revision {}", revision.longValue());
-			return null;
+			return;
 		}
 
-		// Extract removed tenants and submit deletions
+		// End the revision-tracking lifecycle of any tenants removed from !contents.
 		UpdateDescription updateDescription = contentsEvent.getUpdateDescription();
 		if (updateDescription != null) {
 			List<String> removedFields = updateDescription.getRemovedFields();
@@ -654,31 +660,18 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					if (removedField.startsWith("tenants.")) {
 						String tenantIdStr = removedField.substring("tenants.".length());
 						TenantId removedTenant = new TenantId(Identifier.from(tenantIdStr));
-						MapValue<String> attributes = findDiagnosticsForTenant(tenantEvents, tenantIdStr);
-						try (var _ = context.withTenant(removedTenant);
-							var _ = context.withOnly(attributes)) {
-							LOGGER.debug("| Delete downstream {} (from !contents)", rootRef);
-							downstream.submitDeletion(rootRef);
-						}
+						LOGGER.debug("| Drop flush lock for removed tenant {}", removedTenant);
+						flushLocks.removeFor(removedTenant);
 					}
 				}
 			}
 		}
 
-		return revision;
-	}
+		// TODO: Use the tenant set in this event as a consistency check against the tenants
+		// we've actually created/deleted from state-document events, and react somehow (perhaps
+		// by disconnecting) if they disagree. It's not yet clear what the right reaction is.
 
-	private MapValue<String> findDiagnosticsForTenant(List<ChangeStreamDocument<BsonDocument>> tenantEvents, String tenantIdStr) {
-		String tenantPrefix = "<" + tenantIdStr + ">";
-		for (int i = tenantEvents.size() - 1; i >= 0; i--) {
-			var event = tenantEvents.get(i);
-			BsonValue id = event.getDocumentKey().get("_id");
-			if (id instanceof BsonString s && s.getValue().startsWith(tenantPrefix)) {
-				BsonDocument attrsBson = fieldTracker.getFieldAsDocument(s, DIAGNOSTICS);
-				return attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
-			}
-		}
-		return MapValue.empty();
+		finishedContentsRevision(revision);
 	}
 
 	private void propagateDownstream(ChangeStreamDocument<BsonDocument> mainEvent, List<ChangeStreamDocument<BsonDocument>> priorEvents) throws UnprocessableEventException {
@@ -940,8 +933,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		if (target.isRoot()) {
 			LOGGER.debug("| Delete root {}", target);
 			try {
+				// Unset the state field (bumping revision and recording diagnostics) first: this
+				// is what drives the downstream deletion via the change stream, exactly the same
+				// way any other state node is deleted. The near-empty root document may be left
+				// behind (acceptable in HASTY mode); it must not be physically deleted until its
+				// state has been unset like this.
+				doUpdate(deletionDoc(target, rootRef), standardRootPreconditions(target));
+				// Update !contents last, per the invariant that !contents is always written last.
 				removeTenantFromContents();
-				doUpdate(blankUpdateDoc(), standardRootPreconditions(target));
 			} catch (NoSuchTenantException e) {
 				LOGGER.debug("Tenant is already nonexistent: {}", e.tenant);
 			}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -32,7 +32,6 @@ import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
 import works.bosk.exceptions.InvalidTypeException;
-import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.util.PerTenantValue;
 import works.bosk.util.PerTenantValue.MultiTenant;
 import works.bosk.util.PerTenantValue.NoTenant;
@@ -148,7 +147,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				return switch (tenancyModel) {
 					case None _ -> NoTenant.just(revision);
 					case Fixed(var id) -> MultiTenant.singleton(Tenant.setTo(id), revision);
-					case Explicit _ -> throw new NotYetImplementedException();
+					case Explicit _ -> throw new AssertionError("Sequoia does not support explicit tenancy");
 				};
 			}
 		} catch (NoSuchElementException e) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -139,8 +139,8 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	@NonNull PerTenantValue<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
-		LOGGER.debug("readRevisionNumbers");
+	@NonNull PerTenantValue<BsonInt64> readRevisionNumbersToFlush() throws RevisionFieldDisruptedException {
+		LOGGER.debug("readRevisionNumbersToFlush");
 		try {
 			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
 				// Our revisionDocumentCursor matches only one document
@@ -161,7 +161,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	@Override
 	public void initializeCollection(PerTenantValue<StateAndMetadata<R>> priorContentsArg) {
 		var normalized = normalizePerTenant(priorContentsArg);
-		ensureFlushLocksInitialized(normalized);
+		replaceFlushLocks(normalized.map(StateAndMetadata::revision));
 		normalized.forEach((tenant, priorContents) -> {
 			// Sequoia has only one document regardless of tenancy
 			BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
@@ -248,17 +248,20 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				UpdateDescription updateDescription = event.getUpdateDescription();
 				if (updateDescription != null) {
 					BsonInt64 revision = formatter.getRevisionFromUpdateEvent(event);
-					if (!shouldSkip(tenant, revision)) {
-						BsonString updateDocId = event.getDocumentKey().getString("_id");
-						BsonDocument updateAttrsBson = fieldTracker.getFieldAsDocument(updateDocId, DocumentFieldTracker.TrackedField.DIAGNOSTICS);
-						MapValue<String> diagnosticAttributes = updateAttrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(updateAttrsBson);
-						try (
-							var _ = context.withTenant(tenant);
-							var _ = context.withOnly(diagnosticAttributes)
-						) {
-							replaceUpdatedFields(updateDescription.getUpdatedFields());
-							deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
+					BsonString updateDocId = event.getDocumentKey().getString("_id");
+					BsonDocument updateAttrsBson = fieldTracker.getFieldAsDocument(updateDocId, DocumentFieldTracker.TrackedField.DIAGNOSTICS);
+					MapValue<String> diagnosticAttributes = updateAttrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(updateAttrsBson);
+					try (
+						var _ = context.withTenant(tenant);
+						var _ = context.withOnly(diagnosticAttributes)
+					) {
+						if (shouldSkip(revision)) {
+							LOGGER.debug("Skipping revision {}", revision.longValue());
+							return;
 						}
+
+						replaceUpdatedFields(updateDescription.getUpdatedFields());
+						deleteRemovedFields(updateDescription.getRemovedFields(), event.getOperationType());
 					}
 					finishedRevision(tenant, revision);
 				}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -37,7 +37,6 @@ import works.bosk.util.PerTenantValue;
 import works.bosk.util.PerTenantValue.MultiTenant;
 import works.bosk.util.PerTenantValue.NoTenant;
 
-import static com.mongodb.ReadConcern.LOCAL;
 import static org.bson.BsonBoolean.FALSE;
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
@@ -115,8 +114,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	@Override
 	PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		try (MongoCursor<BsonDocument> cursor = collection
-			.withReadConcern(LOCAL) // The revision field needs to be the latest
-			.find(documentFilter())
+			.findLatest(documentFilter()) // The revision field needs to be the latest
 			.limit(1)
 			.cursor()
 		) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -32,9 +32,9 @@ import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
-import works.bosk.util.PerTenant;
-import works.bosk.util.PerTenant.MultiTenant;
-import works.bosk.util.PerTenant.NoTenant;
+import works.bosk.util.PerTenantValue;
+import works.bosk.util.PerTenantValue.MultiTenant;
+import works.bosk.util.PerTenantValue.NoTenant;
 
 import static com.mongodb.ReadConcern.LOCAL;
 import static org.bson.BsonBoolean.FALSE;
@@ -112,7 +112,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	PerTenant<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		try (MongoCursor<BsonDocument> cursor = collection
 			.withReadConcern(LOCAL) // The revision field needs to be the latest
 			.find(documentFilter())
@@ -138,7 +138,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	@NonNull PerTenant<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
+	@NonNull PerTenantValue<BsonInt64> readRevisionNumbers() throws RevisionFieldDisruptedException {
 		LOGGER.debug("readRevisionNumbers");
 		try {
 			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
@@ -158,7 +158,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	public void initializeCollection(PerTenant<StateAndMetadata<R>> priorContentsArg) {
+	public void initializeCollection(PerTenantValue<StateAndMetadata<R>> priorContentsArg) {
 		var normalized = normalizePerTenant(priorContentsArg);
 		ensureFlushLocksInitialized(normalized);
 		normalized.forEach((tenant, priorContents) -> {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -122,9 +122,9 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			BsonDocument document = cursor.next();
 			var bsm = new BsonStateAndMetadata(
 				document.getString("_id"),
-				document.getDocument(DocumentFields.state.name(), null),
 				document.getInt64(DocumentFields.revision.name(), null),
-				Formatter.getDiagnosticAttributesIfAny(document)
+				Formatter.getDiagnosticAttributesIfAny(document),
+				document.getDocument(DocumentFields.state.name(), null)
 			);
 			return switch (tenancyModel) {
 				case None _ -> NoTenant.just(bsm);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -112,7 +112,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	PerTenantValue<BsonStateAndMetadata> readBsonStateAndMetadata() throws InvalidCollectionContentsException {
+	BsonAllState readBsonStateAndMetadata() throws InvalidCollectionContentsException {
 		try (MongoCursor<BsonDocument> cursor = collection
 			.findLatest(documentFilter()) // The revision field needs to be the latest
 			.limit(1)
@@ -125,11 +125,11 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				Formatter.getDiagnosticAttributesIfAny(document),
 				document.getDocument(DocumentFields.state.name())
 			);
-			return switch (tenancyModel) {
+			return new BsonAllState(switch (tenancyModel) {
 				case None _ -> NoTenant.just(bsm);
 				case Fixed(var tenantId) -> MultiTenant.singleton(Tenant.setTo(tenantId), bsm);
-				case Explicit _ -> throw new NotYetImplementedException();
-			};
+				case Explicit _ -> throw new AssertionError("Sequoia does not support explicit tenancy");
+			}, null);
 		} catch (NoSuchElementException e) {
 			throw new InvalidCollectionContentsException(SEQUOIA, "State document not found: " + DOCUMENT_ID, e);
 		} catch (BsonInvalidOperationException e) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
+import org.bson.BsonInvalidOperationException;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.jspecify.annotations.NonNull;
@@ -122,9 +123,9 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			BsonDocument document = cursor.next();
 			var bsm = new BsonStateAndMetadata(
 				document.getString("_id"),
-				document.getInt64(DocumentFields.revision.name(), null),
+				document.getInt64(DocumentFields.revision.name()),
 				Formatter.getDiagnosticAttributesIfAny(document),
-				document.getDocument(DocumentFields.state.name(), null)
+				document.getDocument(DocumentFields.state.name())
 			);
 			return switch (tenancyModel) {
 				case None _ -> NoTenant.just(bsm);
@@ -133,6 +134,8 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			};
 		} catch (NoSuchElementException e) {
 			throw new InvalidCollectionContentsException(SEQUOIA, "State document not found: " + DOCUMENT_ID, e);
+		} catch (BsonInvalidOperationException e) {
+			throw new InvalidCollectionContentsException(SEQUOIA, "State document is missing required fields: " + DOCUMENT_ID, e);
 		}
 
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
@@ -23,7 +23,10 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import works.bosk.Bosk;
 import works.bosk.logging.MdcKeys;
+
+import static com.mongodb.ReadConcern.LOCAL;
 
 /**
  * A wrapper for {@link MongoCollection} that manages a thread-local
@@ -36,7 +39,6 @@ class TransactionalCollection {
 	private final MongoCollection<BsonDocument> downstream;
 	private final MongoClient mongoClient;
 	private final ThreadLocal<Session> currentSession = new ThreadLocal<>();
-	private static final AtomicLong identityCounter = new AtomicLong(1);
 
 	public Session newSession() throws FailedMongoClientSessionException {
 		return new Session(false);
@@ -57,6 +59,7 @@ class TransactionalCollection {
 		final boolean isReadOnly;
 		final String name;
 		final String oldMDC;
+		static final AtomicLong identityCounter = new AtomicLong(1);
 
 		public Session(boolean isReadOnly) throws FailedMongoClientSessionException {
 			this.isReadOnly = isReadOnly;
@@ -115,6 +118,8 @@ class TransactionalCollection {
 			}
 		}
 
+		private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
+
 		@Override
 		public void close() {
 			if (clientSession.hasActiveTransaction()) {
@@ -165,17 +170,10 @@ class TransactionalCollection {
 	 * have expected you to have ended their transaction: they might have pending
 	 * updates they don't expect to be committed, or they may do subsequent operations
 	 * and then expect to be able to roll them back.
-	 *
-	 * @throws IllegalStateException if there's no active transaction
 	 */
-	public void commitTransaction() {
+	public void commitTransactionIfAny() {
 		LOGGER.debug("Commit transaction");
-		Session session = currentSession.get();
-		if (session.clientSession.hasActiveTransaction()) {
-			session.commitTransactionIfAny();
-		} else {
-			throw new IllegalStateException("No active transaction");
-		}
+		currentSession.get().commitTransactionIfAny();
 	}
 
 	public void abortTransaction() {
@@ -192,16 +190,26 @@ class TransactionalCollection {
 		}
 	}
 
-	public MongoCollection<BsonDocument> withReadConcern(ReadConcern readConcern) {
-		return this.downstream.withReadConcern(readConcern);
-	}
-
-	public long countDocuments(Bson filter, CountOptions options) {
-		return this.downstream.countDocuments(currentSession(), filter, options);
+	/**
+	 * Read the most recent value from the database regardless of the current session.
+	 * Uses {@link ReadConcern#LOCAL} and bypasses any session/transaction in progress.
+	 * Analogous to {@link Bosk#supersedingReadSession()} in that it bypasses the usual
+	 * determinism features and gives direct access to the very latest data.
+	 * <p>
+	 * This is appropriate for initializing state and implementing {@link FormatDriver#flush()}.
+	 * It's probably not appropriate for ordinary updates, which benefit from the determinism
+	 * and reproducibility of sessions and transactions.
+	 */
+	public FindIterable<BsonDocument> findLatest(Bson filter) {
+		return this.downstream.withReadConcern(LOCAL).find(filter);
 	}
 
 	public FindIterable<BsonDocument> find(Bson filter) {
 		return this.downstream.find(currentSession(), filter);
+	}
+
+	public long countDocuments(Bson filter, CountOptions options) {
+		return this.downstream.countDocuments(currentSession(), filter, options);
 	}
 
 	public InsertOneResult insertOne(BsonDocument document) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
@@ -118,8 +118,6 @@ class TransactionalCollection {
 			}
 		}
 
-		private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
-
 		@Override
 		public void close() {
 			if (clientSession.hasActiveTransaction()) {
@@ -132,6 +130,7 @@ class TransactionalCollection {
 			MDC.put(MdcKeys.TRANSACTION, oldMDC);
 		}
 
+		private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
 	}
 
 	/**

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/status/MongoStatus.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/status/MongoStatus.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat;
 import works.bosk.drivers.mongo.internal.Manifest;
-import works.bosk.util.PerTenant;
+import works.bosk.util.PerTenantValue;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -15,7 +15,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public record MongoStatus(
 	@JsonInclude(NON_NULL) String error,
 	ManifestStatus manifest,
-	PerTenant<StateStatus> state
+	PerTenantValue<StateStatus> state
 ) {
 	public MongoStatus with(DatabaseFormat preferredFormat, StateTreeNode actualManifest) {
 		return new MongoStatus(

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverInitializationFailureTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverInitializationFailureTest.java
@@ -6,21 +6,25 @@ import works.bosk.Bosk;
 import works.bosk.BoskConfig;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.exceptions.InitialStateFailureException;
+import works.bosk.logback.ReplayLogsOnFailure;
 import works.bosk.testing.drivers.state.TestEntity;
 
 import static ch.qos.logback.classic.Level.ERROR;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static works.bosk.drivers.mongo.MongoDriverSettings.InitialDatabaseUnavailableMode.FAIL_FAST;
+import static works.bosk.drivers.mongo.internal.TestParameters.SHORT_TIMESCALE;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 /**
  * Tests the functionality of {@link MongoDriverSettings.InitialDatabaseUnavailableMode#FAIL_FAST FAIL_FAST} mode.
  * The other tests in {@link MongoDriverRecoveryTest} exercise {@link MongoDriverSettings.InitialDatabaseUnavailableMode#DISCONNECT DISCONNECT} mode.
  */
+@ReplayLogsOnFailure
 public class MongoDriverInitializationFailureTest extends AbstractMongoDriverTest {
 	public MongoDriverInitializationFailureTest() {
 		super(MongoDriverSettings.builder()
 			.database(MongoDriverInitializationFailureTest.class.getSimpleName())
+			.timescaleMS(SHORT_TIMESCALE)
 			.initialDatabaseUnavailableMode(FAIL_FAST));
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverRecoveryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverRecoveryTest.java
@@ -13,6 +13,7 @@ import org.bson.BsonString;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -246,6 +247,7 @@ public class MongoDriverRecoveryTest extends AbstractMongoDriverTest {
 	}
 
 	@Test
+	@Disabled
 	void revisionDeleted_recovers() throws InterruptedException, IOException {
 		// It's not clear that this is a valid test. If this test is a burden to support,
 		// we can consider removing it.

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -810,14 +810,15 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			AbstractMongoDriverTest::initialState,
 			BoskConfig.<TestEntity>builder().driverFactory(createDriverFactory(logController, testInfo)).build());
 
-		// (Close this so it doesn't crash when we delete the "path" field)
+		// (Close this so it doesn't crash when we start mucking with the database)
 		initialBosk.getDriver(MongoDriver.class).close();
 
-		// Delete some metadata fields
-		MongoCollection<Document> collection = mongoService.client()
+		// Add a bogus metadata field
+		MongoCollection<BsonDocument> collection = mongoService.client()
 			.getDatabase(driverSettings.database())
-			.getCollection(MainDriver.COLLECTION_NAME);
-		deleteFields(collection, Formatter.DocumentFields.revision);
+			.getCollection(MainDriver.COLLECTION_NAME, BsonDocument.class);
+		String bogusField = "bogusField";
+		addFields(collection, bogusField);
 
 		// Make the bosk whose refurbish operation we want to test
 		Bosk<TestEntity> bosk = new Bosk<>(
@@ -829,26 +830,20 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		// Get the new bosk reconnected
 		bosk.driver().flush();
 
-		// Simply connecting a new bosk repairs certain fields.
-		// To test those, delete them again.
-		// This may cause the receiver to throw an exception for deleting this field unexpectedly,
-		// but it recovers, so that's ok.
-		deleteFields(collection, Formatter.DocumentFields.revision);
-
-		// Verify that the fields are indeed gone
+		// Verify that the fields are indeed there
 		BsonDocument filterDoc = rootDocumentsFilter();
-		try (MongoCursor<Document> cursor = collection.find(filterDoc).cursor()) {
-			Document doc = cursor.next();
-			assertNull(doc.get(Formatter.DocumentFields.revision.name()));
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			BsonDocument doc = cursor.next();
+			assertEquals(new BsonString(bogusField), doc.getString(bogusField));
 		}
 
 		// Refurbish
 		bosk.getDriver(MongoDriver.class).refurbish();
 
-		// Verify the fields are now there
-		try (MongoCursor<Document> cursor = collection.find(filterDoc).cursor()) {
-			Document doc = cursor.next();
-			assertEquals(1L, doc.getLong(Formatter.DocumentFields.revision.name()));
+		// Verify the field is now gone
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			BsonDocument doc = cursor.next();
+			assertNull(doc.get(bogusField));
 		}
 
 	}
@@ -963,7 +958,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		}
 	}
 
-	private void deleteFields(MongoCollection<Document> collection, Formatter.DocumentFields... fields) {
+	private void deleteFields(MongoCollection<BsonDocument> collection, Formatter.DocumentFields... fields) {
 		BsonDocument fieldsToUnset = new BsonDocument();
 		for (Formatter.DocumentFields field: fields) {
 			fieldsToUnset.append(field.name(), BsonNull.VALUE); // Value is ignored
@@ -974,10 +969,31 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			new BsonDocument("$unset", fieldsToUnset));
 
 		// Let's just make sure they're gone
-		try (MongoCursor<Document> cursor = collection.find(filterDoc).cursor()) {
-			Document doc = cursor.next();
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			BsonDocument doc = cursor.next();
 			for (Formatter.DocumentFields field: fields) {
 				assertNull(doc.get(field.name()));
+			}
+		}
+
+		errorRecorder.assertAllClear("after test");
+	}
+
+	private void addFields(MongoCollection<BsonDocument> collection, String... fieldNames) {
+		BsonDocument fieldsToSet = new BsonDocument();
+		for (String fieldName: fieldNames) {
+			fieldsToSet.append(fieldName, new BsonString(fieldName));
+		}
+		BsonDocument filterDoc = rootDocumentsFilter();
+		collection.updateOne(
+			filterDoc,
+			new BsonDocument("$set", fieldsToSet));
+
+		// Make sure they exist
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			BsonDocument doc = cursor.next();
+			for (String fieldName: fieldNames) {
+				assertEquals(new BsonString(fieldName), doc.getString(fieldName));
 			}
 		}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/PandoRefurbishContentsRevisionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/PandoRefurbishContentsRevisionTest.java
@@ -1,0 +1,124 @@
+package works.bosk.drivers.mongo.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import works.bosk.Bosk;
+import works.bosk.BoskConfig;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.TenantId;
+import works.bosk.BoskDriver;
+import works.bosk.BoskDriver.EntireState;
+import works.bosk.Identifier;
+import works.bosk.Path;
+import works.bosk.drivers.mongo.MongoDriver;
+import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.logback.ReplayLogsOnFailure;
+import works.bosk.testing.drivers.state.TestEntity;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static works.bosk.drivers.mongo.MongoDriverSettings.TenancyFormat.ID_PREFIX;
+import static works.bosk.drivers.mongo.internal.TestParameters.SHORT_TIMESCALE;
+import static works.bosk.testing.BoskTestUtils.boskName;
+
+/**
+ * Demonstrates a bug found by TLA+ modeling of {@link PandoFormatDriver}: refurbishing to the
+ * SAME database format resets the {@code !contents} document's revision number back to 1
+ * ({@code PandoFormatDriver#writeContentsDocument}, via {@code nextRevision(REVISION_ZERO)}),
+ * instead of carrying the prior revision forward the way per-tenant state documents already do.
+ * <p>
+ * Because a same-format refurbish leaves the manifest unchanged, an observing replica does NOT
+ * reconnect (its manifest change event is treated as benign), so it keeps its existing
+ * {@code contentsFlushLock}. If that replica has already seen a {@code !contents} revision
+ * number at least as high as the one a subsequent write receives after the reset, the observing
+ * replica's {@code handleContentsEvent} skips the event entirely
+ * ({@code contentsFlushLock.alreadySeen(revision)}), including a tenant REMOVAL, which is
+ * propagated {@code ONLY} via that event. The result: the observing replica continues to serve a
+ * tenant that has been deleted from the database.
+ */
+@ReplayLogsOnFailure
+class PandoRefurbishContentsRevisionTest extends AbstractMongoDriverTest {
+	PandoRefurbishContentsRevisionTest() {
+		super(MongoDriverSettings.builder()
+			.database(PandoRefurbishContentsRevisionTest.class.getSimpleName())
+			.preferredDatabaseFormat(PandoFormat.oneBigDocument().withTenancyFormat(ID_PREFIX))
+//			.testing(Testing.builder().eventDelayMS(SHORT_TIMESCALE).build())
+			.timescaleMS(SHORT_TIMESCALE));
+	}
+
+	@Test
+	void refurbish_doesNotLoseSubsequentTenantRemoval(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		// The writer bosk initializes the (empty) collection and performs all the writes.
+		Bosk<TestEntity> writerBosk = new Bosk<>(
+			boskName("Writer"),
+			TestEntity.class,
+			PandoRefurbishContentsRevisionTest::emptyMultiTree,
+			BoskConfig.<TestEntity>builder()
+				.tenancyModel(TenancyModel.EXPLICIT)
+				.driverFactory(driverFactory)
+				.build());
+		BoskDriver writerDriver = writerBosk.driver();
+
+		// The observer bosk is an independent connection to the same collection that never writes.
+		Bosk<TestEntity> observerBosk = new Bosk<>(
+			boskName("Observer"),
+			TestEntity.class,
+			_ -> { throw new AssertionError("observerBosk should use the state from MongoDB"); },
+			BoskConfig.<TestEntity>builder()
+				.tenancyModel(TenancyModel.EXPLICIT)
+				.driverFactory(createDriverFactory(logController, testInfo))
+				.build());
+		BoskDriver observerDriver = observerBosk.driver();
+
+		LOGGER.debug("Writer adds tenantA");
+		TestEntity rootA = TestEntity.empty(Identifier.from("tenantA"),
+			writerBosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+		try (
+			var _ = writerBosk.context().withTenant(tenantA)
+		) {
+			writerDriver.submitConditionalCreation(writerBosk.rootReference(), rootA);
+		}
+
+		LOGGER.debug("Observer catches up, establishing its contentsFlushLock at the post-add revision");
+		observerDriver.flush();
+		try (
+			var _ = observerBosk.context().withTenant(tenantA);
+			var _ = observerBosk.readSession()
+		) {
+			assertNotNull(observerBosk.rootReference().valueIfExists(), "Observer should see the newly added tenant");
+		}
+
+		LOGGER.debug("Refurbish to the same format");
+		writerBosk.getDriver(MongoDriver.class).refurbish();
+
+		LOGGER.debug("Writer removes tenantA");
+		try (
+			var _ = writerBosk.context().withTenant(tenantA)
+		) {
+			writerDriver.submitDeletion(writerBosk.rootReference());
+		}
+
+		LOGGER.debug("Observer flush");
+		observerDriver.flush();
+
+		LOGGER.debug("Observer should no longer see tenantA");
+		TestEntity leaked;
+		try (
+			var _ = observerBosk.context().withTenant(tenantA);
+			var _ = observerBosk.readSession()
+		) {
+			leaked = observerBosk.rootReference().valueIfExists();
+		}
+		assertNull(leaked, "Removed tenant must not still be served after refurbish resets the !contents revision");
+	}
+
+	private static EntireState<TestEntity> emptyMultiTree(Bosk<TestEntity> bosk) {
+		return EntireState.MultiTree.empty();
+	}
+
+	private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(PandoRefurbishContentsRevisionTest.class);
+}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/PandoTenantReAddTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/PandoTenantReAddTest.java
@@ -1,0 +1,440 @@
+package works.bosk.drivers.mongo.internal;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import org.bson.BsonDocument;
+import org.bson.BsonInt64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import works.bosk.Bosk;
+import works.bosk.BoskConfig;
+import works.bosk.BoskConfig.TenancyModel;
+import works.bosk.BoskContext.Tenant;
+import works.bosk.BoskContext.Tenant.TenantId;
+import works.bosk.BoskDriver;
+import works.bosk.BoskDriver.EntireState;
+import works.bosk.DriverFactory;
+import works.bosk.DriverStack;
+import works.bosk.Identifier;
+import works.bosk.Path;
+import works.bosk.drivers.mongo.BsonSerializer;
+import works.bosk.drivers.mongo.MongoDriver;
+import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.logback.BoskLogFilter;
+import works.bosk.logback.ReplayLogsOnFailure;
+import works.bosk.testing.drivers.state.TestEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static works.bosk.drivers.mongo.MongoDriverSettings.TenancyFormat.ID_PREFIX;
+import static works.bosk.drivers.mongo.internal.MainDriver.COLLECTION_NAME;
+import static works.bosk.testing.BoskTestUtils.boskName;
+
+/**
+ * Tests tenant add/remove/re-add cycles in {@link PandoFormatDriver}.
+ * <p>
+ * {@link PandoFormatDriver#doReplacement} re-adds a tenant by writing its document at revision 1
+ * ({@code initializeTenant(tid, value, nextRevision(REVISION_ZERO))}), regardless of what
+ * revision the orphaned document (left behind by the earlier removal, per HASTY orphan mode) was
+ * already at. The author of that code was aware re-adds need help getting past the driver's own
+ * {@code FlushLock} skip check, and patches the WRITER's own lock at write time
+ * ({@code finishedRevision(tid, REVISION_BEFORE_ANY)}, {@code PandoFormatDriver.java:880}).
+ * <p>
+ * But that patch is applied at WRITE time, while the skip decision happens at EVENT-PROCESSING
+ * time. If the application performs additional writes (here: remove then re-add) before the
+ * change stream has processed the earlier ones -- the normal case, since writes do not wait for
+ * their own events -- those intervening events raise the per-tenant lock past the value the
+ * patch set, and the re-add's change-stream event (revision 1) is skipped as stale
+ * ({@code shouldSkip}: {@code revision <= alreadySeen}). The tenant is lost permanently: no
+ * further event will ever un-skip it, because its revision numbers were reused rather than
+ * carried forward.
+ */
+@ReplayLogsOnFailure
+class PandoTenantReAddTest extends AbstractMongoDriverTest {
+	PandoTenantReAddTest() {
+		super(MongoDriverSettings.builder()
+			.database(PandoTenantReAddTest.class.getSimpleName())
+			.preferredDatabaseFormat(PandoFormat.oneBigDocument().withTenancyFormat(ID_PREFIX))
+			.timescaleMS(5_000));
+	}
+
+	@Test
+	void reAddTenant_afterRemove_isNotLost(TestInfo testInfo) throws Exception {
+		var racer = newBosk(testInfo, "ReAddRace",
+			MongoDriverSettings.Testing.builder().eventDelayMS(200).build());
+		addRemoveReAddOrFail(racer.bosk, racer.driver, "reAdd");
+	}
+
+	@Test
+	void addRemoveReAdd_noEventDelay(TestInfo testInfo) throws Exception {
+		var racer = newBosk(testInfo, "NoDelay");
+		addRemoveReAddOrFail(racer.bosk, racer.driver, "reAdd");
+	}
+
+	@Test
+	void addRemoveReAdd_twoTenants(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+		TenantId tenantB = Tenant.setTo(Identifier.from("tenantB"));
+
+		var racer = newBosk(testInfo, "TwoTenants");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		TestEntity rootA;
+		TestEntity rootB;
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+		}
+		try (var _ = bosk.context().withTenant(tenantB)) {
+			rootB = TestEntity.empty(Identifier.from("tenantB"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantB");
+			driver.submitConditionalCreation(bosk.rootReference(), rootB);
+		}
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+		}
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			TestEntity reAdd = rootA.withString("reAdded");
+			LOGGER.debug("Re-add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), reAdd);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantB); var _ = bosk.readSession()) {
+			assertNotNull(bosk.rootReference().valueIfExists(), "tenantB should still exist");
+		}
+		try (var _ = bosk.context().withTenant(tenantA); var _ = bosk.readSession()) {
+			assertEquals("reAdded", bosk.rootReference().valueIfExists().string(),
+				"Re-added tenantA should have the re-added value");
+		}
+	}
+
+	@Test
+	void addRemoveReAdd_andReplace(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		var racer = newBosk(testInfo, "FullLifecycle");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		TestEntity rootA, reAdd, replaced;
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+
+			reAdd = rootA.withString("reAdded");
+			LOGGER.debug("Re-add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), reAdd);
+
+			replaced = reAdd.withString("replaced");
+			LOGGER.debug("Replace tenantA root");
+			driver.submitReplacement(bosk.rootReference(), replaced);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA); var _ = bosk.readSession()) {
+			assertEquals("replaced", bosk.rootReference().valueIfExists().string(),
+				"TenantA should have the replacement value");
+		}
+	}
+
+	@Test
+	void replacementAfterRemove_reEnlists(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		var racer = newBosk(testInfo, "ReplacementReEnlist");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		TestEntity rootA, replacement;
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+
+			replacement = rootA.withString("replacement");
+			LOGGER.debug("SubmitReplacement on removed tenantA");
+			driver.submitReplacement(bosk.rootReference(), replacement);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA); var _ = bosk.readSession()) {
+			assertEquals("replacement", bosk.rootReference().valueIfExists().string(),
+				"TenantA should be re-enlisted with the replacement value");
+		}
+	}
+
+	@Test
+	void registerCreatedTenantInContents(TestInfo testInfo) throws Exception {
+		// Ensures that creating a tenant using submitConditionalCreation registers it in !contents
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		var racer = newBosk(testInfo, "RegisterInContents");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			var rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA); var _ = bosk.readSession()) {
+			assertNotNull(bosk.rootReference().valueIfExists(), "Newly created tenant should be visible");
+		}
+	}
+
+	@Test
+	void addRemoveFlushReAdd(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		var racer = newBosk(testInfo, "FlushBetween");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		TestEntity rootA, reAdd;
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+		}
+
+		// Flush so the change stream processes the add before we remove
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+		}
+
+		// Flush so the change stream processes the deletion before we re-add
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			reAdd = rootA.withString("reAdded");
+			LOGGER.debug("Re-add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), reAdd);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA); var _ = bosk.readSession()) {
+			assertEquals("reAdded", bosk.rootReference().valueIfExists().string(),
+				"Re-added tenant should be visible with its re-added value after flush");
+		}
+	}
+
+	@Test
+	void conditionalReplacement_againstDeadTenant_doesNotResurrect(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		var racer = newBosk(testInfo, "CondReplaceDead");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			var rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+		}
+
+		driver.flush();
+
+		// Now tenantA is dead but orphan root document exists with state.id = "tenantA"
+
+		// Baseline orphan revision numbers
+		var coll = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		long contentsRevBefore = readRevision(coll, "!contents");
+		long rootRevBefore = readRevision(coll, "<tenantA>|");
+
+		// Conditional replacement with matching precondition on dead tenant
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			var precondition = bosk.rootReference().then(Identifier.class, Path.just(TestEntity.Fields.id));
+			var newValue = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Conditional replacement on dead tenant with matching precondition");
+			driver.submitConditionalReplacement(bosk.rootReference(), newValue, precondition, Identifier.from("tenantA"));
+		}
+
+		// Read revisions after (the write should not happen with the fix)
+		long contentsRevAfter = readRevision(coll, "!contents");
+		long rootRevAfter = readRevision(coll, "<tenantA>|");
+
+		assertEquals(contentsRevBefore, contentsRevAfter,
+			"!contents revision should not change after conditional replacement on dead tenant");
+		assertEquals(rootRevBefore, rootRevAfter,
+			"Orphan root document revision should not change after conditional replacement on dead tenant");
+	}
+
+	@Test
+	void conditionalDeletion_againstDeadTenant_doesNotMutateOrphan(TestInfo testInfo) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		var racer = newBosk(testInfo, "CondDeleteDead");
+		Bosk<TestEntity> bosk = racer.bosk;
+		BoskDriver driver = racer.driver;
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			var rootA = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), rootA);
+		}
+
+		driver.flush();
+
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+		}
+
+		driver.flush();
+
+		// Baseline orphan revision numbers
+		var coll = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		long contentsRevBefore = readRevision(coll, "!contents");
+		long rootRevBefore = readRevision(coll, "<tenantA>|");
+
+		// Conditional deletion with matching precondition on dead tenant
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			var precondition = bosk.rootReference().then(Identifier.class, Path.just(TestEntity.Fields.id));
+			LOGGER.debug("Conditional deletion on dead tenant with matching precondition");
+			driver.submitConditionalDeletion(bosk.rootReference(), precondition, Identifier.from("tenantA"));
+		}
+
+		// Read revisions after (the write should not happen with the fix)
+		long contentsRevAfter = readRevision(coll, "!contents");
+		long rootRevAfter = readRevision(coll, "<tenantA>|");
+
+		assertEquals(contentsRevBefore, contentsRevAfter,
+			"!contents revision should not change after conditional deletion on dead tenant");
+		assertEquals(rootRevBefore, rootRevAfter,
+			"Orphan root document revision should not change after conditional deletion on dead tenant");
+	}
+
+	private static long readRevision(MongoCollection<BsonDocument> coll, String documentId) {
+		var doc = coll.find(Filters.eq("_id", documentId)).first();
+		if (doc == null) {
+			return -1;
+		}
+		return doc.getInt64("revision", new BsonInt64(0)).longValue();
+	}
+
+	/**
+	 * Helper: add, remove, re-add tenantA, flush, and assert the re-added value.
+	 */
+	private void addRemoveReAddOrFail(Bosk<TestEntity> bosk, BoskDriver driver, String reAddString) throws Exception {
+		TenantId tenantA = Tenant.setTo(Identifier.from("tenantA"));
+
+		TestEntity firstAdd, reAdd;
+		try (var _ = bosk.context().withTenant(tenantA)) {
+			firstAdd = TestEntity.empty(Identifier.from("tenantA"),
+				bosk.rootReference().thenCatalog(TestEntity.class, Path.just(TestEntity.Fields.catalog)));
+			LOGGER.debug("Add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), firstAdd);
+
+			LOGGER.debug("Remove tenantA");
+			driver.submitDeletion(bosk.rootReference());
+
+			reAdd = firstAdd.withString(reAddString);
+			LOGGER.debug("Re-add tenantA");
+			driver.submitConditionalCreation(bosk.rootReference(), reAdd);
+		}
+
+		driver.flush();
+		TestEntity actual;
+		try (var _ = bosk.context().withTenant(tenantA); var _ = bosk.readSession()) {
+			actual = bosk.rootReference().valueIfExists();
+		}
+		assertEquals(reAdd, actual, "Re-added tenant should be visible with its latest value after flush");
+	}
+
+	/**
+	 * Creates a Bosk for tenant re-add testing with custom testing settings.
+	 */
+	private BoskAndDriver newBosk(TestInfo testInfo, String boskNameSuffix,
+		MongoDriverSettings.Testing testing) {
+		var customSettings = MongoDriverSettings.builder()
+			.database(PandoTenantReAddTest.class.getSimpleName())
+			.preferredDatabaseFormat(PandoFormat.oneBigDocument().withTenancyFormat(ID_PREFIX))
+			.timescaleMS(5_000)
+			.testing(testing)
+			.build();
+		return newBoskWithSettings(testInfo, boskNameSuffix, customSettings);
+	}
+
+	/**
+	 * Creates a Bosk for tenant re-add testing with default (no event delay) settings.
+	 */
+	private BoskAndDriver newBosk(TestInfo testInfo, String boskNameSuffix) {
+		return newBoskWithSettings(testInfo, boskNameSuffix, driverSettings);
+	}
+
+	private BoskAndDriver newBoskWithSettings(TestInfo testInfo, String boskNameSuffix,
+		MongoDriverSettings settings) {
+		DriverFactory<TestEntity> factory = (boskInfo, downstream) -> {
+			MongoDriver driver = MongoDriver.<TestEntity>factory(
+				mongoService.clientSettings(testInfo),
+				settings,
+				new BsonSerializer()
+			).build(boskInfo, downstream);
+			tearDownActions.addFirst(driver::close);
+			return driver;
+		};
+		factory = DriverStack.of(
+			BoskLogFilter.withController(logController),
+			factory
+		);
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName(boskNameSuffix),
+			TestEntity.class,
+			PandoTenantReAddTest::emptyMultiTree,
+			BoskConfig.<TestEntity>builder()
+				.tenancyModel(TenancyModel.EXPLICIT)
+				.driverFactory(factory)
+				.build());
+		return new BoskAndDriver(bosk, bosk.driver());
+	}
+
+	private record BoskAndDriver(Bosk<TestEntity> bosk, BoskDriver driver) {}
+
+	private static EntireState<TestEntity> emptyMultiTree(Bosk<TestEntity> bosk) {
+		return EntireState.MultiTree.empty();
+	}
+
+	private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(PandoTenantReAddTest.class);
+}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/TransactionalCollectionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/TransactionalCollectionTest.java
@@ -1,0 +1,487 @@
+package works.bosk.drivers.mongo.internal;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import works.bosk.drivers.mongo.internal.TransactionalCollection.Session;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TransactionalCollectionTest {
+	private static MongoService mongoService;
+	private static final String DB_NAME = "TransactionalCollectionTest";
+	private static final String COLLECTION_NAME = "testCollection";
+	private TransactionalCollection collection;
+
+	@BeforeAll
+	static void setupMongo() {
+		mongoService = new MongoService();
+	}
+
+	@BeforeEach
+	void setupCollection() {
+		MongoClient client = mongoService.client();
+		MongoCollection<BsonDocument> raw = client
+			.getDatabase(DB_NAME)
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		raw.drop();
+		collection = TransactionalCollection.of(raw, client);
+	}
+
+	@Test
+	void findLatest_worksWithoutSession() throws FailedMongoClientSessionException {
+		makeData("test");
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("test")))
+			.cursor()
+		) {
+			assertTrue(cursor.hasNext());
+			assertEquals("test", cursor.next().getString("_id").getValue());
+		}
+	}
+
+	@Test
+	void findLatest_returnsData() throws FailedMongoClientSessionException {
+		makeData("doc1");
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("doc1")))
+			.cursor()
+		) {
+			assertTrue(cursor.hasNext());
+		}
+	}
+
+	@Test
+	void newSession_createsSession() throws FailedMongoClientSessionException {
+		try (Session session = collection.newSession()) {
+			assertNotNull(session.clientSession);
+			assertFalse(session.isReadOnly);
+		}
+	}
+
+	@Test
+	void newReadOnlySession_createsSession() throws FailedMongoClientSessionException {
+		try (Session session = collection.newReadOnlySession()) {
+			assertNotNull(session.clientSession);
+			assertTrue(session.isReadOnly);
+		}
+	}
+
+	@Test
+	void nestedSession_throws() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			assertThrows(IllegalStateException.class, () -> collection.newSession());
+		}
+	}
+
+	@Test
+	void nestedReadOnlySession_throws() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			assertThrows(IllegalStateException.class, () -> collection.newReadOnlySession());
+		}
+	}
+
+	@Test
+	void sessionCreation_afterClose_allowed() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) { }
+		assertDoesNotThrow(() -> {
+			try (Session _ = collection.newSession()) { }
+		});
+	}
+
+	@Test
+	void find_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.find(new BsonDocument("_id", new BsonString("x"))));
+	}
+
+	@Test
+	void countDocuments_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.countDocuments(new BsonDocument(), new CountOptions()));
+	}
+
+	@Test
+	void insertOne_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.insertOne(new BsonDocument("_id", new BsonString("x"))));
+	}
+
+	@Test
+	void deleteOne_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.deleteOne(new BsonDocument("_id", new BsonString("x"))));
+	}
+
+	@Test
+	void deleteMany_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.deleteMany(new BsonDocument()));
+	}
+
+	@Test
+	void replaceOne_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.replaceOne(
+				new BsonDocument("_id", new BsonString("x")),
+				new BsonDocument("_id", new BsonString("x")),
+				new ReplaceOptions()));
+	}
+
+	@Test
+	void updateOne_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.updateOne(
+				new BsonDocument("_id", new BsonString("x")),
+				new BsonDocument("$set", new BsonDocument("val", new BsonInt32(1)))));
+	}
+
+	@Test
+	void updateOneWithOptions_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.updateOne(
+				new BsonDocument("_id", new BsonString("x")),
+				new BsonDocument("$set", new BsonDocument("val", new BsonInt32(1))),
+				new UpdateOptions()));
+	}
+
+	@Test
+	void ensureTransactionStarted_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.ensureTransactionStarted());
+	}
+
+	@Test
+	void abortTransaction_withoutSession_throws() {
+		assertThrows(IllegalStateException.class,
+			() -> collection.abortTransaction());
+	}
+
+	@Test
+	void insertAndFindLatest_withSession_works() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("sdoc")));
+			collection.commitTransactionIfAny();
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("sdoc"))).cursor()
+		) {
+			assertTrue(cursor.hasNext());
+		}
+	}
+
+	@Test
+	void deleteOne_withSession_works() throws FailedMongoClientSessionException {
+		makeData("delme");
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			DeleteResult result = collection.deleteOne(new BsonDocument("_id", new BsonString("delme")));
+			assertEquals(1, result.getDeletedCount());
+			collection.commitTransactionIfAny();
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("delme"))).cursor()
+		) {
+			assertFalse(cursor.hasNext());
+		}
+	}
+
+	@Test
+	void deleteMany_withSession_works() throws FailedMongoClientSessionException {
+		makeData("dm1");
+		makeData("dm2");
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			DeleteResult result = collection.deleteMany(new BsonDocument("_id", new BsonString("dm1")));
+			assertEquals(1, result.getDeletedCount());
+			collection.commitTransactionIfAny();
+		}
+	}
+
+	@Test
+	void replaceOne_withSession_works() throws FailedMongoClientSessionException {
+		makeData("rpl");
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			BsonDocument replacement = new BsonDocument("_id", new BsonString("rpl"))
+				.append("val", new BsonInt32(42));
+			UpdateResult result = collection.replaceOne(
+				new BsonDocument("_id", new BsonString("rpl")),
+				replacement,
+				new ReplaceOptions().upsert(true));
+			assertEquals(1, result.getMatchedCount());
+			collection.commitTransactionIfAny();
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("rpl"))).cursor()
+		) {
+			assertTrue(cursor.hasNext());
+			assertEquals(42, cursor.next().getInt32("val").getValue());
+		}
+	}
+
+	@Test
+	void updateOne_withSession_works() throws FailedMongoClientSessionException {
+		makeData("upd");
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			UpdateResult result = collection.updateOne(
+				new BsonDocument("_id", new BsonString("upd")),
+				new BsonDocument("$set", new BsonDocument("val", new BsonInt32(99))));
+			assertEquals(1, result.getMatchedCount());
+			collection.commitTransactionIfAny();
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("upd"))).cursor()
+		) {
+			assertTrue(cursor.hasNext());
+			assertEquals(99, cursor.next().getInt32("val").getValue());
+		}
+	}
+
+	@Test
+	void updateOneWithOptions_withSession_works() throws FailedMongoClientSessionException {
+		makeData("updo");
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			UpdateResult result = collection.updateOne(
+				new BsonDocument("_id", new BsonString("updo")),
+				new BsonDocument("$set", new BsonDocument("val", new BsonInt32(88))),
+				new UpdateOptions().upsert(false));
+			assertEquals(1, result.getMatchedCount());
+			collection.commitTransactionIfAny();
+		}
+	}
+
+	@Test
+	void countDocuments_withSession_works() throws FailedMongoClientSessionException {
+		makeData("cd1");
+		makeData("cd2");
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			long count = collection.countDocuments(new BsonDocument(), new CountOptions());
+			assertEquals(2, count);
+			collection.commitTransactionIfAny();
+		}
+	}
+
+	@Test
+	void commit_persistsData() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("commitDoc")));
+			collection.commitTransactionIfAny();
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("commitDoc"))).cursor()
+		) {
+			assertTrue(cursor.hasNext(), "Committed data must be visible");
+		}
+	}
+
+	@Test
+	void abortOnClose_rollsBackData() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("rollbackDoc")));
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("rollbackDoc"))).cursor()
+		) {
+			assertFalse(cursor.hasNext(), "Uncommitted data must not be visible after abort");
+		}
+	}
+
+	@Test
+	void explicitAbort_rollsBackData() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("abortDoc")));
+			collection.abortTransaction();
+		}
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("abortDoc"))).cursor()
+		) {
+			assertFalse(cursor.hasNext(), "Aborted data must not be visible");
+		}
+	}
+
+	@Test
+	void readOnlySession_cannotStartTransaction() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newReadOnlySession()) {
+			assertThrows(IllegalStateException.class,
+				() -> collection.ensureTransactionStarted());
+		}
+	}
+
+	@Test
+	void ensureTransactionStarted_twice_isIdempotent() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.ensureTransactionStarted();
+			collection.commitTransactionIfAny();
+		}
+	}
+
+	@Test
+	void findLatestWithSession_seesTransactionData() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("txDoc")));
+			try (MongoCursor<BsonDocument> cursor = collection
+				.find(new BsonDocument("_id", new BsonString("txDoc")))
+				.cursor()
+			) {
+				assertTrue(cursor.hasNext(), "Transaction should see its own writes");
+			}
+			collection.abortTransaction();
+		}
+	}
+
+	@Test
+	void standaloneFindLatest_doesNotSeeUncommittedData() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("uncommittedDoc")));
+			try (MongoCursor<BsonDocument> cursor = collection
+				.findLatest(new BsonDocument("_id", new BsonString("uncommittedDoc")))
+				.cursor()
+			) {
+				assertFalse(cursor.hasNext(), "Standalone reads must not see uncommitted transaction data");
+			}
+			collection.abortTransaction();
+		}
+	}
+
+	@Test
+	void multipleInsertsAndFindsWithinSession() throws FailedMongoClientSessionException {
+		try (Session _ = collection.newSession()) {
+			collection.ensureTransactionStarted();
+			collection.insertOne(new BsonDocument("_id", new BsonString("a")));
+			collection.insertOne(new BsonDocument("_id", new BsonString("b")));
+			collection.insertOne(new BsonDocument("_id", new BsonString("c")));
+			long count = collection.countDocuments(new BsonDocument(), new CountOptions());
+			assertEquals(3, count);
+			collection.abortTransaction();
+		}
+	}
+
+	@Test
+	void findAfterSessionClose_throws() throws FailedMongoClientSessionException {
+		{
+			try (Session _ = collection.newSession()) { }
+		}
+		assertThrows(IllegalStateException.class,
+			() -> collection.find(new BsonDocument("_id", new BsonString("x"))));
+	}
+
+	@Test
+	void sessionNames_areDistinct() throws FailedMongoClientSessionException {
+		String name1, name2;
+		try (Session s = collection.newSession()) {
+			name1 = s.name;
+		}
+		try (Session s = collection.newSession()) {
+			name2 = s.name;
+		}
+		assertNotNull(name1);
+		assertNotNull(name2);
+		assertNotEquals(name1, name2, "Session names should be distinct");
+	}
+
+	@Test
+	void readOnlySessionNames_prefixedWithR() throws FailedMongoClientSessionException {
+		try (Session s = collection.newReadOnlySession()) {
+			assertTrue(s.name.startsWith("r"));
+		}
+	}
+
+	@Test
+	void sessionNames_prefixedWithS() throws FailedMongoClientSessionException {
+		try (Session s = collection.newSession()) {
+			assertTrue(s.name.startsWith("s"));
+		}
+	}
+
+	@Test
+	void concurrentSessions_areIsolated() throws FailedMongoClientSessionException {
+		MongoClient client = mongoService.client();
+		MongoCollection<BsonDocument> raw = client
+			.getDatabase(DB_NAME)
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		TransactionalCollection collection2 = TransactionalCollection.of(raw, client);
+
+		try (Session _ = collection.newSession();
+			Session _ = collection2.newSession()
+		) {
+			collection.ensureTransactionStarted();
+			collection2.ensureTransactionStarted();
+
+			collection.insertOne(new BsonDocument("_id", new BsonString("s1Doc")));
+
+			try (MongoCursor<BsonDocument> cursor = collection
+				.find(new BsonDocument("_id", new BsonString("s1Doc"))).cursor()
+			) {
+				assertTrue(cursor.hasNext(), "Session should see its own write");
+			}
+
+			try (MongoCursor<BsonDocument> cursor = collection2
+				.find(new BsonDocument("_id", new BsonString("s1Doc"))).cursor()
+			) {
+				assertFalse(cursor.hasNext(), "Session must not see other session's uncommitted write");
+			}
+
+			collection.commitTransactionIfAny();
+
+			try (MongoCursor<BsonDocument> cursor = collection2
+				.find(new BsonDocument("_id", new BsonString("s1Doc"))).cursor()
+			) {
+				assertFalse(cursor.hasNext(), "Snapshot isolation: still should not see s1Doc after s1 committed");
+			}
+
+			collection2.commitTransactionIfAny();
+		}
+
+		try (MongoCursor<BsonDocument> cursor = collection
+			.findLatest(new BsonDocument("_id", new BsonString("s1Doc"))).cursor()
+		) {
+			assertTrue(cursor.hasNext(), "s1Doc should be visible after s1 commit");
+		}
+		try (MongoCursor<BsonDocument> cursor = collection2
+			.findLatest(new BsonDocument("_id", new BsonString("s1Doc"))).cursor()
+		) {
+			assertTrue(cursor.hasNext(), "s1Doc should be visible to collection2 after s1 commit");
+		}
+	}
+
+	private static void insertFresh(TransactionalCollection coll, BsonDocument doc) throws FailedMongoClientSessionException {
+		try (Session _ = coll.newSession()) {
+			coll.ensureTransactionStarted();
+			coll.insertOne(doc);
+			coll.commitTransactionIfAny();
+		}
+	}
+
+	private void makeData(String id) throws FailedMongoClientSessionException {
+		insertFresh(collection, new BsonDocument("_id", new BsonString(id)));
+	}
+
+}

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConformanceTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import works.bosk.drivers.sql.SqlTestService.Database;
@@ -28,17 +27,6 @@ class SqlDriverConformanceTest extends PolyfillDriverConformanceTest {
 	private final AtomicInteger dbCounter = new AtomicInteger(0);
 	private SqlDriverSettings settings;
 	private HikariDataSource dataSource;
-
-	@BeforeAll
-	static void validateSmokeTestDatabases() {
-		// Fail this test promptly if we can't connect to the smoke test databases,
-		// instead of painstakingly hitting this error on every single test.
-		for (Database database : Database.values()) {
-			try (var ds = database.dataSourceFor("smoke-test")) {
-				ds.validate();
-			}
-		}
-	}
 
 	@BeforeEach
 	void setupDriverFactory() {

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlTestService.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlTestService.java
@@ -5,8 +5,10 @@ import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import works.bosk.exceptions.NotYetImplementedException;
 import works.bosk.testing.drivers.state.TestEntity;
 
@@ -29,16 +31,35 @@ public class SqlTestService {
 	}
 
 	public enum Database {
-		// TODO: Use a dockerfile like we do for MongoDB so dependabot can keep these up to date
-		MYSQL(testcontainers("mysql:9.6.0", "/var/lib/mysql")),
-		POSTGRES(testcontainers("postgresql:18.3", "/var/lib/postgresql")),
+		MYSQL("mysql", "mysql", "bosk-test", "src/test/resources/mysql.dockerfile", "/var/lib/mysql"),
+		POSTGRES("postgres", "postgresql", "bosk-test", "src/test/resources/postgresql.dockerfile", "/var/lib/postgresql"),
 		SQLITE(dbName -> "jdbc:sqlite:" + TEMP_DIR.resolve(dbName + ".db")),
 		;
 
 		final Function<String, String> url;
 
+		Database(String dockerName, String jdbcName, String tag, String dockerfilePath, String dataDir) {
+			String imageTag = dockerName + ":" + tag;
+			this.url = dbName -> {
+				ensureImageIsBuilt(imageTag, dockerfilePath);
+				return "jdbc:tc:" + jdbcName + ":" + tag
+					+ ":///" + dbName
+					+ "?TC_DAEMON=true"
+					+ "&TC_TMPFS=" + dataDir + ":rw";
+			};
+		}
+
 		Database(Function<String, String> url) {
 			this.url = url;
+		}
+
+		private static final ConcurrentHashMap<String, Boolean> IMAGES_BUILT = new ConcurrentHashMap<>();
+
+		private static void ensureImageIsBuilt(String imageTag, String dockerfilePath) {
+			IMAGES_BUILT.computeIfAbsent(imageTag, _ ->
+				new ImageFromDockerfile(imageTag)
+					.withDockerfile(Paths.get(dockerfilePath)).get()
+				!= null); // Super clever way to always generate `true`
 		}
 
 		public HikariDataSource dataSourceFor(String databaseName) {
@@ -51,14 +72,6 @@ public class SqlTestService {
 		config.setJdbcUrl(key.database().url.apply(key.databaseName()));
 		config.setAutoCommit(false);
 		return new HikariDataSource(config);
-	}
-
-	private static Function<String, String> testcontainers(String image, String dataDir) {
-		return dbName -> "jdbc:tc:" + image
-			+ ":///" + dbName
-			+ "?TC_DAEMON=true"
-			+ "&TC_TMPFS=" + dataDir + ":rw"
-			;
 	}
 
 	public static SqlDriverImpl.SqlDriverFactory<TestEntity> sqlDriverFactory(SqlDriverSettings settings, HikariDataSource dataSource) {

--- a/bosk-sql/src/test/resources/mysql.dockerfile
+++ b/bosk-sql/src/test/resources/mysql.dockerfile
@@ -1,0 +1,1 @@
+FROM mysql:9.7.1

--- a/bosk-sql/src/test/resources/postgresql.dockerfile
+++ b/bosk-sql/src/test/resources/postgresql.dockerfile
@@ -1,0 +1,1 @@
+FROM postgres:18.3

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -11,7 +11,7 @@ import works.bosk.BoskContext.Tenant.TenantId;
 import works.bosk.BoskDriver.EntireState;
 import works.bosk.DriverFactory;
 import works.bosk.testing.drivers.state.TestEntity;
-import works.bosk.util.PerTenant;
+import works.bosk.util.PerTenantValue;
 
 import static java.util.function.Function.identity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,8 +77,8 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 		if (scenario.tenancyModel instanceof Fixed(var id)) {
 			// Either a single tenant or NoTenant is ok. Normalize before comparing
 			TenantId tenantId = Tenant.setTo(id);
-			var e = PerTenant.from(expected, identity()).asNoTenant(tenantId);
-			var a = PerTenant.from(actual, identity()).asNoTenant(tenantId);
+			var e = PerTenantValue.from(expected, identity()).asNoTenant(tenantId);
+			var a = PerTenantValue.from(actual, identity()).asNoTenant(tenantId);
 			assertEquals(e, a);
 		} else {
 			// Must be exactly equal

--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,12 @@ configure(subprojects.findAll { it.name.startsWith("bosk-") || it.name == "boson
 // Spotless configuration
 subprojects {
 	apply plugin: 'com.diffplug.spotless'
+
 	spotless {
+		// Workaround for
+		// https://github.com/diffplug/spotless/issues/2998
+		enforceCheck = false
+
 		java {
 			importOrder '', '\\#' // Static imports after regular imports, as per mt-server standard and IntelliJ default
 			removeUnusedImports()
@@ -188,24 +193,6 @@ subprojects {
 			replaceRegex 'class-level javadoc indentation fix', /^\*/, ' *'
 			replaceRegex 'method-level javadoc indentation fix', /\t\*/, '\t *'
 			endWithNewline()
-		}
-	}
-}
-
-// https://github.com/diffplug/spotless/issues/2998
-// Spotless's expandWildcardImports() resolves ALL of a project's resolvable
-// configurations (including test/runtime classpaths) into plain File paths at
-// configuration time, without preserving Gradle's task-dependency info.
-// If one of those files is another subproject's jar that hasn't been built yet
-// (e.g. via a cross-project test dependency), spotlessJavaCheck can crash with
-// a FileNotFoundException instead of Gradle simply building it first.
-// As a workaround, we force all subprojects' jar tasks to run before any
-// spotlessJava/spotlessJavaCheck task.
-gradle.projectsEvaluated {
-	def allJarTasks = subprojects.findAll { it.tasks.findByName('jar') }.collect { it.tasks.named('jar') }
-	subprojects.each { sub ->
-		sub.tasks.matching { it.name == 'spotlessJava' || it.name == 'spotlessJavaCheck' }.configureEach { t ->
-			t.dependsOn allJarTasks
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,24 @@ subprojects {
 	}
 }
 
+// https://github.com/diffplug/spotless/issues/2998
+// Spotless's expandWildcardImports() resolves ALL of a project's resolvable
+// configurations (including test/runtime classpaths) into plain File paths at
+// configuration time, without preserving Gradle's task-dependency info.
+// If one of those files is another subproject's jar that hasn't been built yet
+// (e.g. via a cross-project test dependency), spotlessJavaCheck can crash with
+// a FileNotFoundException instead of Gradle simply building it first.
+// As a workaround, we force all subprojects' jar tasks to run before any
+// spotlessJava/spotlessJavaCheck task.
+gradle.projectsEvaluated {
+	def allJarTasks = subprojects.findAll { it.tasks.findByName('jar') }.collect { it.tasks.named('jar') }
+	subprojects.each { sub ->
+		sub.tasks.matching { it.name == 'spotlessJava' || it.name == 'spotlessJavaCheck' }.configureEach { t ->
+			t.dependsOn allJarTasks
+		}
+	}
+}
+
 // Apply publishing only to published modules
 configure(subprojects.findAll { it.name.startsWith("bosk-") || it.name == "boson" }) {
 	apply plugin: 'maven-publish'

--- a/lib-testing/src/main/resources/junit-platform.properties
+++ b/lib-testing/src/main/resources/junit-platform.properties
@@ -8,5 +8,7 @@ junit.jupiter.execution.parallel.config.executor-service=WORKER_THREAD_POOL
 # and causing timeouts due to our deliberately short timeout settings.
 junit.jupiter.execution.parallel.mode.default = same_thread
 
-# Way longer than tests should actually take; 5s would probably work
+# Way longer than tests should actually take: 5s would probably work.
+# The trouble is, it takes GitHub CI tests almost this long just to
+# pull all the required docker images.
 junit.jupiter.execution.timeout.default=1m

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
  		<filter class="works.bosk.logback.LoggerLevelFilter">
 			<logger> <name>com.mongodb</name> <level>INFO</level> </logger>
 			<logger> <name>org.mongodb</name> <level>INFO</level> </logger>
+			<logger> <name>works.bosk.drivers.mongo.internal.MongoService</name> <level>INFO</level> </logger>
  		</filter>
  	</turboFilter>
 	<turboFilter class="works.bosk.logback.BoskLogFilter"/>


### PR DESCRIPTION
The existing implementation was half-baked, especially when it came to multitenant operations. This PR establishes new protocols around the `!contents` document that should make the updates reliable.

### Design principles

The `!contents` document is the system of record for which tenants exist. Each tenant listed in `!contents` is associated with corresponding state documents, including the root document, which contains the tenant's `revision` field. The `!contents` document itself also has a `revision` field. Additional stale state documents may also exist in `HASTY` mode and must be ignored.

When writing a new tenant, we write the state documents before writing the `!contents` document. This has the effect that when the `!contents` change event arrives, the receiver can be assured it has already seen all relevant events for creating the state documents. All of these changes happen in a transaction, meaning that the intermediate states (where state documents are changed but `!contents` hasn't been updated) are not visible to read operations; the ordering matters only for change events.

#### Flush

The `flush()` operation must wait for change events corresponding to the last update for all tenants that existed at the moment the flush began. Because of how MongoDB replication works, this requires us to read the revision numbers using `ReadConcern.LOCAL`, which doesn't obey any kind of reliable snapshot, session, or transaction semantics, so we must be able to tolerate database changes interleaved with our revision number read operations.

The way it works is:
0. (The flush is required to wait for updates from before this moment in time.)
1. Read all `revision` fields form all root documents
  - (Because of the lack of snapshot, this occurs over an extended period of time)
2. Read the `!contents` document
3. Wait on the `contentsFlushLock`
4. Wait on the `flushLock` for all tenants present in both steps 1 and 2 and also in `flushLocks`.

It's not obvious that this is the right sequence. Here's how it works.

First, we read the `!contents` document last, ensuring that we have a contents revision number from _after_ we scanned for tenant revision numbers. If any tenants were created or deleted while step 1 was in progress, step 2 will supply a revision number that ensures we have seen all those creations and deletions.

Second, waiting only for tenants that are present in _all three_ places (step 1, step 2, and `flushLocks`) is sufficient:
- If a tenant is absent in step 1 and present in step 2, then it must have been created after the start of step 1, so we're under no obligation to wait for it.
- If a tenant is absent in step 2, it must have been deleted before step 2, and we'll wait for that deletion in step 3.
- If a tenant is present in both steps 1 and 2 but absent from `flushLocks` in step 4, then it was deleted after step 2, in which case we're under no obligation to wait because we must wait only for events before step 1.
