### PR TITLE
Clean up hook interruption

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -12,8 +12,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -95,7 +94,6 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	private final Thread.Builder hookThreadBuilder = Thread
 		.ofVirtual()
 		.name("bosk-hook-", 1);
-	private final ExecutorService hookExecutor = Executors.newThreadPerTaskExecutor(hookThreadBuilder::unstarted);
 
 	/**
 	 * Mutable state.
@@ -603,24 +601,46 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 			do {
 				if (hookExecutionPermit.tryAcquire()) {
 					try {
-						for (Runnable ex = hookExecutionQueue.pollFirst(); ex != null; ex = hookExecutionQueue.pollFirst()) {
+						while (true) {
+							// An interrupt means "stop"; quit before starting another hook,
+							// leaving the remaining queued hooks for a later update.
+							if (Thread.currentThread().isInterrupted()) {
+								LOGGER.debug("Interrupted; deferring the remaining queued hooks");
+								return;
+							}
+							Runnable ex = hookExecutionQueue.pollFirst();
+							if (ex == null) {
+								break;
+							}
 							// Run the task in a separate virtual thread to prevent ThreadLocals from propagating.
 							// This is slightly tragic, because usually ThreadLocal propagation works just the
 							// way we'd want, but not always. Given the choices "always, sometimes, never", if
 							// we can't achieve "always", then the bosk philosophy prefers "never" over "sometimes".
-							hookExecutor.submit(ex).get();
+							FutureTask<Void> task = new FutureTask<>(ex, null);
+							Thread hookThread = hookThreadBuilder.start(task);
+							try {
+								task.get();
+							} catch (ExecutionException e) {
+								try {
+									throw e.getCause();
+								} catch (RuntimeException | Error cause) {
+									throw cause;
+								} catch (Throwable t) {
+									throw new AssertionError("Hook runnable should catch and wrap checked exceptions", t);
+								}
+							} catch (InterruptedException e) {
+								// The interrupt is intended for the hook work in flight here.
+								// Deliver it to the running hook, per the BoskHook contract,
+								// and await its termination before proceeding. This is intended
+								// to mimic structured concurrency (StructuredTaskScope.close()):
+								// cancel the in-flight subtasks and wait for them to terminate.
+								hookThread.interrupt();
+								awaitTermination(hookThread);
+								Thread.currentThread().interrupt();
+								LOGGER.warn("Interrupted while running hooks; the running hook was interrupted and terminated, and the remaining queued hooks are deferred to the next update", e);
+								return;
+							}
 						}
-					} catch (ExecutionException e) {
-						if (e.getCause() instanceof RuntimeException r) {
-							throw r;
-						} else if (e.getCause() instanceof Error error) {
-							throw error;
-						} else {
-							throw new AssertionError("Hook runnable should catch and wrap checked exceptions", e);
-						}
-					} catch (InterruptedException e) {
-						LOGGER.warn("Interrupted while running hooks", e);
-						return;
 					} finally {
 						hookExecutionPermit.release();
 					}
@@ -658,6 +678,22 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 				// succeed in acquiring the permit and will itself drain the queue.
 
 			} while (!hookExecutionQueue.isEmpty());
+		}
+
+		/**
+		 * Wait for the given hook thread to terminate. If this (the draining) thread is
+		 * interrupted while waiting, keep waiting: the interrupt has already been delivered
+		 * to the hook, and proceeding without it would leave the hook running orphaned.
+		 */
+		private void awaitTermination(Thread hookThread) {
+			while (true) {
+				try {
+					hookThread.join();
+					return;
+				} catch (InterruptedException e) {
+					// Keep waiting; the interrupt has been delivered to the hook already.
+				}
+			}
 		}
 
 		@Override

