### PR TITLE
Mongo manifest epoch field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,8 @@ The module names follow the same conventions as package names.
 
 ### Exceptions
 
-Consider `RuntimeException` to be abstract and throw the appropriate subtype: often `IllegalStateException` but consider whether others are more appropriate.
+Consider `RuntimeException` to be abstract and throw the appropriate subtype:
+often `IllegalStateException` but consider whether others are more appropriate.
 
 We use checked exceptions to help avoid bugs, except where they'd place undue burden on the user.
 Our internal exceptions are usually checked so the compiler can ensure we handle them.
@@ -85,7 +86,13 @@ where `throws` clauses have no real downside.
 We put exceptions for a module into a sub-package that ends with `.exceptions`
 so they don't clutter up other packages.
 
-When declaring `throws` on a method, use the specific exception type(s), not a superclass like `Exception`. This applies to test methods too — declaring `throws Exception` is not a good habit and we don't want examples of that in the code.
+When declaring `throws` on a method, use the specific exception type(s), not a superclass like `Exception`.
+This applies to test methods too: declaring `throws Exception` is not a good habit
+and we don't want examples of that in the code.
+
+Don't delete unused constructors of Exception subclasses.
+We typically provide a suite of constructors so future maintainers won't need to wonder if they're
+breaking some implicit design rule by adding a new exception that wasn't there before.
 
 ### Javadocs
 

