### PR TITLE
Fixes and docs for MDC and trace context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ The usual Gradle commands, plus:
   - Conditional guarded statements should be on their own line to facilitate breakpoints
 - Prefer if-then-else over early returns (to make subsequent refactoring easier) except in specific situations:
   - If there's an especially simple case, like errors or "already computed" one-liner cases, those can return early to avoid mixing with complex logic
+- Documentation and comments should compose proper sentences with normal words and punctuation,
+  rather than gluing together sentence fragments with em dashes.
 
 ### Modules
 

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -548,7 +548,10 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 				LOGGER.debug("Hook: queue {}({}) due to {}", reg.name, changedRef, target);
 				hookExecutionQueue.addLast(() -> {
 					// We use two nested try statements here so that the "finally" clause runs within the diagnostic scope
-					try (var _ = context.withOnly(attributes)) {
+					try (
+						var _ = setupMDC(name(), instanceID());
+						var _ = context.withOnly(attributes)
+					) {
 						try (ReadSession _ = new ReadSession(rootForHook)) {
 							LOGGER.debug("Hook: RUN {}({})", reg.name, changedRef);
 							reg.hook.onChanged(changedRef);

--- a/bosk-core/src/main/java/works/bosk/DriverFactory.java
+++ b/bosk-core/src/main/java/works/bosk/DriverFactory.java
@@ -11,7 +11,7 @@ package works.bosk;
  * in a predictable and composable way
  * with little or no coordination or even awareness of each other.
  * Concerns like database persistence ({@code MongoDriver}, {@code SqlDriver}),
- * observability ({@code OpenTelemetryDriver}, {@code ReportingDriver}),
+ * observability ({@code TraceContextDriver}, {@code ReportingDriver}),
  * and context propagation ({@code ContextScopeDriver})
  * can each be implemented as orthogonal drivers.
  *

--- a/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
+++ b/bosk-core/src/main/java/works/bosk/drivers/ReplicaSet.java
@@ -19,6 +19,7 @@ import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static java.util.Objects.requireNonNull;
+import static works.bosk.logging.MappedDiagnosticContext.setupMDC;
 
 /**
  * A pool of bosks arranged such that submitting an update to any of them submits to all of them.
@@ -222,7 +223,8 @@ public class ReplicaSet<R extends StateTreeNode> {
 			var diagnosticContext = originContext.getAttributes();
 			replicas.forEach(replica -> {
 				try (
-					var _ = replica.boskInfo.context().withOnly(diagnosticContext)
+					var _ = replica.boskInfo.context().withOnly(diagnosticContext);
+					var _ = setupMDC(replica.boskInfo.name(), replica.boskInfo.instanceID())
 				) {
 					action.accept(replica);
 				}

--- a/bosk-core/src/main/java/works/bosk/logging/MdcKeys.java
+++ b/bosk-core/src/main/java/works/bosk/logging/MdcKeys.java
@@ -5,8 +5,14 @@ import works.bosk.Bosk;
 /**
  * Keys to use for SLF4J's Mapped Diagnostic Context.
  * <p>
- * Evolution note: we're going to want to get organized in how we generate MDC.
- * For now, only bosk-mongo uses these.
+ * {@link #BOSK_NAME} and {@link #BOSK_INSTANCE_ID} are established for the duration of every
+ * driver operation and every hook call-back, and re-established by drivers on their own
+ * background threads, so that log output can be attributed to the bosk performing the work.
+ * The keys are always set to the values of the bosk doing the logging,
+ * regardless of which thread or process performs the operation;
+ * MDC is for logging, not for propagating context between threads or hosts.
+ * <p>
+ * The {@code bosk.MongoDriver.*} keys are specific to {@code bosk-mongo}.
  */
 public final class MdcKeys {
 	/**

--- a/bosk-core/src/test/java/works/bosk/BoskContextTest.java
+++ b/bosk-core/src/test/java/works/bosk/BoskContextTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 import works.bosk.annotations.ReferencePath;
 import works.bosk.testing.drivers.AbstractDriverTest;
 import works.bosk.testing.drivers.DriverConformanceTest;
@@ -14,6 +15,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static works.bosk.logging.MdcKeys.BOSK_INSTANCE_ID;
+import static works.bosk.logging.MdcKeys.BOSK_NAME;
 import static works.bosk.testing.BoskTestUtils.boskName;
 
 /**
@@ -48,6 +51,20 @@ public class BoskContextTest extends AbstractDriverTest {
 		}
 		bosk.driver().flush();
 		assertTrue(diagnosticsVerified.tryAcquire(5, SECONDS));
+	}
+
+	@Test
+	void hook_executionEstablishesBoskMdc() throws IOException, InterruptedException {
+		Semaphore mdcVerified = new Semaphore(0);
+		bosk.driver().flush();
+		bosk.hookRegistrar().registerHook("mdcIsSetInHook", bosk.rootReference(), _ -> {
+			assertEquals(bosk.name(), MDC.get(BOSK_NAME));
+			assertEquals(bosk.instanceID().toString(), MDC.get(BOSK_INSTANCE_ID));
+			mdcVerified.release();
+		});
+		bosk.driver().flush();
+		assertTrue(mdcVerified.tryAcquire(5, SECONDS),
+			"Hook should see the bosk MDC keys established during its execution");
 	}
 
 	@Test

--- a/bosk-opentelemetry/README.md
+++ b/bosk-opentelemetry/README.md
@@ -1,6 +1,6 @@
 ## bosk-opentelemetry
 
 This is the subproject for the published `bosk-opentelemetry` library,
-including support for propagating W3C trace context via bosk diagnostic attributes.
+including support for propagating trace context via bosk diagnostic attributes.
 
 See the [javadocs](https://javadoc.io/doc/works.bosk/bosk-opentelemetry/latest/works.bosk.opentelemetry/module-summary.html) for more information.

--- a/bosk-opentelemetry/README.md
+++ b/bosk-opentelemetry/README.md
@@ -1,6 +1,6 @@
 ## bosk-opentelemetry
 
 This is the subproject for the published `bosk-opentelemetry` library,
-including support for propagating OpenTelemetry context via bosk diagnostic attributes.
+including support for propagating W3C trace context via bosk diagnostic attributes.
 
 See the [javadocs](https://javadoc.io/doc/works.bosk/bosk-opentelemetry/latest/works.bosk.opentelemetry/module-summary.html) for more information.

--- a/bosk-opentelemetry/src/main/java/module-info.java
+++ b/bosk-opentelemetry/src/main/java/module-info.java
@@ -1,15 +1,15 @@
 /**
- * Provides OpenTelemetry context propagation for Bosk.
+ * Provides OpenTelemetry integration for Bosk, including trace context propagation.
  * <p>
  * To use this, configure your bosk instance to do the following two things:
  * <ol>
  *     <li>
- *         Use {@link works.bosk.opentelemetry.OpenTelemetryDriver#wrapping} on any driver
+ *         Use {@link works.bosk.opentelemetry.TraceContextDriver#wrapping} on any driver
  *         that does not implicitly propagate thread context by calling its downstream driver
  *         synchronously on the same thread.
  *     </li>
  *     <li>
- *         Use {@link works.bosk.opentelemetry.OpenTelemetryRegistrar#factory()}.
+ *         Use {@link works.bosk.opentelemetry.TraceContextRegistrar#factory()}.
  *     </li>
  * </ol>
  */

--- a/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/TraceContextDriver.java
+++ b/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/TraceContextDriver.java
@@ -8,23 +8,26 @@ import works.bosk.StateTreeNode;
 import works.bosk.drivers.ContextScopeDriver;
 
 /**
- * A {@link DriverFactory} that transmits OpenTelemetry context
+ * A {@link DriverFactory} that transmits the current span's trace context
  * across the given {@code subject} driver
  * via diagnostic attributes in the {@link BoskContext bosk context}.
+ * <p>
+ * The current implementation uses the W3C trace context format;
+ * other trace context formats could be supported in future.
  */
-public sealed interface OpenTelemetryDriver extends BoskDriver permits ReceiverDriver {
+public sealed interface TraceContextDriver extends BoskDriver permits TraceContextReceiverDriver {
 	/**
-	 * @return a {@link DriverFactory} that transmits OpenTelemetry context
+	 * @return a {@link DriverFactory} that transmits the current span's trace context
 	 * across the given {@code subject} driver
 	 * via diagnostic attributes in the {@link BoskContext bosk context}.
 	 *
-	 * @see OpenTelemetryRegistrar
+	 * @see TraceContextRegistrar
 	 */
 	static <RR extends StateTreeNode> DriverFactory<RR> wrapping(DriverFactory<RR> subject) {
 		return DriverStack.of(
 			ContextScopeDriver.factory(Utils::boskContextScopeWithDiagnosticsFromCurrentSpan),
 			subject,
-			ReceiverDriver.factory()
+			TraceContextReceiverDriver.factory()
 		);
 	}
 

--- a/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/TraceContextReceiverDriver.java
+++ b/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/TraceContextReceiverDriver.java
@@ -10,19 +10,19 @@ import works.bosk.StateTreeNode;
 import works.bosk.exceptions.InvalidTypeException;
 
 /**
- * Propagates OpenTelemetry context from the diagnostic attributes
+ * Propagates trace context from the diagnostic attributes
  * in the {@link BoskContext bosk context} into the downstream driver.
  */
-final class ReceiverDriver implements OpenTelemetryDriver {
+final class TraceContextReceiverDriver implements TraceContextDriver {
 
 	private final BoskContext context;
 	private final BoskDriver downstream;
 
 	public static <R extends StateTreeNode> DriverFactory<R> factory() {
-		return (b, d) -> new ReceiverDriver(b.context(), d);
+		return (b, d) -> new TraceContextReceiverDriver(b.context(), d);
 	}
 
-	ReceiverDriver(BoskContext diagnosticContext1, BoskDriver downstream) {
+	TraceContextReceiverDriver(BoskContext diagnosticContext1, BoskDriver downstream) {
 		this.context = diagnosticContext1;
 		this.downstream = downstream;
 	}

--- a/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/TraceContextRegistrar.java
+++ b/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/TraceContextRegistrar.java
@@ -7,30 +7,30 @@ import works.bosk.Reference;
 import works.bosk.RegistrarFactory;
 
 /**
- * {@link HookRegistrar} that propagates OpenTelemetry context from
+ * {@link HookRegistrar} that propagates trace context from
  * the diagnostic attributes in the {@link BoskContext bosk context}
  * into hooks.
  * <p>
  * Thread-locals are not automatically propagated into hooks,
- * and so OpenTelemetry context must be explicitly propagated.
- * This registrar retrieves diagnostic attributes placed there by {@link OpenTelemetryDriver}
- * and propagate them into hooks.
+ * and so trace context must be explicitly propagated.
+ * This registrar retrieves diagnostic attributes placed there by {@link TraceContextDriver}
+ * and propagates them into hooks.
  */
-public final class OpenTelemetryRegistrar implements HookRegistrar {
+public final class TraceContextRegistrar implements HookRegistrar {
 	final BoskContext context;
 	final HookRegistrar downstream;
 
-	OpenTelemetryRegistrar(BoskContext context, HookRegistrar downstream) {
+	TraceContextRegistrar(BoskContext context, HookRegistrar downstream) {
 		this.context = context;
 		this.downstream = downstream;
 	}
 
 	/**
-	 * @return a {@link HookRegistrar} that propagates OpenTelemetry context
+	 * @return a {@link HookRegistrar} that propagates trace context
 	 * from the diagnostic attributes in the {@link BoskContext bosk context} into hooks.
 	 */
 	public static RegistrarFactory factory() {
-		return (b,d) -> new OpenTelemetryRegistrar(b.context(), d);
+		return (b,d) -> new TraceContextRegistrar(b.context(), d);
 	}
 
 	@Override

--- a/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/Utils.java
+++ b/bosk-opentelemetry/src/main/java/works/bosk/opentelemetry/Utils.java
@@ -20,7 +20,6 @@ class Utils {
 	 * Future-proof this putting the attributes under a sub-prefix so we can evolve this later.
 	 */
 	static final String W3C_SUB_PREFIX = "w3c.";
-
 	/**
 	 * On the setter side, we'll be given plain old OTel keys and need to add the prefixes.
 	 * We add {@link #W3C_SUB_PREFIX} to them here, and then the {@link #OTEL_PREFIX} prefix
@@ -59,7 +58,7 @@ class Utils {
 				if (k.startsWith(OTEL_PREFIX + W3C_SUB_PREFIX)) {
 					otelAttributes.put(k.substring(OTEL_PREFIX.length() + W3C_SUB_PREFIX.length()), v);
 				} else {
-					throw new IllegalStateException("Only w3c context propagation is supported; unexpected OpenTelemetry key from diagnostic context: " + k);
+					throw new IllegalStateException("Unexpected OpenTelemetry key from diagnostic context: " + k);
 				}
 			}
 		});
@@ -68,11 +67,11 @@ class Utils {
 	}
 
 	/**
-	 * Stashes OpenTelemetry context into the
+	 * Stashes trace context into the
 	 * diagnostic attributes in the {@link BoskContext bosk context},
 	 * where it can be retrieved by
-	 * {@link ReceiverDriver} to propagate the context downstream,
-	 * and by {@link OpenTelemetryRegistrar} to propagate the context into hooks.
+	 * {@link TraceContextReceiverDriver} to propagate the context downstream,
+	 * and by {@link TraceContextRegistrar} to propagate the context into hooks.
 	 */
 	static BoskContext.ContextScope boskContextScopeWithDiagnosticsFromCurrentSpan(BoskContext boskContext) {
 		return boskContext.withReplacedPrefix(OTEL_PREFIX, w3cContextFromCurrentSpan());

--- a/bosk-opentelemetry/src/test/java/works/bosk/opentelemetry/TraceContextDriverTest.java
+++ b/bosk-opentelemetry/src/test/java/works/bosk/opentelemetry/TraceContextDriverTest.java
@@ -22,7 +22,7 @@ import works.bosk.drivers.BufferingDriver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class OpenTelemetryDriverTest {
+class TraceContextDriverTest {
 
 	private static OpenTelemetrySdk openTelemetry;
 
@@ -44,7 +44,7 @@ class OpenTelemetryDriverTest {
 	@Test
 	void wrapping_propagatesTraceId() throws InterruptedException, IOException {
 		DriverFactory<Root> driverFactory = DriverStack.of(
-			OpenTelemetryDriver.wrapping(
+			TraceContextDriver.wrapping(
 				// Use a driver that does not call its downstream driver synchronously on the same thread
 				// so that the OpenTelemetry thread context is not propagated implicitly.
 				// Otherwise, this isn't much of a test.
@@ -57,7 +57,7 @@ class OpenTelemetryDriverTest {
 			_ -> new Root(0),
 			BoskConfig.<Root>builder()
 				.driverFactory(driverFactory)
-				.registrarFactory(OpenTelemetryRegistrar.factory())
+				.registrarFactory(TraceContextRegistrar.factory())
 				.build());
 		record Observation(int revision, String traceID) { }
 		BlockingQueue<Observation> observations = new LinkedBlockingQueue<>();

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/MdcCheckingDriver.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/MdcCheckingDriver.java
@@ -1,0 +1,93 @@
+package works.bosk.testing.drivers;
+
+import java.io.IOException;
+import org.slf4j.MDC;
+import works.bosk.BoskDriver;
+import works.bosk.DriverFactory;
+import works.bosk.DriverStack;
+import works.bosk.Identifier;
+import works.bosk.Reference;
+import works.bosk.StateTreeNode;
+import works.bosk.exceptions.InvalidTypeException;
+
+import static works.bosk.logging.MdcKeys.BOSK_INSTANCE_ID;
+import static works.bosk.logging.MdcKeys.BOSK_NAME;
+
+/**
+ * Ensures that the {@code bosk.name} and {@code bosk.instanceID} MDC keys are set
+ * to the values of the bosk performing the work during every driver operation.
+ */
+public final class MdcCheckingDriver implements BoskDriver {
+	private final String boskName;
+	private final String boskInstanceID;
+	private final BoskDriver downstream;
+
+	private MdcCheckingDriver(String boskName, String boskInstanceID, BoskDriver downstream) {
+		this.boskName = boskName;
+		this.boskInstanceID = boskInstanceID;
+		this.downstream = downstream;
+	}
+
+	/**
+	 * @return a driver factory that wraps {@code subject} with an {@link MdcCheckingDriver}
+	 * on its downstream side.
+	 */
+	public static <RR extends StateTreeNode> DriverFactory<RR> wrap(DriverFactory<RR> subject) {
+		return DriverStack.of(subject, factory());
+	}
+
+	private static <RR extends StateTreeNode> DriverFactory<RR> factory() {
+		return (b, d) -> new MdcCheckingDriver(b.name(), b.instanceID().toString(), d);
+	}
+
+	@Override
+	public <R extends StateTreeNode> R initialState(Class<R> rootType) throws InvalidTypeException, IOException, InterruptedException {
+		checkMDC();
+		return downstream.initialState(rootType);
+	}
+
+	@Override
+	public <T> void submitReplacement(Reference<T> target, T newValue) {
+		checkMDC();
+		downstream.submitReplacement(target, newValue);
+	}
+
+	@Override
+	public <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
+		checkMDC();
+		downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
+	}
+
+	@Override
+	public <T> void submitConditionalCreation(Reference<T> target, T newValue) {
+		checkMDC();
+		downstream.submitConditionalCreation(target, newValue);
+	}
+
+	@Override
+	public <T> void submitDeletion(Reference<T> target) {
+		checkMDC();
+		downstream.submitDeletion(target);
+	}
+
+	@Override
+	public <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
+		checkMDC();
+		downstream.submitConditionalDeletion(target, precondition, requiredValue);
+	}
+
+	@Override
+	public void flush() throws IOException, InterruptedException {
+		checkMDC();
+		downstream.flush();
+	}
+
+	private void checkMDC() {
+		if (!boskName.equals(MDC.get(BOSK_NAME))) {
+			throw new AssertionError("MDC bosk name must be " + boskName + " but was " + MDC.get(BOSK_NAME));
+		}
+		if (!boskInstanceID.equals(MDC.get(BOSK_INSTANCE_ID))) {
+			throw new AssertionError("MDC bosk instance ID must be " + boskInstanceID + " but was " + MDC.get(BOSK_INSTANCE_ID));
+		}
+	}
+}

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/SharedDriverConformanceTest.java
@@ -26,7 +26,7 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			TestEntity.class,
 			this::initialState,
 			BoskConfig.<TestEntity>builder()
-				.driverFactory(driverFactory)
+				.driverFactory(MdcCheckingDriver.wrap(driverFactory))
 				.build());
 	}
 
@@ -40,7 +40,7 @@ public abstract class SharedDriverConformanceTest extends DriverConformanceTest 
 			TestEntity.class,
 			this::initialState,
 			BoskConfig.<TestEntity>builder()
-				.driverFactory(driverFactory)
+				.driverFactory(MdcCheckingDriver.wrap(driverFactory))
 				.build());
 		assertSameBoskContents(latecomer);
 	}

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -669,6 +669,45 @@ The `DriverFactory` and `DriverStack` classes make this a one-line change.
 
 All of this might appear a bit abstract, but the upshot is that your drivers can snap together like Lego.
 
+#### Troubleshooting concerns
+
+##### Logging
+
+All bosk drivers set the `bosk.name` and `bosk.instanceID` keys in SLF4J's Mapped Diagnostic Context (MDC)
+for the duration of every driver operation, so that log output can be traced back to the bosk performing the work.
+The keys always reflect the bosk doing the logging, namely the _local_ bosk,
+no matter which thread or process the work happens on.
+
+For most drivers, this happens automatically, with no effort on the part of the driver:
+the bosk's `IngressDriver` establishes the keys on the calling thread,
+and a driver that performs its downstream calls synchronously on the calling thread simply inherits them.
+A driver that performs some of its work on its own background threads, such as `MongoDriver` or `SQLDriver`,
+must re-establish the keys on those threads.
+
+The driver conformance tests verify that these keys are present during every incoming and outgoing driver operation.
+
+You can include these keys in your logging configuration;
+for example, using Logback, you can add `%X{bosk.name}` to your appender's encoder pattern.
+
+MDC is intended for logging, not for propagating context between threads or hosts.
+
+##### Diagnostic attributes
+
+The `BoskContext` diagnostic attributes are for instrumentation and troubleshooting:
+they describe _how_ something happened, and are not guaranteed to be present in every context
+(for example, hooks triggered at registration time have no operation context).
+Do not use them to carry application data that your code depends on, such as tenant or user IDs;
+information that must be reliably available belongs in the bosk state tree.
+
+For most drivers, the diagnostic attributes flow through without any special effort:
+a driver that calls its downstream driver synchronously on the calling thread passes them along automatically.
+A driver needs to make a special effort when it does not perform the update's work
+on the calling thread at the time of submission.
+This includes deferring the work until later, running it on another thread,
+or sending it to another process or host.
+Such a driver must capture the attributes when the update is submitted
+and restore them when the work is performed.
+
 #### Built-in drivers
 
 Some handy drivers ship with the `bosk-core` module.
@@ -767,13 +806,16 @@ Additional detail is available at higher logging levels:
 `DEBUG` is more likely to be useful for the maintainers of the bosk library.
 (`TRACE` can produce a large amount of output and isn't generally recommended for production.)
 
-The logs make use of the Mapped Diagnostic Context (MDC) feature of SLF4J to provide
-several MDC keys with `MongoDriver` as a prefix.
-If you might find this useful, you can configure your logging system to emit this key;
-for example, using Logback, you can add `%X{MongoDriver}` to your appender's encoder pattern.
-When present, the string associated with the `MongoDriver` MDC key always starts with a single space character,
-so you can append it to your existing log strings with no whitespace,
-meaning it takes up no space at all when it's not present.
+The logs make use of the Mapped Diagnostic Context (MDC) feature of SLF4J.
+The `bosk.name` and `bosk.instanceID` MDC keys are set automatically by all bosk drivers
+for the duration of every driver operation (see _Drivers_ above),
+so log output can be traced back to a particular bosk.
+
+`MongoDriver` also provides two driver-specific MDC keys:
+- `bosk.MongoDriver.event`: a unique string for each MongoDB change event the bosk receives.
+- `bosk.MongoDriver.transaction`: a unique string for each MongoDB `ClientSession` the driver uses.
+
+You can include these in your encoder pattern as well, for example `%X{bosk.MongoDriver.event}`.
 
 ##### Database format & layout
 

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -538,6 +538,20 @@ bosk.registerHook("Widget changed", bosk.anyWidget, ref -> {
 The hook call-back occurs inside a read session containing a state snapshot taken immediately after the triggering update occurred.
 This means there are no race conditions between bosk reads in a hook versus other bosk updates happening in parallel.
 
+Hooks run on separate threads from the one that submitted the triggering update,
+and so they do not inherit that thread's MDC.
+The `bosk.name` and `bosk.instanceID` MDC keys are nevertheless established during hook execution,
+just as they are during every driver operation.
+The `BoskContext` diagnostic attributes are propagated into hooks:
+a hook triggered by an update sees the attributes of that update,
+while a hook triggered by registration sees the attributes of the registering thread.
+This is not a bug: diagnostic attributes tell you _how_ something happened, not merely _that_ it happened,
+so the same hook can legitimately observe different attributes depending on what triggered it.
+Hooks must therefore not depend on the presence or values of specific attributes.
+If a hook needs information to be available on every invocation,
+that information belongs in the bosk state tree, which the hook's read session makes accessible,
+rather than in the diagnostic attributes.
+
 If a single update triggers multiple hooks, the hooks will run in the order they were registered.
 
 #### Breadth-first ordering

--- a/example-hello/src/main/java/works/bosk/hello/HelloBosk.java
+++ b/example-hello/src/main/java/works/bosk/hello/HelloBosk.java
@@ -15,7 +15,7 @@ import works.bosk.hello.state.BoskState;
 import works.bosk.hello.state.Target;
 import works.bosk.logback.BoskLogFilter;
 import works.bosk.logback.BoskLogFilter.LogController;
-import works.bosk.opentelemetry.OpenTelemetryDriver;
+import works.bosk.opentelemetry.TraceContextDriver;
 
 @Component
 public class HelloBosk extends Bosk<BoskState> {
@@ -34,7 +34,7 @@ public class HelloBosk extends Bosk<BoskState> {
 	private static DriverFactory<BoskState> driverFactory(LogController logController) {
 		return DriverStack.of(
 			BoskLogFilter.withController(logController),
-			OpenTelemetryDriver.wrapping(
+			TraceContextDriver.wrapping(
 				ForwardingDriver.factory()
 //				BufferingDriver.factory() // Defer operations to try to mix up the OTel context
 			)


### PR DESCRIPTION
There was some loose thinking around these. Here we establish:
- MDC is not propagated by drivers; some particular attributes are established in each driver
  - Added tests for this
- We propagate W3C trace context, not other kinds of OTel context like baggage or custom keys
  - Renamed `TraceContextDriver`
- Diagnostic attributes are propagated into hooks based on how they are called
  - The diagnostics one bosk hook sees might not match a hook fired in another bosk for the same update

Fixes #169 