--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -543,7 +543,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		private <T, S> void triggerQueueingOfHooks(Reference<T> target, @Nullable R priorRoot, R rootForHook, HookRegistration<S> reg) {
 			MapValue<String> attributes = context.getAttributes();
 			reg.triggerAction(priorRoot, rootForHook, target, changedRef -> {
-				LOGGER.debug("Hook: queue {}({}) due to {}", reg.name, changedRef, target);
+				HOOK_LOGGER.debug("Hook: queue {}({}) due to {}", reg.name, changedRef, target);
 				hookExecutionQueue.addLast(() -> {
 					// We use two nested try statements here so that the "finally" clause runs within the diagnostic scope
 					try (
@@ -551,19 +551,19 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 						var _ = context.withOnly(attributes)
 					) {
 						try (ReadSession _ = new ReadSession(rootForHook)) {
-							LOGGER.debug("Hook: RUN {}({})", reg.name, changedRef);
+							HOOK_LOGGER.debug("Hook: RUN {}({})", reg.name, changedRef);
 							reg.hook.onChanged(changedRef);
 						} catch (InterruptedException e) {
-							LOGGER.warn("Bosk hook \"{}\" was interrupted; proceeding", reg.name(), e);
+							HOOK_LOGGER.warn("Bosk hook \"{}\" was interrupted; proceeding", reg.name(), e);
 						} catch (RuntimeException e) {
-							LOGGER.error("Bosk hook \"{}\" terminated with an exception, which usually indicates a bug. State updates may have been lost", reg.name(), e);
+							HOOK_LOGGER.error("Bosk hook \"{}\" terminated with an exception, which usually indicates a bug. State updates may have been lost", reg.name(), e);
 
 							// Note that we don't catch Error. The practical reason is to allow users to write
 							// unit tests that throw AssertionError from hooks, but the bigger reason is that
 							// Errors indicate that something has gone dreadfully wrong, and we probably should
 							// not attempt to continue.
 						} finally {
-							LOGGER.debug("Hook: end {}({})", reg.name, changedRef);
+							HOOK_LOGGER.debug("Hook: end {}({})", reg.name, changedRef);
 						}
 					}
 				});
@@ -605,7 +605,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 							// An interrupt means "stop"; quit before starting another hook,
 							// leaving the remaining queued hooks for a later update.
 							if (Thread.currentThread().isInterrupted()) {
-								LOGGER.debug("Interrupted; deferring the remaining queued hooks");
+								HOOK_LOGGER.debug("Interrupted; deferring the remaining queued hooks");
 								return;
 							}
 							Runnable ex = hookExecutionQueue.pollFirst();
@@ -637,7 +637,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 								hookThread.interrupt();
 								awaitTermination(hookThread);
 								Thread.currentThread().interrupt();
-								LOGGER.warn("Interrupted while running hooks; the running hook was interrupted and terminated, and the remaining queued hooks are deferred to the next update", e);
+								HOOK_LOGGER.warn("Interrupted while running hooks; the running hook was interrupted and terminated, and the remaining queued hooks are deferred to the next update", e);
 								return;
 							}
 						}
@@ -1496,5 +1496,12 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 		return (Class) EnumerableByIdentifier.class;
 	}
 
+	/**
+	 * Logger name for hook execution specifically, so that hook-execution warnings can be
+	 * selectively suppressed (for example in tests) without affecting other bosk logs.
+	 */
+	public static final String HOOK_LOGGER_NAME = Bosk.class.getName() + ".hooks";
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(Bosk.class);
+	private static final Logger HOOK_LOGGER = LoggerFactory.getLogger(HOOK_LOGGER_NAME);
 }

