### PR TITLE
Remove the legacy publishing repository configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -255,19 +255,6 @@ configure(subprojects.findAll { it.name.startsWith("bosk-") || it.name == "boson
 				}
 			}
 		}
-
-		repositories {
-			maven {
-				def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
-				def snapshotsRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/'
-				url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-
-				credentials {
-					username = providers.gradleProperty("ossrhUsername").getOrElse("bogusUser")
-					password = providers.gradleProperty("ossrhPassword").getOrElse("bogusPassword")
-				}
-			}
-		}
 	}
 
 	signing {


### PR DESCRIPTION
The nexus-publish-plugin configures its own publishing repository from the nexusPublishing block.