### PR TITLE
Fix mongo retry logic

### DIFF
--- a/bosk-mongo/DEVELOPERS.md
+++ b/bosk-mongo/DEVELOPERS.md
@@ -314,6 +314,12 @@ and uses the `with` methods to set the ones it needs. The probes are:
   mid-stream: `MongoDriverLoadRaceTest`, for example, wraps the load's cursor in a
   `PausingCursor` that signals a `BlockingGate` after the first document and blocks until
   the test lets it proceed.
+- `commitInterceptor` runs after each transaction commit attempt and may throw to simulate
+  a commit failure. This is how a test exercises the commit-retry logic: throwing a
+  `MongoException` with the `UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL` label causes the
+  commit to be retried. The interceptor runs after the real commit so that the driver's
+  own transaction state machine (which clears `hasActiveTransaction()` even when a commit
+  reports an unknown result) runs first.
 
 The coordinating primitive is `BlockingGate` (in `lib-testing`): the background operation
 calls `signal()` when it reaches the blocking point and blocks on `awaitRelease(...)`,

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/CommitInterceptor.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/CommitInterceptor.java
@@ -1,0 +1,32 @@
+package works.bosk.drivers.mongo.internal;
+
+import com.mongodb.MongoException;
+
+/**
+ * Lets tests interpose on transaction commits. Each commit attempt in
+ * {@link TransactionalCollection.Session#commitTransactionIfAny()} runs the actual commit
+ * and then invokes this interceptor, which may throw to simulate a failed commit.
+ * Throwing a {@link MongoException} with the
+ * {@link MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL} error label causes the
+ * commit to be retried, so tests can exercise the retry logic.
+ * <p>
+ * The interceptor runs <em>after</em> the actual commit attempt, not before, because the
+ * MongoDB driver's own transaction state machine must run first: the driver marks the
+ * transaction committed (and {@code hasActiveTransaction()} subsequently returns
+ * {@code false}) even when the commit reports an unknown result, and the retry logic
+ * depends on reproducing that behaviour.
+ * <p>
+ * Installed via {@link TestProbes#withCommitInterceptor(CommitInterceptor)}.
+ */
+@FunctionalInterface
+public interface CommitInterceptor {
+	/**
+	 * Invoked after each commit attempt, before the retry decision is made.
+	 * Throwing simulates a commit that failed with the given exception.
+	 */
+	void afterCommitAttempt();
+
+	static CommitInterceptor identity() {
+		return () -> {};
+	}
+}

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -211,7 +211,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 
 			this.queryCollection = TransactionalCollection.of(queryClient
 				.getDatabase(driverSettings.database())
-				.getCollection(COLLECTION_NAME, BsonDocument.class), queryClient, testProbes.findInterceptor(), testProbes.writeInterceptor());
+				.getCollection(COLLECTION_NAME, BsonDocument.class), queryClient, testProbes.findInterceptor(), testProbes.writeInterceptor(), testProbes.commitInterceptor());
 			LOGGER.debug("Using database \"{}\" collection \"{}\"", driverSettings.database(), COLLECTION_NAME);
 
 			this.formatter = new Formatter(boskInfo, bsonSerializer);

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TestProbes.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TestProbes.java
@@ -34,6 +34,8 @@ import works.bosk.drivers.mongo.internal.MainDriver.MongoClientFactory;
  * {@link FindInterceptor}.</li>
  * <li>{@code writeInterceptor}: interposes on database writes; see
  * {@link WriteInterceptor}.</li>
+ * <li>{@code commitInterceptor}: interposes on transaction commits; see
+ * {@link CommitInterceptor}.</li>
  * </ul>
  */
 record TestProbes(
@@ -42,34 +44,39 @@ record TestProbes(
 	Runnable prePublicationWaitAction,
 	Runnable beforeRefurbishDelete,
 	FindInterceptor findInterceptor,
-	WriteInterceptor writeInterceptor
+	WriteInterceptor writeInterceptor,
+	CommitInterceptor commitInterceptor
 ) {
 	static TestProbes noop() {
-		return new TestProbes(MongoClientFactory.ALWAYS_CREATE, null, NOOP, NOOP, FindInterceptor.identity(), WriteInterceptor.identity());
+		return new TestProbes(MongoClientFactory.ALWAYS_CREATE, null, NOOP, NOOP, FindInterceptor.identity(), WriteInterceptor.identity(), CommitInterceptor.identity());
 	}
 
 	TestProbes withClientFactory(MongoClientFactory value) {
-		return new TestProbes(value, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor);
+		return new TestProbes(value, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor, commitInterceptor);
 	}
 
 	TestProbes withListenerFactory(UnaryOperator<ChangeListener> value) {
-		return new TestProbes(clientFactory, value, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor);
+		return new TestProbes(clientFactory, value, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor, commitInterceptor);
 	}
 
 	TestProbes withPrePublicationWaitAction(Runnable value) {
-		return new TestProbes(clientFactory, listenerFactory, value, beforeRefurbishDelete, findInterceptor, writeInterceptor);
+		return new TestProbes(clientFactory, listenerFactory, value, beforeRefurbishDelete, findInterceptor, writeInterceptor, commitInterceptor);
 	}
 
 	TestProbes withBeforeRefurbishDelete(Runnable value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, value, findInterceptor, writeInterceptor);
+		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, value, findInterceptor, writeInterceptor, commitInterceptor);
 	}
 
 	TestProbes withFindInterceptor(FindInterceptor value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, value, writeInterceptor);