--- a/bosk-core/src/main/java/works/bosk/BoskHook.java
+++ b/bosk-core/src/main/java/works/bosk/BoskHook.java
@@ -2,6 +2,11 @@ package works.bosk;
 
 /**
  * Called to indicate the hook's "scope object" may have been modified.
+ * <p>
+ * Hooks run on their own virtual thread. If the bosk machinery that runs a hook is
+ * interrupted (for example, because a driver is shutting down or disconnecting),
+ * bosk delivers the interrupt to the running hook so it can stop promptly;
+ * implementations should therefore be written to respond to interruption.
  */
 public interface BoskHook<T> {
 	/**

--- a/bosk-core/src/test/java/works/bosk/HooksTest.java
+++ b/bosk-core/src/test/java/works/bosk/HooksTest.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -25,10 +26,13 @@ import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static works.bosk.BoskConfig.simpleDriver;
 
@@ -117,6 +121,40 @@ public class HooksTest extends AbstractBoskTest {
 		});
 		String observed = queue.take();
 		assertEquals("initial", observed, "Thread locals should not propagate into hooks");
+	}
+
+	@Test
+	void hookInterrupted_whenSubmittingThreadInterrupted() throws InterruptedException {
+		CountDownLatch hookStarted = new CountDownLatch(1);
+		CountDownLatch gate = new CountDownLatch(1);
+		CountDownLatch hookInterrupted = new CountDownLatch(1);
+		AtomicBoolean hookTerminated = new AtomicBoolean(false);
+
+		// The hook is registered on a child that doesn't exist yet, so registering it
+		// doesn't fire the hook; the submit that creates the child is what triggers it.
+		Identifier newChildID = Identifier.from("newChild");
+		bosk.hookRegistrar().registerHook("blocking", refs.child(newChildID), ref -> {
+			hookStarted.countDown();
+			try {
+				gate.await();
+			} catch (InterruptedException e) {
+				hookInterrupted.countDown();
+			} finally {
+				hookTerminated.set(true);
+			}
+		});
+
+		Thread submitter = new Thread(() ->
+			bosk.driver().submitReplacement(refs.child(newChildID),
+				new TestChild(newChildID, "newChild", TestEnum.OK, Catalog.empty())));
+		submitter.start();
+
+		assertTrue(hookStarted.await(10, SECONDS), "The hook must start running");
+		submitter.interrupt();
+		assertTrue(hookInterrupted.await(10, SECONDS), "The running hook must receive the interrupt");
+		submitter.join(10_000);
+		assertFalse(submitter.isAlive(), "submitReplacement must return after the hook is interrupted");
+		assertTrue(hookTerminated.get(), "The hook must terminate before submitReplacement returns");
 	}
 
 	@ParameterizedTest

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -336,7 +336,7 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 	@Test
 	@DisruptsMongoProxy
 	void hookInterrupted_whenReceiverDisconnects() throws InvalidTypeException, InterruptedException, IOException {
-		setLogging(ERROR, MainDriver.class, ChangeReceiver.class, Bosk.class);
+		setLogging(ERROR, MainDriver.class, ChangeReceiver.class);
 
 		Bosk<TestEntity> bosk = new Bosk<>(
 			boskName(),

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import lombok.With;
 import org.bson.BsonBoolean;
@@ -69,6 +70,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -329,6 +331,82 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			latecomerActual = latecomerBosk.rootReference().value();
 		}
 		assertEquals(expected, latecomerActual);
+	}
+
+	@Test
+	@DisruptsMongoProxy
+	void hookInterrupted_whenReceiverDisconnects() throws InvalidTypeException, InterruptedException, IOException {
+		setLogging(ERROR, MainDriver.class, ChangeReceiver.class, Bosk.class);
+
+		Bosk<TestEntity> bosk = new Bosk<>(
+			boskName(),
+			TestEntity.class,
+			AbstractMongoDriverTest::initialState,
+			BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
+		Refs refs = bosk.buildReferences(Refs.class);
+		BoskDriver driver = bosk.driver();
+
+		CountDownLatch hookStarted = new CountDownLatch(1);
+		CountDownLatch gate = new CountDownLatch(1);
+		CountDownLatch hookInterrupted = new CountDownLatch(1);
+
+		// The hook is registered on a listing entry that doesn't exist yet, so registering
+		// it doesn't fire the hook; the submit that creates the entry triggers it.
+		bosk.hookRegistrar().registerHook("blocking", refs.listingEntry(entity124), ref -> {
+			hookStarted.countDown();
+			try {
+				gate.await();
+			} catch (InterruptedException e) {
+				hookInterrupted.countDown();
+			}
+		});
+
+		LOGGER.debug("Wait till MongoDB is up and running");
+		driver.flush();
+
+		LOGGER.debug("Submit an update that triggers the blocking hook");
+		driver.submitReplacement(refs.listingEntry(entity124), LISTING_ENTRY);
+
+		boolean started = hookStarted.await(30, SECONDS);
+		assertTrue(started, "The hook must start running");
+
+		LOGGER.debug("Cut connection and submit an update that fails, disconnecting the driver");
+		mongoService.cutConnection();
+		tearDownActions.add(() -> mongoService.restoreConnection());
+
+		// The submit runs on a worker thread because, once it triggers the disconnect,
+		// it blocks waiting for the receiver to reconnect.
+		AtomicReference<Throwable> submitFailure = new AtomicReference<>();
+		Thread submitter = new Thread(() -> {
+			try {
+				driver.submitReplacement(refs.listingEntry(entity124), LISTING_ENTRY);
+			} catch (Throwable t) {
+				submitFailure.set(t);
+			}
+		});
+		submitter.start();
+
+		boolean interrupted = hookInterrupted.await(30, SECONDS);
+		assertTrue(interrupted, "The running hook must receive the interrupt when the receiver disconnects");
+
+		LOGGER.debug("Reestablish connection");
+		mongoService.restoreConnection();
+
+		driver.flush();
+		submitter.join(30_000);
+		assertFalse(submitter.isAlive(), "The submit that triggered the disconnect must complete after recovery");
+		Throwable failure = submitFailure.get();
+		if (failure != null) {
+			throw new AssertionError("Submit during outage failed unexpectedly", failure);
+		}
+
+		TestEntity expected = initialRoot(bosk)
+			.withListing(Listing.of(refs.catalog(), entity123, entity124));
+		TestEntity actual;
+		try (var _ = bosk.readSession()) {
+			actual = bosk.rootReference().value();
+		}
+		assertEquals(expected, actual, "The bosk must recover and converge to the expected state");
 	}
 
 	@Test

--- a/lib-testing/src/main/resources/logback.xml
+++ b/lib-testing/src/main/resources/logback.xml
@@ -20,6 +20,7 @@
 
 	<!-- This emits warnings that matter in production but not in tests -->
 	<logger name="works.bosk.drivers.mongo.MongoDriver.uninitializedCollection" level="ERROR"/>
+	<logger name="works.bosk.Bosk.hooks" level="ERROR"/>
 
 	<!-- How to add more tracing during unit tests
 	<logger name="works.bosk" level="INFO"/>


### PR DESCRIPTION
Interrupting a thread while it's running hooks should cleanly stop processing those hooks, and should then resume once new updates start flowing again. (Note that the actual interrupted hook does not re-run, which shouldn't really surprise folks.)

Also avoids logging these interruptions in tests, because they practically always happen as part of test shutdown and aren't a problem.

Fixes #150.