### PR TITLE
JSON parsing fixes

### DIFF
--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonCompiler.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonCompiler.java
@@ -24,6 +24,7 @@ import tools.jackson.databind.SerializationConfig;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.type.TypeFactory;
 import works.bosk.BoskInfo;
 import works.bosk.Phantom;
@@ -315,7 +316,9 @@ final class JacksonCompiler {
 					try {
 						parameterValues = jacksonSerializer.parameterValueList(nodeJavaType.getRawClass(), valueMap, componentsByName, boskInfo);
 					} catch (DeserializationException e) {
-						throw new IllegalStateException(e);
+						MismatchedInputException mismatch = MismatchedInputException.from(p, nodeJavaType, e.getMessage());
+						mismatch.initCause(e);
+						throw mismatch;
 					}
 
 					@SuppressWarnings("unchecked")

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
@@ -17,7 +17,6 @@ import java.util.function.Function;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
-import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.BeanDescription;
 import tools.jackson.databind.DeserializationConfig;
@@ -29,6 +28,7 @@ import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.databind.deser.Deserializers;
+import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.jsontype.TypeDeserializer;
 import tools.jackson.databind.jsontype.TypeSerializer;
 import tools.jackson.databind.ser.Serializers;
@@ -343,13 +343,13 @@ public final class JacksonSerializer extends StateTreeSerializer {
 					Reference<Catalog<Entity>> domain = null;
 					List<Identifier> ids = null;
 
-					expect(START_OBJECT, p);
+					expect(START_OBJECT, p, ctxt);
 					while (p.nextToken() != END_OBJECT) {
 						p.nextValue();
 						switch (p.currentName()) {
 							case "ids":
 								if (ids != null) {
-									throw new StreamReadException(p, "'ids': ids already appeared");
+									return ctxt.reportInputMismatch(Object.class, "'ids': ids already appeared");
 								}
 								ids = (List<Identifier>) ctxt
 									.findContextualValueDeserializer(ID_LIST_TYPE, null)
@@ -357,27 +357,27 @@ public final class JacksonSerializer extends StateTreeSerializer {
 								break;
 							case "entriesById":
 								if (ids != null) {
-									throw new StreamReadException(p, "'entriesById': ids already appeared");
+									return ctxt.reportInputMismatch(Object.class, "'entriesById': ids already appeared");
 								}
 								ids = List.copyOf(readMapEntries(p, typeFactory.constructType(Boolean.class), ctxt).keySet());
 								break;
 							case "domain":
 								if (domain != null) {
-									throw new StreamReadException(p, "'domain' field appears twice");
+									return ctxt.reportInputMismatch(Object.class, "'domain' field appears twice");
 								}
 								domain = (Reference<Catalog<Entity>>) ctxt
 									.findContextualValueDeserializer(CATALOG_REF_TYPE, null)
 									.deserialize(p, ctxt);
 								break;
 							default:
-								throw new StreamReadException(p, "Unrecognized field in Listing: " + p.currentName());
+								return ctxt.reportInputMismatch(Object.class, "Unrecognized field in Listing: " + p.currentName());
 						}
 					}
 
 					if (domain == null) {
-						throw new StreamReadException(p, "Missing 'domain' field");
+						return ctxt.reportInputMismatch(Object.class, "Missing 'domain' field");
 					} else if (ids == null) {
-						throw new StreamReadException(p, "Missing 'ids' field");
+						return ctxt.reportInputMismatch(Object.class, "Missing 'ids' field");
 					} else {
 						return Listing.of(domain, ids);
 					}
@@ -414,7 +414,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 					if (p.getBooleanValue()) {
 						return LISTING_ENTRY;
 					} else {
-						throw new StreamReadException(p, "Unexpected Listing entry value: " + p.getBooleanValue());
+						return ctxt.reportInputMismatch(Object.class, "Unexpected Listing entry value: " + p.getBooleanValue());
 					}
 				}
 			};
@@ -429,7 +429,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 					Reference<Catalog<Entity>> domain = null;
 					LinkedHashMap<Identifier, Object> valuesById = null;
 
-					expect(START_OBJECT, p);
+					expect(START_OBJECT, p, ctxt);
 					while (p.nextToken() != END_OBJECT) {
 						p.nextValue();
 						switch (p.currentName()) {
@@ -437,7 +437,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 								if (valuesById == null) {
 									valuesById = readMapEntries(p, valueType, ctxt);
 								} else {
-									throw new StreamReadException(p, "'valuesById' field appears twice");
+									return ctxt.reportInputMismatch(Object.class, "'valuesById' field appears twice");
 								}
 								break;
 							case "domain":
@@ -446,19 +446,19 @@ public final class JacksonSerializer extends StateTreeSerializer {
 										.findContextualValueDeserializer(CATALOG_REF_TYPE, null)
 										.deserialize(p, ctxt);
 								} else {
-									throw new StreamReadException(p, "'domain' field appears twice");
+									return ctxt.reportInputMismatch(Object.class, "'domain' field appears twice");
 								}
 								break;
 							default:
-								throw new StreamReadException(p, "Unrecognized field in SideTable: " + p.currentName());
+								return ctxt.reportInputMismatch(Object.class, "Unrecognized field in SideTable: " + p.currentName());
 						}
 					}
-					expect(END_OBJECT, p);
+					expect(END_OBJECT, p, ctxt);
 
 					if (domain == null) {
-						throw new StreamReadException(p, "Missing 'domain' field");
+						return ctxt.reportInputMismatch(Object.class, "Missing 'domain' field");
 					} else if (valuesById == null) {
-						throw new StreamReadException(p, "Missing 'valuesById' field");
+						return ctxt.reportInputMismatch(Object.class, "Missing 'valuesById' field");
 					} else {
 						return SideTable.copyOf(domain, valuesById);
 					}
@@ -484,16 +484,16 @@ public final class JacksonSerializer extends StateTreeSerializer {
 			return new ValueDeserializer<>() {
 				@Override
 				public TaggedUnion<V> deserialize(JsonParser p, DeserializationContext ctxt) {
-					expect(START_OBJECT, p);
+					expect(START_OBJECT, p, ctxt);
 					if (p.nextToken() == END_OBJECT) {
-						throw new StreamReadException(p, "Input is missing variant tag field; expected one of " + variantCaseMap.keySet());
+						return ctxt.reportInputMismatch(Object.class, "Input is missing variant tag field; expected one of " + variantCaseMap.keySet());
 					}
 					p.nextValue();
 
 					String tag = p.currentName();
 					ValueDeserializer<?> deserializer = deserializers.get(tag);
 					if (deserializer == null) {
-						throw new StreamReadException(p, "TaggedUnion<" + caseStaticClass.getSimpleName() + "> has unexpected variant tag field \"" + tag + "\"; expected one of " + variantCaseMap.keySet());
+						return ctxt.reportInputMismatch(Object.class, "TaggedUnion<" + caseStaticClass.getSimpleName() + "> has unexpected variant tag field \"" + tag + "\"; expected one of " + variantCaseMap.keySet());
 					}
 					Object deserialized = deserializer.deserialize(p, ctxt);
 					@SuppressWarnings("unchecked") Class<D> caseDynamicClass = (Class<D>) rawClass(variantCaseMap.get(tag));
@@ -501,11 +501,13 @@ public final class JacksonSerializer extends StateTreeSerializer {
 					try {
 						value = caseDynamicClass.cast(deserialized);
 					} catch (ClassCastException e) {
-						throw new StreamReadException(p, "Deserialized " + deserialized.getClass().getSimpleName() + " has incorrect tag \"" + tag + "\" corresponding to incompatible type " + caseDynamicClass.getSimpleName());
+						MismatchedInputException mismatch = MismatchedInputException.from(p, Object.class, "Deserialized " + deserialized.getClass().getSimpleName() + " has incorrect tag \"" + tag + "\" corresponding to incompatible type " + caseDynamicClass.getSimpleName());
+						mismatch.initCause(e);
+						throw mismatch;
 					}
 
 					p.nextToken();
-					expect(END_OBJECT, p);
+					expect(END_OBJECT, p, ctxt);
 					return TaggedUnion.of(value);
 				}
 			};
@@ -532,7 +534,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 				@Override
 				public MapValue<Object> deserialize(JsonParser p, DeserializationContext ctxt) {
 					LinkedHashMap<String, Object> result1 = new LinkedHashMap<>();
-					expect(START_OBJECT, p);
+					expect(START_OBJECT, p, ctxt);
 					while (p.nextToken() != END_OBJECT) {
 						p.nextValue();
 						String key = p.currentName();
@@ -540,10 +542,10 @@ public final class JacksonSerializer extends StateTreeSerializer {
 							.deserialize(p, ctxt);
 						Object old = result1.put(key, value);
 						if (old != null) {
-							throw new StreamReadException(p, "MapValue key appears twice: \"" + key + "\"");
+							return ctxt.reportInputMismatch(Object.class, "MapValue key appears twice: \"" + key + "\"");
 						}
 					}
-					expect(END_OBJECT, p);
+					expect(END_OBJECT, p, ctxt);
 					return MapValue.copyOf(result1);
 				}
 			};
@@ -588,9 +590,9 @@ public final class JacksonSerializer extends StateTreeSerializer {
 		@SuppressWarnings("unchecked")
 		ValueDeserializer<V> valueDeserializer = (ValueDeserializer<V>) ctxt.findContextualValueDeserializer(valueType, null);
 		LinkedHashMap<Identifier, V> result = new LinkedHashMap<>();
-		expect(START_ARRAY, p);
+		expect(START_ARRAY, p, ctxt);
 		while (p.nextToken() != END_ARRAY) {
-			expect(START_OBJECT, p);
+			expect(START_OBJECT, p, ctxt);
 			p.nextValue();
 			String fieldName = p.currentName();
 			Identifier entryID = Identifier.from(fieldName);
@@ -599,11 +601,11 @@ public final class JacksonSerializer extends StateTreeSerializer {
 				value = valueDeserializer.deserialize(p, ctxt);
 			}
 			p.nextToken();
-			expect(END_OBJECT, p);
+			expect(END_OBJECT, p, ctxt);
 
 			V oldValue = result.put(entryID, value);
 			if (oldValue != null) {
-				throw new StreamReadException(p, "Duplicate sideTable entry '" + fieldName + "'");
+				return ctxt.reportInputMismatch(Object.class, "Duplicate sideTable entry '" + fieldName + "'");
 			}
 		}
 		return result;
@@ -627,7 +629,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 	public Map<String, Object> gatherParameterValuesByName(JavaType nodeJavaType, Map<String, RecordComponent> componentsByName, JsonParser p, DeserializationContext ctxt) {
 		Class<?> nodeClass = nodeJavaType.getRawClass();
 		Map<String, Object> parameterValuesByName = new HashMap<>();
-		expect(START_OBJECT, p);
+		expect(START_OBJECT, p, ctxt);
 		while (p.nextToken() != END_OBJECT) {
 			p.nextValue();
 			String name = p.currentName();
@@ -636,7 +638,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 				if (ignoreUnrecognizedField(nodeClass, name)) {
 					p.skipChildren();
 				} else {
-					throw new StreamReadException(p, "No such component in record " + nodeClass.getSimpleName() + ": " + name);
+					return ctxt.reportInputMismatch(Object.class, "No such component in record " + nodeClass.getSimpleName() + ": " + name);
 				}
 			} else {
 				JavaType parameterType = typeFactory.resolveMemberType(component.getGenericType(), nodeJavaType.getBindings());
@@ -647,7 +649,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 				Object value = deserializedValue;
 				Object prev = parameterValuesByName.put(name, value);
 				if (prev != null) {
-					throw new StreamReadException(p, "Parameter appeared twice: " + name);
+					return ctxt.reportInputMismatch(Object.class, "Parameter appeared twice: " + name);
 				}
 			}
 		}
@@ -666,12 +668,12 @@ public final class JacksonSerializer extends StateTreeSerializer {
 				// must be an error rather than silently becoming Optional.empty() or, worse,
 				// being deserialized as a value with the string "null" (as the Identifier
 				// deserializer would do, since JsonParser.getString() returns "null").
-				throw new StreamReadException(p, "Optional field \"" + name + "\" cannot be null; omit the field to deserialize it as Optional.empty()");
+				return ctxt.reportInputMismatch(contentsType, "Optional field \"" + name + "\" cannot be null; omit the field to deserialize it as Optional.empty()");
 			}
 			Object deserializedValue = readField(name, p, ctxt, contentsType);
 			return Optional.of(deserializedValue);
 		} else if (Phantom.class.isAssignableFrom(effectiveClass)) {
-			throw new StreamReadException(p, "Unexpected phantom field \"" + name + "\"");
+			return ctxt.reportInputMismatch(Object.class, "Unexpected phantom field \"" + name + "\"");
 		} else {
 			ValueDeserializer<Object> parameterDeserializer = ctxt.findContextualValueDeserializer(effectiveType, null);
 			return parameterDeserializer.deserialize(p, ctxt);
@@ -698,13 +700,13 @@ public final class JacksonSerializer extends StateTreeSerializer {
 		try {
 			return parameterizedType.findTypeParameters(expectedClass)[index];
 		} catch (IndexOutOfBoundsException e) {
-			throw new IllegalStateException("Error computing javaParameterType(" + parameterizedType + ", " + expectedClass + ", " + index + ")");
+			throw new IllegalStateException("Error computing javaParameterType(" + parameterizedType + ", " + expectedClass + ", " + index + ")", e);
 		}
 	}
 
-	public static void expect(JsonToken expected, JsonParser p) {
+	public static void expect(JsonToken expected, JsonParser p, DeserializationContext ctxt) {
 		if (p.currentToken() != expected) {
-			throw new StreamReadException(p, "Expected " + expected + "; found " + p.currentToken());
+			ctxt.reportInputMismatch(Object.class, "Expected %s; found %s", expected, p.currentToken());
 		}
 	}
 }

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
@@ -661,6 +661,13 @@ public final class JacksonSerializer extends StateTreeSerializer {
 		if (Optional.class.isAssignableFrom(effectiveClass)) {
 			// Optional field is present in JSON; wrap deserialized value in Optional.of
 			JavaType contentsType = javaParameterType(effectiveType, Optional.class, 0);
+			if (p.currentToken() == JsonToken.VALUE_NULL) {
+				// An Optional field is serialized as absent when empty, so a present null
+				// must be an error rather than silently becoming Optional.empty() or, worse,
+				// being deserialized as a value with the string "null" (as the Identifier
+				// deserializer would do, since JsonParser.getString() returns "null").
+				throw new StreamReadException(p, "Optional field \"" + name + "\" cannot be null; omit the field to deserialize it as Optional.empty()");
+			}
 			Object deserializedValue = readField(name, p, ctxt, contentsType);
 			return Optional.of(deserializedValue);
 		} else if (Phantom.class.isAssignableFrom(effectiveClass)) {

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JsonNodeDriver.java
@@ -1,6 +1,7 @@
 package works.bosk.jackson;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.StringNode;
 import works.bosk.BoskContext;
 import works.bosk.BoskDriver;
 import works.bosk.BoskInfo;
@@ -64,7 +66,7 @@ public class JsonNodeDriver implements BoskDriver {
 	public synchronized <T> void submitConditionalReplacement(Reference<T> target, T newValue, Reference<Identifier> precondition, Identifier requiredValue) {
 		traceCurrentState("Before submitConditionalReplacement");
 		JsonNode root = currentRoot();
-		if (root != null && requiredValue.toString().equals(surgeon.valueNode(root, precondition).asString())) {
+		if (preconditionMatches(root, precondition, requiredValue)) {
 			doReplacement(surgeon.nodeInfo(root, target), () -> target.path().lastSegment(), newValue);
 		}
 		downstream.submitConditionalReplacement(target, newValue, precondition, requiredValue);
@@ -93,7 +95,7 @@ public class JsonNodeDriver implements BoskDriver {
 	public synchronized <T> void submitConditionalDeletion(Reference<T> target, Reference<Identifier> precondition, Identifier requiredValue) {
 		traceCurrentState("Before submitConditionalDeletion");
 		JsonNode root = currentRoot();
-		if (root != null && requiredValue.toString().equals(surgeon.valueNode(root, precondition).asString())) {
+		if (preconditionMatches(root, precondition, requiredValue)) {
 			surgeon.deleteNode(surgeon.nodeInfo(root, target));
 		}
 		downstream.submitConditionalDeletion(target, precondition, requiredValue);
@@ -104,6 +106,17 @@ public class JsonNodeDriver implements BoskDriver {
 	public synchronized void flush() throws IOException, InterruptedException {
 		traceCurrentState("Before flush");
 		downstream.flush();
+	}
+
+	/**
+	 * @return true if the node referenced by <code>precondition</code> exists in
+	 * <code>root</code> and has the value <code>requiredValue</code>. A nonexistent
+	 * precondition does not match (it does not cause an exception).
+	 */
+	private boolean preconditionMatches(JsonNode root, Reference<Identifier> precondition, Identifier requiredValue) {
+		return root != null
+			&& surgeon.valueNode(root, precondition) instanceof StringNode text
+			&& Objects.equals(text.asString(), requiredValue.toString());
 	}
 
 	private <T> void doReplacement(NodeInfo nodeInfo, Supplier<String> lastSegment, T newValue) {

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.type.TypeFactory;
 import works.bosk.BindingEnvironment;
@@ -39,6 +39,7 @@ import works.bosk.TaggedUnion;
 import works.bosk.annotations.DeserializationPath;
 import works.bosk.annotations.Polyfill;
 import works.bosk.annotations.ReferencePath;
+import works.bosk.exceptions.DeserializationException;
 import works.bosk.exceptions.MalformedPathException;
 import works.bosk.exceptions.ParameterUnboundException;
 import works.bosk.exceptions.UnexpectedPathException;
@@ -234,11 +235,22 @@ class JacksonSerializerTest extends AbstractBoskTest {
 		// "Present with a value of null" is not the same as "absent":
 		// an Optional field is serialized as absent when empty, so an explicit
 		// null in the input must be rejected rather than silently treated as empty.
-		assertThrows(StreamReadException.class, () ->
-			boskMapper.readerFor(HasOptionalIdentifier.class).readValue("{ \"optionalIdentifier\": null }"));
+		assertJsonException("{ \"optionalIdentifier\": null }", HasOptionalIdentifier.class);
 	}
 
 	public record HasOptionalIdentifier(Optional<Identifier> optionalIdentifier) implements StateTreeNode { }
+
+	@Test
+	void missingRequiredField_throwsWithCause() {
+		// The DeserializationException that parameterValueList throws must not be
+		// discarded when it's reported as a MismatchedInputException.
+		MismatchedInputException e = assertThrows(MismatchedInputException.class, () ->
+			boskMapper.readerFor(HasRequiredField.class).readValue("{}"));
+		assertInstanceOf(DeserializationException.class, e.getCause());
+		assertThat(e.getCause().getMessage(), containsString("Missing field \"requiredField\""));
+	}
+
+	public record HasRequiredField(String requiredField) implements StateTreeNode { }
 
 	@Test
 	void rootReference_works() {
@@ -602,7 +614,7 @@ class JacksonSerializerTest extends AbstractBoskTest {
 			params[i] = typeFactory.constructType(parameters[i]);
 		}
 		JavaType parametricType = typeFactory.constructParametricType(rawClass, params);
-		assertThrows(StreamReadException.class, () -> boskMapper.readerFor(parametricType).readValue(json));
+		assertThrows(MismatchedInputException.class, () -> boskMapper.readerFor(parametricType).readValue(json));
 	}
 
 	@Test

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
@@ -230,6 +230,17 @@ class JacksonSerializerTest extends AbstractBoskTest {
 	}
 
 	@Test
+	void optional_presentButNull_throws() {
+		// "Present with a value of null" is not the same as "absent":
+		// an Optional field is serialized as absent when empty, so an explicit
+		// null in the input must be rejected rather than silently treated as empty.
+		assertThrows(StreamReadException.class, () ->
+			boskMapper.readerFor(HasOptionalIdentifier.class).readValue("{ \"optionalIdentifier\": null }"));
+	}
+
+	public record HasOptionalIdentifier(Optional<Identifier> optionalIdentifier) implements StateTreeNode { }
+
+	@Test
 	void rootReference_works() {
 		String json = boskMapper.writeValueAsString(bosk.rootReference());
 		assertEquals("\"/\"", json);

--- a/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
+++ b/bosk-testing/src/main/java/works/bosk/testing/drivers/DriverConformanceTest.java
@@ -336,6 +336,26 @@ public abstract class DriverConformanceTest extends AbstractDriverTest {
 	}
 
 	@InjectedTest
+	void conditionalUpdateNonexistentPrecondition_doesNothing(@EnclosingCatalog Path enclosingCatalogPath) throws InvalidTypeException {
+		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
+		Reference<Identifier> nonexistentPrecondition = ref.then(Identifier.from("nonexistent")).then(Identifier.class, TestEntity.Fields.id);
+
+		LOGGER.debug("Conditional replacement with nonexistent precondition - should have no effect");
+		driver.submitConditionalReplacement(
+			ref.then(child1ID), newEntity(child1ID, ref).withString("replacement"),
+			nonexistentPrecondition, child1ID
+		);
+		assertCorrectBoskContents();
+
+		LOGGER.debug("Conditional deletion with nonexistent precondition - should have no effect");
+		driver.submitConditionalDeletion(
+			ref.then(child2ID),
+			nonexistentPrecondition, child1ID
+		);
+		assertCorrectBoskContents();
+	}
+
+	@InjectedTest
 	void replaceFieldOfNonexistentEntry(@EnclosingCatalog Path enclosingCatalogPath) throws InvalidTypeException {
 		CatalogReference<TestEntity> ref = initializeBoskWithCatalog(enclosingCatalogPath);
 		driver.submitReplacement(


### PR DESCRIPTION
Tightens up some handling around nulls. Also improves the exceptions thrown by `JacksonSerializer`.

Fixes #387. Fixes #388.