### PR TITLE
BindingEnvironment.Builder.bind: don't corrupt bindings on failure.

### DIFF
--- a/bosk-core/src/main/java/works/bosk/BindingEnvironment.java
+++ b/bosk-core/src/main/java/works/bosk/BindingEnvironment.java
@@ -140,7 +140,7 @@ public final class BindingEnvironment {
 		 * @throws ParameterAlreadyBoundException if <code>name</code> has a binding.
 		 */
 		public Builder bind(String name, Identifier value) {
-			Identifier old = bindings.put(validParameterName(name), value);
+			Identifier old = bindings.putIfAbsent(validParameterName(name), value);
 			if (old == null) {
 				return this;
 			} else {

--- a/bosk-core/src/test/java/works/bosk/BindingEnvironmentTest.java
+++ b/bosk-core/src/test/java/works/bosk/BindingEnvironmentTest.java
@@ -107,6 +107,15 @@ class BindingEnvironmentTest extends AbstractBoskTest {
 		assertSame(builder, builder.unbind("p"), "Fluent unbind() should return its receiver object");
 	}
 
+	@Test
+	void failedBind_doesNotCorruptBuilder() {
+		Builder builder = Builder.empty().bind("p", id(1));
+		assertThrows(ParameterAlreadyBoundException.class, () -> builder.bind("p", id(2)));
+		assertEquals(id(1), builder.build().get("p"), "A failed bind must not replace the existing binding");
+		builder.bind("q", id(3));
+		assertEquals(MapMaker.with("p", id(1)).and("q", id(3)).map, builder.build().asMap(), "The builder should remain usable after a failed bind");
+	}
+
 	@TestFactory
 	Stream<DynamicTest> testMapIsEquivalentToEnvironment() {
 		Stream<DynamicTest> happyPaths = allEnvTests()


### PR DESCRIPTION
A failed bind() previously overwrote the existing binding with the new value before throwing ParameterAlreadyBoundException, so a caller that caught the exception and continued using the builder would silently have the rejected value installed. Use putIfAbsent so an existing binding is never overwritten.

Fixes #393.