### PR TITLE
Eliminate Gradle 10 deprecation warnings from the build scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,12 @@ plugins {
 	alias(libs.plugins.spotbugs) apply false
 }
 
-ext {
-	jdkVersion = 26 // If you bump this, change the CI workflows too
-	minSupportedJavaVersion = 25
-}
+def jdkVersion = providers.gradleProperty("jdkVersion").get().toInteger()
+def minSupportedJavaVersion = providers.gradleProperty("minSupportedJavaVersion").get().toInteger()
+
+// Bind Gradle's injected `libs` accessor to a script-local of the same name.
+def libsShadow = libs
+def libs = libsShadow
 
 java {
 	toolchain {
@@ -261,8 +263,8 @@ configure(subprojects.findAll { it.name.startsWith("bosk-") || it.name == "boson
 				url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
 				credentials {
-					username = project.properties['ossrhUsername'] ?: 'bogusUser'
-					password = project.properties['ossrhPassword'] ?: 'bogusPassword'
+					username = providers.gradleProperty("ossrhUsername").getOrElse("bogusUser")
+					password = providers.gradleProperty("ossrhPassword").getOrElse("bogusPassword")
 				}
 			}
 		}
@@ -270,8 +272,8 @@ configure(subprojects.findAll { it.name.startsWith("bosk-") || it.name == "boson
 
 	signing {
 		sign publishing.publications.mavenJava
-		def signingKey = findProperty("signingKey")
-		def signingPassword = findProperty("signingPassword")
+		def signingKey = providers.gradleProperty("signingKey").orNull
+		def signingPassword = providers.gradleProperty("signingPassword").orNull
 		useInMemoryPgpKeys(signingKey, signingPassword)
 	}
 
@@ -288,8 +290,8 @@ nexusPublishing {
 		sonatype {
 			nexusUrl = uri('https://ossrh-staging-api.central.sonatype.com/service/local/')
 			snapshotRepositoryUrl = uri('https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/')
-			username = project.properties['ossrhUsername'] ?: 'bogusUser'
-			password = project.properties['ossrhPassword'] ?: 'bogusPassword'
+			username = providers.gradleProperty("ossrhUsername").getOrElse("bogusUser")
+			password = providers.gradleProperty("ossrhPassword").getOrElse("bogusPassword")
 		}
 	}
 }

--- a/example-hello/build.gradle
+++ b/example-hello/build.gradle
@@ -8,6 +8,9 @@ group = 'works.bosk'
 version = '0.0.1-SNAPSHOT'
 description = 'Bosk example project'
 
+def jdkVersion = providers.gradleProperty("jdkVersion").get().toInteger()
+def minSupportedJavaVersion = providers.gradleProperty("minSupportedJavaVersion").get().toInteger()
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(jdkVersion)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+
+# If you bump these, change the CI workflows too
+jdkVersion=26
+minSupportedJavaVersion=25

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,8 @@
 
+// Adopt Gradle 10 semantics early: fail fast if build logic relies on implicit lookup
+// of properties or methods in parent projects.
+enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
+
 rootProject.name = 'bosk'
 
 include 'bosk-annotations'


### PR DESCRIPTION
The build relied on implicit lookup of properties in parent projects: the shared dependencies block and the toolchain configuration resolved the version catalog and the Java version constants from the root project instead of from each subproject. It also used `Project.getProperties()`.

Gradle 10 deprecates these things.

Fixes:
- Move the Java version constants into `gradle.properties` and read them with `providers.gradleProperty()`
- Capture the version catalog accessor in a script-local variable so the shared dependency declarations resolve lexically instead of walking up the project hierarchy.

Also enable the `NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS` feature preview so any future reliance on implicit parent-project lookup fails fast instead of warning.