+		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, value, writeInterceptor, commitInterceptor);
 	}
 
 	TestProbes withWriteInterceptor(WriteInterceptor value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, value);
+		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, value, commitInterceptor);
+	}
+
+	TestProbes withCommitInterceptor(CommitInterceptor value) {
+		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor, value);
 	}
 
 	private static final Runnable NOOP = () -> {};

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TestProbes.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TestProbes.java
@@ -1,6 +1,7 @@
 package works.bosk.drivers.mongo.internal;
 
 import java.util.function.UnaryOperator;
+import lombok.With;
 import works.bosk.Bosk;
 import works.bosk.drivers.mongo.internal.MainDriver.MongoClientFactory;
 
@@ -38,6 +39,7 @@ import works.bosk.drivers.mongo.internal.MainDriver.MongoClientFactory;
  * {@link CommitInterceptor}.</li>
  * </ul>
  */
+@With
 record TestProbes(
 	MongoClientFactory clientFactory,
 	UnaryOperator<ChangeListener> listenerFactory,
@@ -49,34 +51,6 @@ record TestProbes(
 ) {
 	static TestProbes noop() {
 		return new TestProbes(MongoClientFactory.ALWAYS_CREATE, null, NOOP, NOOP, FindInterceptor.identity(), WriteInterceptor.identity(), CommitInterceptor.identity());
-	}
-
-	TestProbes withClientFactory(MongoClientFactory value) {
-		return new TestProbes(value, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor, commitInterceptor);
-	}
-
-	TestProbes withListenerFactory(UnaryOperator<ChangeListener> value) {
-		return new TestProbes(clientFactory, value, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor, commitInterceptor);
-	}
-
-	TestProbes withPrePublicationWaitAction(Runnable value) {
-		return new TestProbes(clientFactory, listenerFactory, value, beforeRefurbishDelete, findInterceptor, writeInterceptor, commitInterceptor);
-	}
-
-	TestProbes withBeforeRefurbishDelete(Runnable value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, value, findInterceptor, writeInterceptor, commitInterceptor);
-	}
-
-	TestProbes withFindInterceptor(FindInterceptor value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, value, writeInterceptor, commitInterceptor);
-	}
-
-	TestProbes withWriteInterceptor(WriteInterceptor value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, value, commitInterceptor);
-	}
-
-	TestProbes withCommitInterceptor(CommitInterceptor value) {
-		return new TestProbes(clientFactory, listenerFactory, prePublicationWaitAction, beforeRefurbishDelete, findInterceptor, writeInterceptor, value);
 	}
 
 	private static final Runnable NOOP = () -> {};

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
@@ -41,13 +41,14 @@ class TransactionalCollection {
 	private final MongoClient mongoClient;
 	private final FindInterceptor findInterceptor;
 	private final WriteInterceptor writeInterceptor;
+	private final CommitInterceptor commitInterceptor;
 	private final ThreadLocal<Session> currentSession = new ThreadLocal<>();
 
 	/**
-	 * A {@code TransactionalCollection} with no read or write interposition.
+	 * A {@code TransactionalCollection} with no read, write, or commit interposition.
 	 */
 	static TransactionalCollection of(MongoCollection<BsonDocument> downstream, MongoClient mongoClient) {
-		return of(downstream, mongoClient, FindInterceptor.identity(), WriteInterceptor.identity());
+		return of(downstream, mongoClient, FindInterceptor.identity(), WriteInterceptor.identity(), CommitInterceptor.identity());
 	}
 
 	public Session newSession() throws FailedMongoClientSessionException {
@@ -111,6 +112,7 @@ class TransactionalCollection {
 				LOGGER.debug("Commit transaction");
 				try {
 					clientSession.commitTransaction();
+					commitInterceptor.afterCommitAttempt();
 				} catch (MongoException e) {
 					if (e.hasErrorLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL)) {
 						if (retriesRemaining >= 1) {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/TransactionalCollection.java
@@ -105,26 +105,40 @@ class TransactionalCollection {
 		/**
 		 * Ends the active transaction; a subsequent call to {@link #ensureTransactionStarted()}
 		 * would start a new transaction.
+		 * <p>
+		 * If the commit returns an {@link MongoException} with the
+		 * {@link MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL} error label,
+		 * the commit is retried, since the transaction may or may not have been committed.
+		 * If the result is still unknown after the retries, the {@link MongoException} is rethrown
+		 * so the caller can resolve the indeterminate outcome.
+		 * <p>
+		 * The retry is driven by the outcome of {@code commitTransaction()}, not by
+		 * {@code hasActiveTransaction()}: the MongoDB driver marks the transaction committed
+		 * even when the commit throws, so {@code hasActiveTransaction()} returns {@code false}
+		 * after a failed commit too, and checking it would make the retry unreachable.
 		 */
 		public void commitTransactionIfAny() {
-			int retriesRemaining = 2;
-			while (clientSession.hasActiveTransaction()) {
-				LOGGER.debug("Commit transaction");
-				try {
-					clientSession.commitTransaction();
-					commitInterceptor.afterCommitAttempt();
-				} catch (MongoException e) {
-					if (e.hasErrorLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL)) {
-						if (retriesRemaining >= 1) {
-							retriesRemaining--;
-							LOGGER.debug("Unknown transaction commit result; retrying the commit", e);
+			if (clientSession.hasActiveTransaction()) {
+				int retriesRemaining = 2;
+				while (true) {
+					LOGGER.debug("Commit transaction");
+					try {
+						clientSession.commitTransaction();
+						commitInterceptor.afterCommitAttempt();
+						break;
+					} catch (MongoException e) {
+						if (e.hasErrorLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL)) {
+							if (retriesRemaining >= 1) {
+								retriesRemaining--;
+								LOGGER.debug("Unknown transaction commit result; retrying the commit", e);
+							} else {
+								LOGGER.debug("Exhausted commit retry attempts", e);
+								throw e;
+							}
 						} else {
-							LOGGER.debug("Exhausted commit retry attempts", e);
+							LOGGER.debug("Can't retry commit; rethrowing", e);
 							throw e;
 						}
-					} else {
-						LOGGER.debug("Can't retry commit; rethrowing", e);
-						throw e;
 					}
 				}
 			}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverCommitRetryTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverCommitRetryTest.java
@@ -1,0 +1,80 @@
+package works.bosk.drivers.mongo.internal;
+
+import com.mongodb.MongoException;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import works.bosk.Bosk;
+import works.bosk.BoskConfig;
+import works.bosk.Reference;
+import works.bosk.drivers.mongo.MongoDriverSettings;
+import works.bosk.drivers.mongo.PandoFormat;
+import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.logback.ReplayLogsOnFailure;
+import works.bosk.testing.drivers.state.TestEntity;
+import works.bosk.testing.drivers.state.TestValues;
+import works.bosk.testing.junit.Slow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.drivers.mongo.internal.TestParameters.LONG_TIMESCALE;
+import static works.bosk.testing.BoskTestUtils.boskName;
+
+/**
+ * Exercises the {@link CommitInterceptor} probe through the full driver.
+ * A commit that reports an unknown result must be retried, so the submit still
+ * completes; the {@code commitInterceptor} is consulted once per commit attempt.
+ * <p>
+ * The Pando format submits its updates inside a multi-document transaction, so this
+ * is the format that actually exercises {@link TransactionalCollection.Session#commitTransactionIfAny()}
+ * on the submit path. (Sequoia writes each update atomically without a transaction.)
+ */
+@Slow
+@ReplayLogsOnFailure
+public class MongoDriverCommitRetryTest extends AbstractMongoDriverTest {
+
+	public MongoDriverCommitRetryTest() {
+		super(MongoDriverSettings.builder()
+			.preferredDatabaseFormat(PandoFormat.oneBigDocument())
+			.timescaleMS(LONG_TIMESCALE)
+			.database("MongoDriverCommitRetryTest"));
+	}
+
+	@AfterEach
+	void resetProbes() {
+		MainDriver.TEST_PROBES.remove();
+	}
+
+	@Test
+	void submitReplacement_retriesCommit_whenCommitResultUnknown() throws InvalidTypeException, IOException, InterruptedException {
+		AtomicInteger commitAttempts = new AtomicInteger();
+		AtomicBoolean armCommitFailure = new AtomicBoolean(false);
+		MainDriver.TEST_PROBES.set(TestProbes.noop().withCommitInterceptor(() -> {
+			if (armCommitFailure.get() && commitAttempts.getAndIncrement() == 0) {
+				throw unknownCommitResult();
+			}
+		}));
+
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName(),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialStateWithEmptyCatalog,
+			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+
+		// The collection-initialization commit must not be disturbed.
+		armCommitFailure.set(true);
+
+		Reference<TestValues> values = bosk.buildReferences(Refs.class).values();
+		bosk.driver().submitReplacement(values, TestValues.blank());
+		bosk.driver().flush();
+
+		assertEquals(2, commitAttempts.get(), "The commit must be retried once after an unknown result");
+	}
+
+	private static MongoException unknownCommitResult() {
+		MongoException e = new MongoException(117, "Simulated unknown commit result");
+		e.addLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL);
+		return e;
+	}
+}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/TransactionalCollectionTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/TransactionalCollectionTest.java
@@ -1,5 +1,6 @@
 package works.bosk.drivers.mongo.internal;
 
+import com.mongodb.MongoException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.CountOptions;
@@ -7,6 +8,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
@@ -313,6 +315,36 @@ class TransactionalCollectionTest {
 	}
 
 	@Test
+	void commitTransactionIfAny_retriesCommit_whenCommitResultUnknown() throws FailedMongoClientSessionException {
+		AtomicInteger commitAttempts = new AtomicInteger();
+		TransactionalCollection coll = withCommitInterceptor(() -> {
+			if (commitAttempts.getAndIncrement() == 0) {
+				throw unknownCommitResult();
+			}
+		});
+		try (Session _ = coll.newSession()) {
+			coll.ensureTransactionStarted();
+			assertDoesNotThrow(coll::commitTransactionIfAny);
+		}
+		assertEquals(2, commitAttempts.get(), "Commit must be retried after an unknown result");
+	}
+
+	@Test
+	void commitTransactionIfAny_rethrows_whenCommitRetriesExhausted() throws FailedMongoClientSessionException {
+		AtomicInteger commitAttempts = new AtomicInteger();
+		TransactionalCollection coll = withCommitInterceptor(() -> {
+			commitAttempts.getAndIncrement();
+			throw unknownCommitResult();
+		});
+		try (Session _ = coll.newSession()) {
+			coll.ensureTransactionStarted();
+			MongoException e = assertThrows(MongoException.class, coll::commitTransactionIfAny);
+			assertTrue(e.hasErrorLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL));
+		}
+		assertEquals(3, commitAttempts.get(), "All commit attempts must be exhausted before rethrowing");
+	}
+
+	@Test
 	void abortOnClose_rollsBackData() throws FailedMongoClientSessionException {
 		try (Session _ = collection.newSession()) {
 			collection.ensureTransactionStarted();
@@ -496,6 +528,24 @@ class TransactionalCollectionTest {
 
 	private void makeData(String id) throws FailedMongoClientSessionException {
 		insertFresh(collection, new BsonDocument("_id", new BsonString(id)));
+	}
+
+	/**
+	 * A {@link TransactionalCollection} whose session commits consult the given
+	 * {@link CommitInterceptor}, which can throw to simulate a commit failure.
+	 */
+	private TransactionalCollection withCommitInterceptor(CommitInterceptor interceptor) {
+		MongoClient client = mongoService.client();
+		MongoCollection<BsonDocument> raw = client
+			.getDatabase(DB_NAME)
+			.getCollection(COLLECTION_NAME, BsonDocument.class);
+		return TransactionalCollection.of(raw, client, FindInterceptor.identity(), WriteInterceptor.identity(), interceptor);
+	}
+
+	private static MongoException unknownCommitResult() {
+		MongoException e = new MongoException(117, "Simulated unknown commit result");
+		e.addLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL);
+		return e;
 	}
 
 }


### PR DESCRIPTION
Turns out `hasActiveTransaction` becomes false even if the commit attempt fails.

Fixes #330, though apparently the description of that bug was not quite right. From DeepSeek:

> #330 assumed the commit retry loop worked as written: retry on `UNKNOWN_TRANSACTION_COMMIT_RESULT`, then throw on exhaustion, and complained the resulting disconnect in MainDriver was a spurious overreaction. Both halves were wrong:
> 
> - The loop never worked. `ClientSessionImpl.commitTransaction()` sets `transactionState = COMMITTED` in a `finally` block even when it throws, so `hasActiveTransaction()` returns `false` after a failed commit too. The `while (hasActiveTransaction())` loop therefore exited silently after the first unknown-result failure; the retry and exhaustion-throw branches were dead code. The title's "never returns on exhaustion" is the inverse: it returns immediately, swallowing the failure and risking silent data loss.
> 
> - The disconnect it complained about is the intended fallback. Once the loop actually retries and rethrows on exhaustion, the outer `operationInSession` disconnects, reloads state, and retries the idempotent operation, which is the correct resolution of an indeterminate commit. MainDriver was left unchanged.
> 
> The fix drives the retry off the outcome of `commitTransaction()` rather than `hasActiveTransaction()`, plus a `commitInterceptor` test probe that runs after the real commit so tests reproduce the driver's `hasActiveTransaction()` semantics. Branch: `fix/commit-retry`.
> 