--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -144,6 +144,15 @@ public interface BoskDriver {
 	 * to implement their own <code>flush</code> method.
 	 *
 	 * <p>
+	 * This usually should not throw runtime exceptions: those can be wrapped as {@link FlushFailureException}.
+	 *
+	 * <p>
+	 * (We say "usually" above because the stackable driver architecture allows all kinds of
+	 * customizations, and in some cases, users might <em>want</em> drivers to break conventions
+	 * to achieve a certain effect. The "usually" rules are guidelines intended to reduce
+	 * surprises, but are not strictly required for conformance.)
+	 *
+	 * <p>
 	 * <strong>Evolution note</strong>: This method currently acts as a full barrier, while
 	 * ultimately we may want a more efficient release-acquire pair that allows writes
 	 * to be reliably visible to subsequent reads.

--- a/bosk-core/src/main/java/works/bosk/exceptions/FlushFailureException.java
+++ b/bosk-core/src/main/java/works/bosk/exceptions/FlushFailureException.java
@@ -8,13 +8,18 @@ import works.bosk.BoskDriver;
  * that all prior updates have been applied.
  *
  * <p>
- * Useful as a wrapper for other kinds of checked exceptions that could be thrown
- * from {@link BoskDriver} implementations.
+ * This is the vehicle by which a {@link BoskDriver} reports flush failures that
+ * are not already {@link IOException}s, such as unexpected database contents,
+ * database timeouts, disconnections, or {@code SQLException}s. Because it extends
+ * {@link IOException}, any code that already handles the failures of a method that
+ * performs IO will also handle this (eg. by aborting, retrying, or logging);
+ * the same is not necessarily true for {@link RuntimeException}.
  *
  * <p>
- * Extends {@link IOException} because we expect that any code that already
- * handles that will do the right thing for this (eg. aborting, retrying, logging).
- * The same is not necessarily true for {@link RuntimeException}.
+ * A driver that encounters a genuine {@link IOException} while flushing (for example,
+ * from its own downstream driver) should let it propagate as-is rather than wrapping
+ * it in a {@code FlushFailureException}: the caller is already expected to handle
+ * {@link IOException}.
  */
 public class FlushFailureException extends IOException {
 	public FlushFailureException(String message) { super(message); }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -5,6 +5,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -97,7 +98,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		if (bsm.state() == null) {
 			throw new IOException("No existing state in document");
 		}
-		replaceFlushLock(bsm.revision());
+		replaceFlushLock(bsm.epoch(), bsm.revision());
 		fieldTracker.process(bsm);
 
 		R root = formatter.document2object(bsm.state(), rootRef);
@@ -105,7 +106,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 			? MapValue.empty() // It's not clear what missing attributes mean, but using null here would have the effect of leaving the old attributes in place, which seems flaky
 			: formatter.decodeDiagnosticAttributes(bsm.diagnosticAttributes());
 
-		return new StateAndMetadata<>(root, bsm.revision(), diagnosticAttributes);
+		return new StateAndMetadata<>(root, bsm.epoch(), bsm.revision(), diagnosticAttributes);
 	}
 
 	@Override
@@ -116,8 +117,8 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	/**
 	 * Must be called before {@link FormatDriver#onHasBeenApplied} or any event processing.
 	 */
-	protected void replaceFlushLock(BsonInt64 revisionNumber) {
-		flushLock.set(new FlushLock(revisionNumber.longValue(), flushTimeoutMS));
+	protected void replaceFlushLock(Optional<BsonString> epoch, BsonInt64 revisionNumber) {
+		flushLock.set(new FlushLock(epoch, revisionNumber.longValue(), flushTimeoutMS));
 	}
 
 	abstract BsonStateAndMetadata readBsonStateAndMetadata() throws InvalidCollectionContentsException;
@@ -160,8 +161,15 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		return blankUpdateDoc().append("$unset", new BsonDocument(key, BsonNull.VALUE));
 	}
 
-	protected boolean shouldSkip(BsonInt64 revision) {
-		return flushLock.get().alreadySeen(revision);
+	/**
+	 * An event from a different epoch indicates the collection has been reinitialized,
+	 * so we must not skip it based on the previous initialization's revision numbers.
+	 *
+	 * @param epoch the collection epoch at the time of the event; {@link Optional#empty()}
+	 * for legacy databases, in which case only the revision is considered
+	 */
+	protected boolean shouldSkip(Optional<BsonString> epoch, BsonInt64 revision) {
+		return flushLock.get().epochMatches(epoch) && flushLock.get().alreadySeen(revision);
 	}
 
 	/**
@@ -195,33 +203,53 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	/**
-	 * @return cursor giving the {@code _id} and {@code revision}
+	 * @return cursor giving the {@code _id}, {@code epoch}, and {@code revision}
 	 * for all root documents that have a revision field.
 	 */
 	protected MongoCursor<BsonDocument> revisionDocumentCursor() {
 		return collection
 			.findLatest(rootDocumentsFilter())
-			.projection(fields(include("_id", DocumentFields.revision.name())))
+			.projection(fields(include("_id", DocumentFields.epoch.name(), DocumentFields.revision.name())))
 			.cursor();
+	}
+
+	/**
+	 * The revision number to flush, whose epoch has been verified to match
+	 * the collection's current epoch.
+	 *
+	 * @param document a root document, as read by {@link #revisionDocumentCursor()}
+	 * @throws EpochMismatchException if {@code document} is from a different epoch
+	 * than the one we loaded
+	 */
+	protected @NonNull BsonInt64 revisionVerifiedAgainstEpoch(BsonDocument document) throws EpochMismatchException {
+		Optional<BsonString> epoch = formatter.epochOf(document);
+		if (!flushLock.get().epochMatches(epoch)) {
+			// The collection has been reinitialized since we loaded it.
+			// We must not wait on our stale revision numbers; instead, throw
+			// so the driver disconnects, reloads the new state, and retries.
+			throw new EpochMismatchException("Collection epoch has changed from "
+				+ flushLock.get().epoch() + " to " + epoch);
+		}
+		return document.getInt64(DocumentFields.revision.name(), Formatter.REVISION_ZERO);
 	}
 
 	/**
 	 * If there's any other waiting to be done besides the revision number waiting,
 	 * this method must do that before returning.
-	 * @return revision number found in the database
-	 * @throws RevisionFieldDisruptedException if unexpected database contents make it impossible to determine the revision number
+	 * @return the revision number found in the database
+	 * @throws FlushFailureException if unexpected database contents make it impossible to determine the revision number
 	 */
 	abstract @NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException, InterruptedException;
 
 	@Override
 	public void flush() throws IOException, InterruptedException {
-		var revision = readRevisionNumberToFlush();
+		BsonInt64 revision = readRevisionNumberToFlush();
 
 		// Don't hold a database transaction while waiting for the flush lock
 		// or flushing downstream.
 		collection.commitTransactionIfAny();
 
-		LOGGER.debug("Revisions to flush: {}", revision);
+		LOGGER.debug("Revision to flush: {}", revision);
 		flushLock.get().awaitRevision(revision);
 		LOGGER.debug("| Flush downstream");
 		downstream.flush();
@@ -243,11 +271,12 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 		LOGGER.debug("| Manifest result: {}", result);
 	}
 
-	protected BsonDocument initialDocument(BsonValue initialState, BsonInt64 revision, BsonString documentId) {
+	protected BsonDocument initialDocument(BsonValue initialState, BsonString epoch, BsonInt64 revision, BsonString documentId) {
 		BsonDocument fieldValues = new BsonDocument("_id", documentId);
 
 		fieldValues.put(DocumentFields.path.name(), new BsonString("/"));
 		fieldValues.put(DocumentFields.state.name(), initialState);
+		fieldValues.put(DocumentFields.epoch.name(), epoch);
 		fieldValues.put(DocumentFields.revision.name(), revision);
 		fieldValues.put(DocumentFields.diagnostics.name(), formatter.encodeDiagnostics(context.getAttributes()));
 
@@ -263,6 +292,7 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	 */
 	record BsonStateAndMetadata(
 		BsonString _id,
+		Optional<BsonString> epoch,
 		BsonInt64 revision,
 		BsonDocument diagnosticAttributes,
 		BsonDocument state

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/AbstractFormatDriver.java
@@ -1,10 +1,13 @@
 package works.bosk.drivers.mongo.internal;
 
+import com.mongodb.MongoException;
+import com.mongodb.MongoInterruptedException;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.result.UpdateResult;
 import java.io.IOException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -214,32 +217,42 @@ abstract non-sealed class AbstractFormatDriver<R extends StateTreeNode> implemen
 	}
 
 	/**
-	 * The revision number to flush, whose epoch has been verified to match
-	 * the collection's current epoch.
+	 * Reads the {@link DocumentFields#revision revision} number of the current root document,
+	 * after verifying its {@link DocumentFields#epoch epoch} matches the one we loaded.
+	 * <p>
+	 * If the format requires any other waiting before flushing, subclasses may override this.
 	 *
-	 * @param document a root document, as read by {@link #revisionDocumentCursor()}
-	 * @throws EpochMismatchException if {@code document} is from a different epoch
-	 * than the one we loaded
-	 */
-	protected @NonNull BsonInt64 revisionVerifiedAgainstEpoch(BsonDocument document) throws EpochMismatchException {
-		Optional<BsonString> epoch = formatter.epochOf(document);
-		if (!flushLock.get().epochMatches(epoch)) {
-			// The collection has been reinitialized since we loaded it.
-			// We must not wait on our stale revision numbers; instead, throw
-			// so the driver disconnects, reloads the new state, and retries.
-			throw new EpochMismatchException("Collection epoch has changed from "
-				+ flushLock.get().epoch() + " to " + epoch);
-		}
-		return document.getInt64(DocumentFields.revision.name(), Formatter.REVISION_ZERO);
-	}
-
-	/**
-	 * If there's any other waiting to be done besides the revision number waiting,
-	 * this method must do that before returning.
 	 * @return the revision number found in the database
-	 * @throws FlushFailureException if unexpected database contents make it impossible to determine the revision number
+	 * @throws EpochMismatchException if the epoch has changed, rendering revisions uncomparable
+	 * @throws FlushFailureException if unable to determine the revision number
+	 * @throws InterruptedException if interrupted while reading
 	 */
-	abstract @NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException, InterruptedException;
+	@NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException, InterruptedException {
+		LOGGER.debug("readRevisionNumberToFlush");
+		try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
+			// Our revisionDocumentCursor matches only one document
+			BsonDocument document = cursor.next();
+			Optional<BsonString> epoch = formatter.epochOf(document);
+            if (flushLock.get().epochMatches(epoch)) {
+                return document.getInt64(DocumentFields.revision.name(), Formatter.REVISION_ZERO);
+            } else {
+                // The collection has been reinitialized since we loaded it.
+                // We must not wait on our stale revision numbers; instead, throw
+                // so the driver disconnects, reloads the new state, and retries.
+                throw new EpochMismatchException("Collection epoch has changed from "
+                    + flushLock.get().epoch() + " to " + epoch);
+            }
+        } catch (NoSuchElementException e) {
+			throw new RevisionFieldDisruptedException("No root documents found", e);
+		} catch (MongoInterruptedException e) {
+			Thread.interrupted();
+			InterruptedException exception = new InterruptedException("Interrupted while reading the revision number");
+			exception.initCause(e);
+			throw exception;
+		} catch (MongoException e) {
+			throw new FlushFailureException("Failed to read the revision number", e);
+		}
+	}
 
 	@Override
 	public void flush() throws IOException, InterruptedException {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonFormatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/BsonFormatter.java
@@ -307,6 +307,18 @@ public class BsonFormatter {
 		state,
 
 		/**
+		 * A {@link java.util.UUID} identifying this collection's current initialization.
+		 * It is generated when the collection is first initialized, and preserved
+		 * when the collection is reinitialized with the same state (eg. by a refurbish).
+		 * It is NOT preserved when a different process deletes the collection and starts over,
+		 * because the start-over is a genuinely new initialization.
+		 *
+		 * <p>
+		 * A missing value indicates a legacy database that predates the epoch mechanism.
+		 */
+		epoch,
+
+		/**
 		 * An ever-increasing 64-bit long that is incremented every time the document changes.
 		 */
 		revision,

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/EpochMismatchException.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/EpochMismatchException.java
@@ -1,0 +1,17 @@
+package works.bosk.drivers.mongo.internal;
+
+import works.bosk.exceptions.FlushFailureException;
+
+/**
+ * A kind of {@link FlushFailureException} indicating that the database collection's
+ * {@link Formatter.DocumentFields#epoch epoch} does not match the epoch that
+ * {@link AbstractFormatDriver}'s {@link FlushLock} was created for,
+ * meaning that {@link Formatter.DocumentFields#revision revision} numbers are no longer comparable.
+ * This makes the {@link FlushLock} unreliable, and so we need to reload
+ * the state from the database and reinitialize the {@link ChangeReceiver}.
+ */
+class EpochMismatchException extends FlushFailureException {
+	public EpochMismatchException(String message) {
+		super(message);
+	}
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FlushLock.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FlushLock.java
@@ -1,10 +1,12 @@
 package works.bosk.drivers.mongo.internal;
 
+import java.util.Optional;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.bson.BsonInt64;
+import org.bson.BsonString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import works.bosk.drivers.mongo.exceptions.DisconnectedException;
@@ -14,56 +16,59 @@ import static java.lang.System.identityHashCode;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * Implements waiting mechanism for revision numbers
- *
- * <h3>Evolution note</h3>
- * There is an important scenario that we ought to support:
- * <ol><li>
- *     Document/collection/database gets deleted
- * </li><li>
- *     A new bosk gets created (say, by restarting a server)
- * </li><li>
- *     The new bosk reinitializes the database
- * </li></ol>
- *
- * This situation is covered in <code>MongoDriverResiliencyTest</code>,
- * but actually we don't handle this perfectly because flush logic looks
- * at the revision number only. In the case where the database
- * is reinitialized with a different bosk state but the same revision number,
- * checking the revision number only is insufficient to determine that the
- * in-memory state is out of date. The test presently passes, presumably
- * because it's rescued by the change stream event describing the disruption,
- * but if that event were sufficiently delayed, the flush could incorrectly
- * conclude that it does not need to wait.
+ * Implements waiting mechanism for revision numbers.
  *
  * <p>
- * One reasonable solution would be to include a UUID <code>epoch</code>
- * field alongside the revision number, and to have the flush logic check
- * both. It would conclude that there's no need to wait only if both the
- * <code>epoch</code> and <code>revision</code> fields match expectations.
+ * The <code>epoch</code> identifies a particular initialization of the database collection.
+ * It is generated when the collection is first initialized, and preserved
+ * when the collection is reinitialized with the same state (eg. by a refurbish operation).
+ * It is NOT preserved when a different process deletes the collection and starts over,
+ * because the start-over is a genuinely new initialization.
  *
  * <p>
- * We have not yet implemented this logic because, at the time of writing,
- * the revision logic seems quite widespread, and we're hoping to encapsulate
- * it within the {@link FormatDriver}. Once that happens, we can easily evolve
- * that logic to include an epoch concept without touching other components.
+ * The reason for the epoch is to detect the scenario where a document/collection/database
+ * is deleted, and then a new bosk reinitializes the database with a * different state.
+ * The revision number alone is an insufficient signal in this case: the reinitialized
+ * collection may very well have the same revision number as what we've already seen,
+ * in which case the flush would wrongly conclude that there is no need to wait.
+ * Hence, we also track the epoch: a flush needs to wait unless it has already seen
+ * both the current <code>epoch</code> and the current <code>revision</code> number.
  */
 class FlushLock {
 	private final long flushTimeoutMS;
 	private final Lock queueLock = new ReentrantLock();
 	private final PriorityBlockingQueue<Waiter> queue = new PriorityBlockingQueue<>();
+	private final Optional<BsonString> epoch;
 	private volatile long alreadySeen;
 	private boolean isClosed;
 
 	/**
-	 * @param revisionAlreadySeen needs to be the exact revision from the database:
+	 * @param epoch the exact epoch from the database; {@link Optional#empty()} indicates a
+	 * legacy database that predates the epoch mechanism, and matches only another empty epoch.
+	 * @param revisionAlreadySeen the exact revision from the database:
 	 * too old, and we'll wait forever for intervening revisions that have already happened;
 	 * too new, and we'll proceed immediately without waiting for revisions that haven't happened yet.
 	 */
-	public FlushLock(long revisionAlreadySeen, long flushTimeoutMS) {
-		LOGGER.debug("New flush lock at revision {} [{}]", revisionAlreadySeen, identityHashCode(this));
+	public FlushLock(Optional<BsonString> epoch, long revisionAlreadySeen, long flushTimeoutMS) {
+		LOGGER.debug("New flush lock at epoch {} revision {} [{}]", epoch, revisionAlreadySeen, identityHashCode(this));
 		this.flushTimeoutMS = flushTimeoutMS;
+		this.epoch = epoch;
 		this.alreadySeen = revisionAlreadySeen;
+	}
+
+	/**
+	 * @return true if the lock and the database agree on the collection's epoch:
+	 * either both have the same epoch, or both are legacy databases with no epoch
+	 */
+	boolean epochMatches(Optional<BsonString> databaseEpoch) {
+		return epoch.equals(databaseEpoch);
+	}
+
+	/**
+	 * @return the epoch this lock was created for
+	 */
+	Optional<BsonString> epoch() {
+		return epoch;
 	}
 
 	private record Waiter(
@@ -140,7 +145,9 @@ class FlushLock {
 				}
 			} while (true);
 
-			alreadySeen = revisionValue;
+			if (revisionValue > alreadySeen) {
+				alreadySeen = revisionValue;
+			}
 			LOGGER.debug("Finished {} [{}]", revisionValue, identityHashCode(this));
 		} finally {
 			queueLock.unlock();

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/FormatDriver.java
@@ -74,8 +74,9 @@ sealed public interface FormatDriver<R extends StateTreeNode>
 	 * but should tolerate documents already existing,
 	 * by using upsert or replace operations, for example.
 	 * @param priorContents the desired state, with metadata representing a (possibly hypothetical)
-	 * "prior" state of the database; in particular, the revision number should be incremented
-	 * so that a {@link #flush} after a {@link #refurbish} succeeds in waiting for the new state.
+	 * "prior" state of the database; in particular, the epoch should be preserved if it exists,
+	 * and the revision number should be incremented so that a {@link #flush} after
+	 * a {@link #refurbish} succeeds in waiting for the new state.
 	 */
 	void initializeCollection(StateAndMetadata<R> priorContents);
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/Formatter.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.bson.BsonBinaryWriter;
 import org.bson.BsonDocument;
@@ -166,6 +167,13 @@ final class Formatter extends BsonFormatter {
 			return null;
 		}
 		return fullDocument.getInt64(DocumentFields.revision.name(), null);
+	}
+
+	Optional<BsonString> epochOf(BsonDocument fullDocument) {
+		if (fullDocument == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(fullDocument.getString(DocumentFields.epoch.name(), null));
 	}
 
 	MapValue<String> getDiagnosticAttributesFromFullDocument(BsonDocument fullDocument) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
@@ -329,7 +330,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 				var session = queryCollection.newSession()
 			) {
 				FormatDriver<R> preferredDriver = newPreferredFormatDriver();
-				StateAndMetadata<R> priorContents = new StateAndMetadata<>(entireState, REVISION_ZERO, diagnosticAttributes);
+				StateAndMetadata<R> priorContents = new StateAndMetadata<>(entireState, Optional.empty(), REVISION_ZERO, diagnosticAttributes);
 				preferredDriver.initializeCollection(priorContents);
 				session.commitTransactionIfAny();
 				// We can now publish the driver knowing that the transaction, if there is one, has committed
@@ -360,8 +361,8 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 	 * Refurbish is the one operation that always <em>must</em> happen in a transaction,
 	 * or else we could fail after deleting the existing contents but before rewriting them,
 	 * which would be catastrophic.
-	 *
-	 * <em<>Design note:</em> This operation shouldn't do any special coordination with
+	 * <p>
+	 * <em>Design note:</em> This operation shouldn't do any special coordination with
 	 * the receiver/listener system, because other replicas won't.
 	 * That system needs to cope with refurbish operations without any help.
 	 */

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -452,9 +452,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			this.<InterruptedException, IOException>doRetryableDriverOperation(() -> {
 				formatDriver.flush();
 			}, "flush");
-		} catch (DisconnectedException | IOException e) {
-			// Callers are expecting a FlushFailureException in these cases
-			// TODO: Is this true for IOException? Why is flush() declared to throw IOException then?
+		} catch (RuntimeException e) {
 			throw new FlushFailureException(e);
 		}
 	}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -55,7 +57,6 @@ import static org.bson.BsonBoolean.TRUE;
 import static works.bosk.Path.parseParameterized;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.docBsonPath;
 import static works.bosk.drivers.mongo.internal.DocumentFieldTracker.TrackedField.DIAGNOSTICS;
-import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
 import static works.bosk.util.Classes.enumerableByIdentifier;
 
 /**
@@ -181,6 +182,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 					bsm = new BsonStateAndMetadata(
 						id,
+						formatter.epochOf(lastPart),
 						revision, diagnosticAttributes, state
 					);
 
@@ -206,11 +208,11 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 	}
 
 	@Override
-	@NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException, InterruptedException {
+	@NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException {
 		LOGGER.debug("readRevisionNumberToFlush");
 		try {
 			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
-				return cursor.next().getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+				return revisionVerifiedAgainstEpoch(cursor.next());
 			}
 		} catch (RuntimeException e) {
 			throw new RevisionFieldDisruptedException(e);
@@ -230,13 +232,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 
 	@Override
 	public void initializeCollection(StateAndMetadata<R> priorContents) {
-		replaceFlushLock(priorContents.revision());
+		BsonString epoch = priorContents.epoch().orElseGet(() -> new BsonString(UUID.randomUUID().toString()));
+		replaceFlushLock(Optional.of(epoch), priorContents.revision());
 		BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
 		BsonInt64 revision = nextRevision(priorContents.revision());
 		try (var _ = context.withOnly(priorContents.diagnosticAttributes())) {
 
 			LOGGER.debug("** Initial upsert");
-			initializeCollection(initialState, revision);
+			initializeCollection(initialState, epoch, revision);
 
 			// When initializing the collection, whether for initialState() or
 			// for refurbish(), the local state will be up to date with no need
@@ -246,14 +249,14 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 		writeManifest(Manifest.forPando(format));
 	}
 
-	private void initializeCollection(BsonValue initialState, BsonInt64 newRevision) {
+	private void initializeCollection(BsonValue initialState, BsonString epoch, BsonInt64 newRevision) {
 		// Note that priorContents.diagnosticAttributes are ignored, and we use the attributes from this thread
 		collection.ensureTransactionStarted();
 		if (initialState instanceof BsonDocument) {
 			upsertAndRemoveSubParts(rootRef, initialState.asDocument()); // Mutates initialState!
 		}
 		BsonString documentId = new BsonString("|");
-		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, documentId));
+		BsonDocument update = new BsonDocument("$set", initialDocument(initialState, epoch, newRevision, documentId));
 		BsonDocument filter = rootDocumentsFilter();
 		filter.put("_id", documentId);
 		UpdateOptions options = new UpdateOptions().upsert(true);
@@ -337,11 +340,12 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					BsonDocument attrsBson = fieldTracker.getFieldAsDocument(docId, DIAGNOSTICS);
 					MapValue<String> diagnosticAttributes = attrsBson == null ? MapValue.empty() : formatter.decodeDiagnosticAttributes(attrsBson);
 
+					Optional<BsonString> epoch = formatter.epochOf(fullDocument);
 					BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
 					try (
 						var _ = context.withOnly(diagnosticAttributes)
 					) {
-						if (shouldSkip(revision)) {
+						if (shouldSkip(epoch, revision)) {
 							LOGGER.debug("Skipping revision {}", revision.longValue());
 							return;
 						}
@@ -361,6 +365,10 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 						}
 					}
 
+					if (!flushLock.get().epochMatches(epoch)) {
+						// Adopt the new epoch so future flushes don't needlessly reconnect
+						replaceFlushLock(epoch, revision);
+					}
 					finishedRevision(revision);
 				} break;
 				case UPDATE: {
@@ -373,7 +381,7 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 						var _ = context.withOnly(attributes)
 					) {
 						revision = formatter.getRevisionFromUpdateEvent(finalEvent);
-						if (shouldSkip(revision)) {
+						if (shouldSkip(flushLock.get().epoch(), revision)) {
 							LOGGER.debug("Skipping revision {}", revision.longValue());
 							return;
 						}
@@ -395,9 +403,11 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 					// No other events in the transaction matter if the root document is gone.
 					// This can happen during a refurbish, so we don't want to throw UnprocessableEventException
 					// even though it's highly disruptive.
-					// TODO: Is this safe? Does this open up a timing hole where updates could be dropped?
-					LOGGER.debug("Document containing revision field has been deleted; assuming revision=0");
-					flushLock.get().finishedRevision(Formatter.REVISION_ZERO);
+					// We deliberately do not reset alreadySeen: the never-backward semantics
+					// in FlushLock ensure that a deleted-and-reinitialized document still causes
+					// flushes to wait, and the epoch mechanism detects that the collection
+					// has been reinitialized.
+					LOGGER.debug("Document containing revision field has been deleted");
 				} break;
 				default: {
 					throw new UnprocessableEventException("Cannot process event", finalEvent.getOperationType());

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/PandoFormatDriver.java
@@ -42,7 +42,6 @@ import works.bosk.drivers.mongo.MongoDriverSettings.OrphanDocumentMode;
 import works.bosk.drivers.mongo.PandoFormat;
 import works.bosk.drivers.mongo.exceptions.FormatMisconfigurationException;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
-import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.NotYetImplementedException;
 
@@ -205,18 +204,6 @@ final class PandoFormatDriver<R extends StateTreeNode> extends AbstractFormatDri
 			throw new NotYetImplementedException("Nothing there!");
 		}
 		return bsm;
-	}
-
-	@Override
-	@NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException {
-		LOGGER.debug("readRevisionNumberToFlush");
-		try {
-			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
-				return revisionVerifiedAgainstEpoch(cursor.next());
-			}
-		} catch (RuntimeException e) {
-			throw new RevisionFieldDisruptedException(e);
-		}
 	}
 
 	/**

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/RevisionFieldDisruptedException.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/RevisionFieldDisruptedException.java
@@ -27,8 +27,4 @@ class RevisionFieldDisruptedException extends FlushFailureException {
 	public RevisionFieldDisruptedException(String message, Throwable cause) {
 		super(message, cause);
 	}
-
-	public RevisionFieldDisruptedException(Throwable cause) {
-		super(cause);
-	}
 }

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -9,6 +9,8 @@ import com.mongodb.client.result.UpdateResult;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonInvalidOperationException;
@@ -27,13 +29,13 @@ import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
+import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.bson.BsonBoolean.FALSE;
 import static works.bosk.drivers.mongo.MongoDriverSettings.DatabaseFormat.SEQUOIA;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.dottedFieldNameOf;
 import static works.bosk.drivers.mongo.internal.BsonFormatter.referenceTo;
-import static works.bosk.drivers.mongo.internal.Formatter.REVISION_ZERO;
 
 /**
  * Implements the {@link MongoDriverSettings.DatabaseFormat#SEQUOIA Sequoia} format.
@@ -107,6 +109,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			BsonDocument document = cursor.next();
 			return new BsonStateAndMetadata(
 				document.getString("_id"),
+				formatter.epochOf(document),
 				document.getInt64(DocumentFields.revision.name()),
 				Formatter.getDiagnosticAttributesIfAny(document),
 				document.getDocument(DocumentFields.state.name())
@@ -120,12 +123,13 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 	}
 
 	@Override
-	@NonNull BsonInt64 readRevisionNumberToFlush() throws RevisionFieldDisruptedException {
+	@NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException {
 		LOGGER.debug("readRevisionNumberToFlush");
 		try {
 			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
 				// Our revisionDocumentCursor matches only one document
-				return cursor.next().getInt64(DocumentFields.revision.name(), REVISION_ZERO);
+				BsonDocument document = cursor.next();
+				return revisionVerifiedAgainstEpoch(document);
 			}
 		} catch (NoSuchElementException e) {
 			throw new RevisionFieldDisruptedException("No root documents found", e);
@@ -136,13 +140,14 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 
 	@Override
 	public void initializeCollection(StateAndMetadata<R> priorContents) {
-		replaceFlushLock(priorContents.revision());
+		BsonString epoch = priorContents.epoch().orElseGet(() -> new BsonString(UUID.randomUUID().toString()));
+		replaceFlushLock(Optional.of(epoch), priorContents.revision());
 
 		// Sequoia has only one document
 		BsonValue initialState = formatter.object2bsonValue(priorContents.state(), rootRef.targetType());
 		BsonInt64 newRevision = new BsonInt64(1 + priorContents.revision().longValue());
 		try (var _ = context.withOnly(priorContents.diagnosticAttributes())) {
-			BsonDocument update = new BsonDocument("$set", initialDocument(initialState, newRevision, DOCUMENT_ID));
+			BsonDocument update = new BsonDocument("$set", initialDocument(initialState, epoch, newRevision, DOCUMENT_ID));
 			BsonDocument filter = documentFilter();
 			UpdateOptions options = new UpdateOptions().upsert(true);
 			LOGGER.debug("** Initial upsert for {}", DOCUMENT_ID);
@@ -203,6 +208,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					var _ = context.withOnly(diagnosticAttributes)
 				) {
 					BsonInt64 revision = formatter.getRevisionFromFullDocument(fullDocument);
+					Optional<BsonString> epoch = formatter.epochOf(fullDocument);
 					BsonDocument state = fullDocument.getDocument(DocumentFields.state.name(), null);
 					if (state == null) {
 						throw new UnprocessableEventException("Missing state field", event.getOperationType());
@@ -213,6 +219,10 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					// disappears, we don't null out revisionToSkip. TODO: Rethink what's the right way to handle this.
 					LOGGER.debug("| Replace {}", rootRef);
 					downstream.submitReplacement(rootRef, newRoot);
+					if (!flushLock.get().epochMatches(epoch)) {
+						// Adopt the new epoch so future flushes don't needlessly reconnect
+						replaceFlushLock(epoch, revision);
+					}
 					finishedRevision(revision);
 				}
 			} break;
@@ -226,7 +236,7 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 					try (
 						var _ = context.withOnly(diagnosticAttributes)
 					) {
-						if (shouldSkip(revision)) {
+						if (shouldSkip(flushLock.get().epoch(), revision)) {
 							LOGGER.debug("Skipping revision {}", revision.longValue());
 							return;
 						}
@@ -238,9 +248,12 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 				}
 			} break;
 			case DELETE: {
-				// TODO: Is this safe? Does this open up a timing hole where updates could be dropped?
-				LOGGER.debug("Document containing revision field has been deleted; assuming revision=0");
-				finishedRevision(REVISION_ZERO);
+				// The revision field has been deleted along with the document.
+				// We deliberately do not reset alreadySeen: the never-backward semantics
+				// in FlushLock ensure that a deleted-and-reinitialized document still causes
+				// flushes to wait, and the epoch mechanism detects that the collection
+				// has been reinitialized.
+				LOGGER.debug("Document containing revision field has been deleted");
 			} break;
 			default: {
 				throw new UnprocessableEventException("Cannot process event", event.getOperationType());

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/SequoiaFormatDriver.java
@@ -16,7 +16,6 @@ import org.bson.BsonInt64;
 import org.bson.BsonInvalidOperationException;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,6 @@ import works.bosk.StateTreeNode;
 import works.bosk.drivers.mongo.BsonSerializer;
 import works.bosk.drivers.mongo.MongoDriverSettings;
 import works.bosk.drivers.mongo.internal.BsonFormatter.DocumentFields;
-import works.bosk.exceptions.FlushFailureException;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.bson.BsonBoolean.FALSE;
@@ -120,22 +118,6 @@ final class SequoiaFormatDriver<R extends StateTreeNode> extends AbstractFormatD
 			throw new InvalidCollectionContentsException(SEQUOIA, "State document is missing required fields: " + DOCUMENT_ID, e);
 		}
 
-	}
-
-	@Override
-	@NonNull BsonInt64 readRevisionNumberToFlush() throws FlushFailureException {
-		LOGGER.debug("readRevisionNumberToFlush");
-		try {
-			try (MongoCursor<BsonDocument> cursor = revisionDocumentCursor()) {
-				// Our revisionDocumentCursor matches only one document
-				BsonDocument document = cursor.next();
-				return revisionVerifiedAgainstEpoch(document);
-			}
-		} catch (NoSuchElementException e) {
-			throw new RevisionFieldDisruptedException("No root documents found", e);
-		} catch (RuntimeException e) {
-			throw new RevisionFieldDisruptedException(e);
-		}
 	}
 
 	@Override

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/StateAndMetadata.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/StateAndMetadata.java
@@ -1,11 +1,14 @@
 package works.bosk.drivers.mongo.internal;
 
+import java.util.Optional;
 import org.bson.BsonInt64;
+import org.bson.BsonString;
 import works.bosk.MapValue;
 import works.bosk.StateTreeNode;
 
 public record StateAndMetadata<R extends StateTreeNode>(
 	R state,
+	Optional<BsonString> epoch,
 	BsonInt64 revision,
 	MapValue<String> diagnosticAttributes
 ) { }

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverReinitializationTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverReinitializationTest.java
@@ -29,8 +29,8 @@ import static works.bosk.testing.BoskTestUtils.boskName;
 /**
  * Tests the behaviour of a bosk whose database collection is deleted and re-initialized
  * with different content by a different process while the bosk is still running.
- * The deleted-and-recreated collection begins a <em>new life</em> that the bosk must
- * detect, even if the new life's revision numbers happen to coincide with old ones.
+ * The bosk must detect that the collection has been deleted and recreated,
+ * even if the new collection's revision numbers happen to coincide with old ones.
  */
 @Slow
 @ParameterizedClass
@@ -91,7 +91,7 @@ public class MongoDriverReinitializationTest extends AbstractMongoDriverTest {
 		bosk.driver().flush();
 		try (var _ = bosk.readSession()) {
 			assertEquals(afterState, bosk.rootReference().value(),
-				"flush must load the state of the collection's new life");
+				"flush must load the state of the reinitialized collection");
 		}
 	}
 

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverReinitializationTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverReinitializationTest.java
@@ -1,0 +1,121 @@
+package works.bosk.drivers.mongo.internal;
+
+import com.mongodb.client.MongoCollection;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import works.bosk.Bosk;
+import works.bosk.BoskConfig;
+import works.bosk.drivers.mongo.MongoDriver;
+import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.drivers.mongo.internal.TestParameters.ParameterSet;
+import works.bosk.testing.drivers.state.TestEntity;
+import works.bosk.testing.junit.Slow;
+
+import static ch.qos.logback.classic.Level.ERROR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.drivers.mongo.internal.MainDriver.COLLECTION_NAME;
+import static works.bosk.drivers.mongo.internal.TestParameters.LONG_TIMESCALE;
+import static works.bosk.testing.BoskTestUtils.boskName;
+
+/**
+ * Tests the behaviour of a bosk whose database collection is deleted and re-initialized
+ * with different content by a different process while the bosk is still running.
+ * The deleted-and-recreated collection begins a <em>new life</em> that the bosk must
+ * detect, even if the new life's revision numbers happen to coincide with old ones.
+ */
+@Slow
+@ParameterizedClass
+@MethodSource("classParameters")
+public class MongoDriverReinitializationTest extends AbstractMongoDriverTest {
+
+	MongoDriverReinitializationTest(ParameterSet parameters) {
+		super(parameters.driverSettingsBuilder());
+	}
+
+	@BeforeEach
+	void overrideLogging() {
+		// This test deliberately provokes disconnections, so log errors only
+		setLogging(ERROR, MainDriver.class, ChangeReceiver.class);
+	}
+
+	static Stream<ParameterSet> classParameters() {
+		return TestParameters.driverSettings(
+			Stream.of(
+				MongoDriverSettings.DatabaseFormat.SEQUOIA,
+				PandoFormat.oneBigDocument(),
+				PandoFormat.withGraftPoints("/catalog", "/sideTable")
+			),
+			// LATE timing delays change-event delivery so that the flush (which is not delayed)
+			// races ahead of the events that would otherwise carry the new state to the bosk.
+			Stream.of(TestParameters.EventTiming.LATE)
+		).map(b -> b.applyDriverSettings(s -> s
+			.timescaleMS(LONG_TIMESCALE)
+		));
+	}
+
+	@Test
+	void collectionDeletedAndReinitialized_flushLoadsNewState() throws InterruptedException, IOException {
+		LOGGER.debug("Initialize the database to a 'before' state");
+		TestEntity beforeState = initializeDatabase("before reinitialization");
+
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName(getClass().getSimpleName()),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+
+		try (var _ = bosk.readSession()) {
+			assertEquals(beforeState, bosk.rootReference().value());
+		}
+
+		// An operator deletes the whole collection (documents and manifest) and someone
+		// reinitializes it with different content before the bosk's flush happens.
+		LOGGER.debug("Delete the collection and manifest, then reinitialize with different content");
+		MongoCollection<BsonDocument> collection = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		collection.drop();
+		TestEntity afterState = initializeDatabase("after reinitialization");
+
+		// A flushes must succeed and load the new state.
+		LOGGER.debug("Flush the bosk and check that it loads the new state");
+		bosk.driver().flush();
+		try (var _ = bosk.readSession()) {
+			assertEquals(afterState, bosk.rootReference().value(),
+				"flush must load the state of the collection's new life");
+		}
+	}
+
+	private TestEntity initializeDatabase(String distinctiveString) {
+		try {
+			AtomicReference<MongoDriver> driverRef = new AtomicReference<>();
+			Bosk<TestEntity> prepBosk = new Bosk<>(
+				boskName("Prep " + getClass().getSimpleName()),
+				TestEntity.class,
+				bosk -> initialState(bosk).withString(distinctiveString),
+				BoskConfig.<TestEntity>builder().driverFactory((b, d) -> {
+					var mongoDriver = (MongoDriver) driverFactory.build(b, d);
+					driverRef.set(mongoDriver);
+					return mongoDriver;
+				}).build());
+			var driver = driverRef.get();
+			driver.flush();
+			driver.close();
+
+			return initialRoot(prepBosk).withString(distinctiveString);
+		} catch (Exception e) {
+			throw new AssertionError(e);
+		}
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MongoDriverReinitializationTest.class);
+}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -845,6 +846,76 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			assertNull(doc.get(bogusField));
 		}
 
+	}
+
+	@Test
+	void refurbish_preservesExistingEpoch(TestInfo testInfo) throws IOException, InterruptedException {
+		// Make the bosk whose refurbish operation we want to test
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName("Main"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(createDriverFactory(logController, testInfo)).build());
+
+		// Get the new bosk connected, which initializes the collection with an epoch
+		bosk.driver().flush();
+
+		MongoCollection<BsonDocument> collection = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(MainDriver.COLLECTION_NAME, BsonDocument.class);
+		BsonDocument filterDoc = rootDocumentsFilter();
+		BsonString epochBefore;
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			epochBefore = cursor.next().getString(Formatter.DocumentFields.epoch.name());
+		}
+
+		// Refurbish
+		bosk.getDriver(MongoDriver.class).refurbish();
+
+		// The existing epoch must be preserved exactly
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			BsonString epochAfter = cursor.next().getString(Formatter.DocumentFields.epoch.name());
+			assertEquals(epochBefore, epochAfter);
+		}
+
+	}
+
+	@Test
+	void refurbish_addsMissingEpoch(TestInfo testInfo) throws IOException, InterruptedException {
+		// Set up the database so it looks basically right
+		Bosk<TestEntity> initialBosk = new Bosk<>(
+			boskName("Initial"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(createDriverFactory(logController, testInfo)).build());
+		initialBosk.getDriver(MongoDriver.class).close();
+
+		// Simulate a legacy collection by removing the epoch field
+		MongoCollection<BsonDocument> collection = mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(MainDriver.COLLECTION_NAME, BsonDocument.class);
+		deleteFields(collection, Formatter.DocumentFields.epoch);
+
+		// Make the bosk whose refurbish operation we want to test
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName("Main"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(createDriverFactory(logController, testInfo)).build());
+
+		// Get the new bosk connected
+		bosk.driver().flush();
+
+		// Refurbish
+		bosk.getDriver(MongoDriver.class).refurbish();
+
+		// The missing epoch must now be present, and must be a plausible UUID
+		BsonDocument filterDoc = rootDocumentsFilter();
+		try (MongoCursor<BsonDocument> cursor = collection.find(filterDoc).cursor()) {
+			BsonString epoch = cursor.next().getString(Formatter.DocumentFields.epoch.name());
+			assertNotNull(epoch);
+			UUID.fromString(epoch.getValue());
+		}
 	}
 
 	@Test

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import lombok.With;
+import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
@@ -73,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static works.bosk.ListingEntry.LISTING_ENTRY;
+import static works.bosk.drivers.mongo.internal.MainDriver.COLLECTION_NAME;
 import static works.bosk.drivers.mongo.internal.TestParameters.SHORT_TIMESCALE;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
@@ -647,6 +649,36 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		assertEquals(0, errorRecorder.failureCount, "No connection failures");
 		assertEquals(1, errorRecorder.disconnections.size(),
 			"Expected 1 disconnection: DatabaseLoadException from DISCONNECT fallback");
+	}
+
+	@Test
+	@Slow
+	void revisionFieldWrongType_flushThrowsFlushFailureException() throws InvalidTypeException, IOException, InterruptedException {
+		setLogging(ERROR, MainDriver.class, ChangeReceiver.class);
+
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName("revisionWrongType"),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+		try (var _ = bosk.readSession()) {
+			assertEquals(initialRoot(bosk), bosk.rootReference().value());
+		}
+
+		// Corrupt the revision field by giving it the wrong BSON type.
+		// The $exists filter targets only the document(s) that have a revision field,
+		// which is the root document in both formats.
+		mongoService.client()
+			.getDatabase(driverSettings.database())
+			.getCollection(COLLECTION_NAME, BsonDocument.class)
+			.updateMany(
+				new BsonDocument(Formatter.DocumentFields.revision.name(), new BsonDocument("$exists", BsonBoolean.TRUE)),
+				new BsonDocument("$set", new BsonDocument(Formatter.DocumentFields.revision.name(), new BsonString("oops")))
+			);
+
+		// A malformed revision must surface as a checked FlushFailureException at the driver
+		// boundary, never as a raw RuntimeException like BsonInvalidOperationException.
+		assertThrows(FlushFailureException.class, () -> bosk.driver().flush());
 	}
 
 	@Test


### PR DESCRIPTION
TLA+ analysis showed a flawed sequence of events:

1. Collection is dropped
2. Bosk 1 re-initializes the collection, resetting the revision to 1
3. Bosk 2 performs a flush() before change stream event from 1 arrives

The flush in step 3 sees a revision of 1 and concludes it does not need to wait, even though a subsequent update has already occurred.

To fix this, we revive an idea I had ages ago: every time we initialize a collection from scratch, pick a random UUID and store it in the `Manifest.epoch` field. If this field ever changes, we assume revision fields are no longer comparable for order, and we conservatively disconnect and reconnect.