### PR TITLE
Serialization fixes

### DIFF
--- a/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
+++ b/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
@@ -207,7 +207,10 @@ public class BosonSerializer extends StateTreeSerializer {
 					}
 					SequencedMap<String, RecognizedMember> members = new LinkedHashMap<>();
 					variantCaseMap.forEach((name, caseType) -> {
-						var ifPresent = new TypeRefNode(DataType.of(caseType));
+						var ifPresent = new ParseCallbackSpec(
+							openVariantCaseDeserializationScope(name, lookup),
+							new TypeRefNode(DataType.of(caseType)),
+							closeVariantCaseDeserializationScope(ReferenceUtils.rawClass(caseType), lookup));
 						var ifAbsent = new ComputedSpec(supplier(
 							DataType.known(caseType),
 							() -> null)); // This is a signal to the finisher that the case is absent
@@ -464,6 +467,47 @@ public class BosonSerializer extends StateTreeSerializer {
 			List.of(lookup),
 			List.copyOf(directives)
 		);
+	}
+
+	/**
+	 * @return nullary callback that opens a {@link DeserializationScope} for a variant case tag.
+	 */
+	private @NonNull TypedHandle openVariantCaseDeserializationScope(String tag, Lookup lookup) {
+		try {
+			MethodHandle variantCaseDeserializationScope = lookup.findVirtual(StateTreeSerializer.class,
+				"variantCaseDeserializationScope",
+				methodType(DeserializationScope.class, String.class));
+			return new TypedHandle(
+				insertArguments(variantCaseDeserializationScope, 0,
+					this, tag
+				),
+				DataType.known(DeserializationScope.class), List.of());
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new IllegalArgumentException("Failed to create scope callback for variant case " + tag, e);
+		}
+	}
+
+	/**
+	 * @return callback that closes a {@link DeserializationScope}
+	 * opened by {@link #openVariantCaseDeserializationScope(String, Lookup)}.
+	 */
+	private static @NonNull TypedHandle closeVariantCaseDeserializationScope(Class<?> caseClass, Lookup lookup) {
+		try {
+			MethodHandle close = lookup.findVirtual(DeserializationScope.class, "close",
+				methodType(void.class));
+
+			// The callback receives the parsed variant case value, but we don't use it
+			MethodHandle mh = dropArguments(close, 1, caseClass);
+
+			return new TypedHandle(mh,
+				DataType.VOID,
+				List.of(
+					DataType.known(DeserializationScope.class),
+					DataType.known(caseClass)
+				));
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new IllegalArgumentException("Failed to create scope callback for variant case " + caseClass.getSimpleName(), e);
+		}
 	}
 
 	/**

--- a/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
+++ b/bosk-boson/src/main/java/works/bosk/bosonSerializer/BosonSerializer.java
@@ -119,7 +119,12 @@ public class BosonSerializer extends StateTreeSerializer {
 
 				@Override
 				public Catalog<E> fromRepresentation(Collection<MapEntry<E>> representation) {
-					// TODO: validate ids?
+					for (MapEntry<E> entry: representation) {
+						Identifier valueID = entry.value().id();
+						if (!entry.id().equals(valueID)) {
+							throw new JsonContentException("Catalog entry ID mismatch: " + entry.id() + " vs " + valueID);
+						}
+					}
 					return Catalog.of(representation.stream().map(MapEntry::value));
 				}
 			})

--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
@@ -27,6 +27,7 @@ import works.bosk.annotations.VariantCaseMap;
 import works.bosk.boson.codec.Codec;
 import works.bosk.boson.codec.CodecBuilder;
 import works.bosk.boson.codec.io.CharArrayJsonReader;
+import works.bosk.boson.exceptions.JsonProcessingException;
 import works.bosk.boson.mapping.TypeMap;
 import works.bosk.boson.mapping.TypeScanner;
 import works.bosk.boson.types.DataType;
@@ -34,6 +35,7 @@ import works.bosk.boson.types.TypeReference;
 import works.bosk.exceptions.InvalidTypeException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BosonSerializerTest {
 
@@ -174,5 +176,17 @@ public class BosonSerializerTest {
 	}
 
 	public record VariantCase1(@Self Reference<VariantCase1> self, String stringField) implements Variant { }
+
+	@Test
+	void catalogEntryKeyMismatch_throws() throws InvalidTypeException {
+		// The JSON member name is the catalog key, so it must agree with the entry's own id.
+		// Otherwise the entry would be silently re-keyed by its id, discarding the key.
+		var parser = codec.parserFor(typeMap.get(DataType.of(new TypeReference<Catalog<Key>>(){})));
+		assertThrows(JsonProcessingException.class, () -> parser.parse(new CharArrayJsonReader(
+			"""
+			[{"w1": {"id": "w2"}}]
+			""".toCharArray()
+		)));
+	}
 
 }

--- a/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
+++ b/bosk-boson/src/test/java/works/bosk/bosonSerializer/BosonSerializerTest.java
@@ -3,6 +3,7 @@ package works.bosk.bosonSerializer;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.reflect.Type;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,12 +13,17 @@ import works.bosk.Catalog;
 import works.bosk.CatalogReference;
 import works.bosk.Entity;
 import works.bosk.Identifier;
+import works.bosk.MapValue;
+import works.bosk.Path;
 import works.bosk.Reference;
 import works.bosk.SideTable;
 import works.bosk.SideTableReference;
 import works.bosk.StateTreeNode;
+import works.bosk.TaggedUnion;
+import works.bosk.VariantCase;
 import works.bosk.annotations.ReferencePath;
 import works.bosk.annotations.Self;
+import works.bosk.annotations.VariantCaseMap;
 import works.bosk.boson.codec.Codec;
 import works.bosk.boson.codec.CodecBuilder;
 import works.bosk.boson.codec.io.CharArrayJsonReader;
@@ -133,5 +139,40 @@ public class BosonSerializerTest {
 		Identifier item1 = Identifier.from("item1");
 		assertEquals(refs.item(item1), parsed.items().get(item1).self());
 	}
+
+	@Test
+	void variantCaseSelfReference_includesTagPath() throws InvalidTypeException, IOException {
+		// A variant case lives at /variant/<tag>, so a @Self reference inside the case
+		// must resolve to the tag path, not the union field path.
+		Bosk<VariantRoot> variantBosk = new Bosk<>("variant", VariantRoot.class, BosonSerializerTest::initialVariantRoot, BoskConfig.simple());
+		var variantTypeMap = new TypeScanner(TypeMap.Settings.DEFAULT)
+			.addBundle(new BosonSerializer().bundleFor(variantBosk))
+			.scan(DataType.of(VariantRoot.class))
+			.build();
+		var variantCodec = CodecBuilder.using(variantTypeMap).buildInterpreter();
+
+		var parser = variantCodec.parserFor(variantTypeMap.get(DataType.of(VariantRoot.class)));
+		VariantRoot parsed = (VariantRoot)parser.parse(new CharArrayJsonReader(
+			"""
+			{"variant": {"case1": {"stringField": "hello"}}}
+			""".toCharArray()
+		));
+
+		assertEquals(Path.parse("/variant/case1"), ((VariantCase1) parsed.variant().variant()).self().path());
+	}
+
+	private static @NonNull VariantRoot initialVariantRoot(Bosk<VariantRoot> bosk) throws InvalidTypeException {
+		return new VariantRoot(TaggedUnion.of(new VariantCase1(bosk.rootReference().then(VariantCase1.class, Path.parse("/variant/case1")), "hello")));
+	}
+
+	public record VariantRoot(TaggedUnion<Variant> variant) implements StateTreeNode { }
+
+	public interface Variant extends VariantCase {
+		@Override default String tag() { return "case1"; }
+		@VariantCaseMap
+		MapValue<Type> CASES = MapValue.singleton("case1", VariantCase1.class);
+	}
+
+	public record VariantCase1(@Self Reference<VariantCase1> self, String stringField) implements Variant { }
 
 }

--- a/bosk-core/src/main/java/works/bosk/StateTreeSerializer.java
+++ b/bosk-core/src/main/java/works/bosk/StateTreeSerializer.java
@@ -94,6 +94,16 @@ public abstract class StateTreeSerializer {
 		return newScope;
 	}
 
+	public final DeserializationScope variantCaseDeserializationScope(String tag) {
+		DeserializationScope outerScope = currentScope.get();
+		DeserializationScope newScope = new NestedDeserializationScope(
+			outerScope,
+			outerScope.path().then(tag),
+			outerScope.bindingEnvironment());
+		currentScope.set(newScope);
+		return newScope;
+	}
+
 	public final DeserializationScope nodeFieldDeserializationScope(Class<?> nodeClass, String fieldName) {
 		DeserializationPath annotation = infoFor(nodeClass).annotatedParameters_DeserializationPath.get(fieldName);
 		DeserializationScope outerScope = currentScope.get();

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
@@ -495,7 +495,10 @@ public final class JacksonSerializer extends StateTreeSerializer {
 					if (deserializer == null) {
 						return ctxt.reportInputMismatch(Object.class, "TaggedUnion<" + caseStaticClass.getSimpleName() + "> has unexpected variant tag field \"" + tag + "\"; expected one of " + variantCaseMap.keySet());
 					}
-					Object deserialized = deserializer.deserialize(p, ctxt);
+					Object deserialized;
+					try (DeserializationScope scope = variantCaseDeserializationScope(tag)) {
+						deserialized = deserializer.deserialize(p, ctxt);
+					}
 					@SuppressWarnings("unchecked") Class<D> caseDynamicClass = (Class<D>) rawClass(variantCaseMap.get(tag));
 					D value;
 					try {

--- a/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
+++ b/bosk-jackson/src/main/java/works/bosk/jackson/JacksonSerializer.java
@@ -330,6 +330,13 @@ public final class JacksonSerializer extends StateTreeSerializer {
 				@Override
 				public Catalog<Entity> deserialize(JsonParser p, DeserializationContext ctxt) {
 					LinkedHashMap<Identifier, Entity> entries = readMapEntries(p, entryType, ctxt);
+					for (Entry<Identifier, Entity> entry: entries.entrySet()) {
+						Identifier entryID = entry.getKey();
+						Identifier valueID = entry.getValue().id();
+						if (!entryID.equals(valueID)) {
+							return ctxt.reportInputMismatch(Object.class, "Catalog entry ID mismatch: " + entryID + " vs " + valueID);
+						}
+					}
 					return Catalog.of(entries.values());
 				}
 			};
@@ -589,8 +596,8 @@ public final class JacksonSerializer extends StateTreeSerializer {
 	/**
 	 * Leaves the parser sitting on the END_ARRAY token. You could call nextToken() to continue with parsing.
 	 */
+	@SuppressWarnings("unchecked")
 	private <V> LinkedHashMap<Identifier, V> readMapEntries(JsonParser p, JavaType valueType, DeserializationContext ctxt) {
-		@SuppressWarnings("unchecked")
 		ValueDeserializer<V> valueDeserializer = (ValueDeserializer<V>) ctxt.findContextualValueDeserializer(valueType, null);
 		LinkedHashMap<Identifier, V> result = new LinkedHashMap<>();
 		expect(START_ARRAY, p, ctxt);
@@ -608,7 +615,7 @@ public final class JacksonSerializer extends StateTreeSerializer {
 
 			V oldValue = result.put(entryID, value);
 			if (oldValue != null) {
-				return ctxt.reportInputMismatch(Object.class, "Duplicate sideTable entry '" + fieldName + "'");
+				return ctxt.reportInputMismatch(Object.class, "Duplicate entry '" + fieldName + "'");
 			}
 		}
 		return result;

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
@@ -27,6 +27,7 @@ import works.bosk.Bosk;
 import works.bosk.BoskConfig;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
+import works.bosk.Entity;
 import works.bosk.Identifier;
 import works.bosk.ListValue;
 import works.bosk.Listing;
@@ -139,6 +140,16 @@ class JacksonSerializerTest extends AbstractBoskTest {
 	private static Arguments catalogCase(String ...ids) {
 		return Arguments.of(asList(ids));
 	}
+
+	@Test
+	void catalogEntryKeyMismatch_throws() {
+		// The JSON member name is the catalog key, so it must agree with the entry's own id.
+		// Otherwise the entry would be silently re-keyed by its id, discarding the key.
+		String json = "[{\"w1\": {\"id\": \"w2\"}}]";
+		assertJsonException(json, Catalog.class, HasIdentifierOnly.class);
+	}
+
+	public record HasIdentifierOnly(Identifier id) implements Entity { }
 
 	@ParameterizedTest
 	@MethodSource("listingArguments")

--- a/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
+++ b/bosk-jackson/src/test/java/works/bosk/jackson/JacksonSerializerTest.java
@@ -24,6 +24,7 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.type.TypeFactory;
 import works.bosk.BindingEnvironment;
 import works.bosk.Bosk;
+import works.bosk.BoskConfig;
 import works.bosk.Catalog;
 import works.bosk.CatalogReference;
 import works.bosk.Identifier;
@@ -36,10 +37,14 @@ import works.bosk.Reference;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
 import works.bosk.TaggedUnion;
+import works.bosk.VariantCase;
 import works.bosk.annotations.DeserializationPath;
 import works.bosk.annotations.Polyfill;
 import works.bosk.annotations.ReferencePath;
+import works.bosk.annotations.Self;
+import works.bosk.annotations.VariantCaseMap;
 import works.bosk.exceptions.DeserializationException;
+import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.exceptions.MalformedPathException;
 import works.bosk.exceptions.ParameterUnboundException;
 import works.bosk.exceptions.UnexpectedPathException;
@@ -239,6 +244,39 @@ class JacksonSerializerTest extends AbstractBoskTest {
 	}
 
 	public record HasOptionalIdentifier(Optional<Identifier> optionalIdentifier) implements StateTreeNode { }
+
+	@Test
+	void variantCaseSelfReference_includesTagPath() throws Exception {
+		// A variant case lives at /variant/<tag>, so a @Self reference inside the case
+		// must resolve to the tag path, not the union field path.
+		Bosk<HasSelfVariant> variantBosk = new Bosk<>("variant", HasSelfVariant.class, this::initialHasSelfVariant, BoskConfig.<HasSelfVariant>builder().build());
+		JacksonSerializer serializer = new JacksonSerializer();
+		ObjectMapper mapper = JsonMapper.builder()
+			.addModule(serializer.moduleFor(variantBosk))
+			.build();
+
+		HasSelfVariant original = new HasSelfVariant(TaggedUnion.of(new SelfVariantCase(variantBosk.rootReference().then(SelfVariantCase.class, Path.parse("/variant/case1")), "hello")));
+		String json = mapper.writeValueAsString(original);
+		HasSelfVariant result;
+		try (var _ = serializer.newDeserializationScope(Path.empty())) {
+			result = mapper.readerFor(HasSelfVariant.class).readValue(json);
+		}
+		assertEquals(Path.parse("/variant/case1"), ((SelfVariantCase) result.variant().variant()).self().path());
+	}
+
+	private HasSelfVariant initialHasSelfVariant(Bosk<HasSelfVariant> bosk) throws InvalidTypeException {
+		return new HasSelfVariant(TaggedUnion.of(new SelfVariantCase(bosk.rootReference().then(SelfVariantCase.class, Path.parse("/variant/case1")), "hello")));
+	}
+
+	public record HasSelfVariant(TaggedUnion<SelfVariant> variant) implements StateTreeNode { }
+
+	public interface SelfVariant extends VariantCase {
+		@Override default String tag() { return "case1"; }
+		@VariantCaseMap
+		MapValue<Type> CASES = MapValue.singleton("case1", SelfVariantCase.class);
+	}
+
+	public record SelfVariantCase(@Self Reference<SelfVariantCase> self, String stringField) implements SelfVariant { }
 
 	@Test
 	void missingRequiredField_throwsWithCause() {

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/BsonSerializer.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/BsonSerializer.java
@@ -506,7 +506,10 @@ public final class BsonSerializer extends StateTreeSerializer {
 						+ ">; expected one of " + variantCaseMap.keySet());
 				}
 				Class<? extends V> caseDynamicClass = (Class<? extends V>) rawClass(variantCaseMap.get(tag));
-				TaggedUnion<V> result = TaggedUnion.of(caseDynamicClass.cast(caseCodec.decode(reader, decoderContext)));
+				TaggedUnion<V> result;
+				try (DeserializationScope scope = variantCaseDeserializationScope(tag)) {
+					result = TaggedUnion.of(caseDynamicClass.cast(caseCodec.decode(reader, decoderContext)));
+				}
 				if (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
 					throw new IllegalStateException("Input has two tags for the same TaggedUnion: \"" + tag + "\" and \"" + reader.readName() + "\"");
 				}

--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonSerializerTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/BsonSerializerTest.java
@@ -22,8 +22,13 @@ import works.bosk.Entity;
 import works.bosk.Identifier;
 import works.bosk.MapValue;
 import works.bosk.Path;
+import works.bosk.Reference;
 import works.bosk.SideTable;
 import works.bosk.StateTreeNode;
+import works.bosk.TaggedUnion;
+import works.bosk.VariantCase;
+import works.bosk.annotations.Self;
+import works.bosk.annotations.VariantCaseMap;
 import works.bosk.exceptions.InvalidTypeException;
 import works.bosk.util.Types;
 
@@ -80,6 +85,24 @@ class BsonSerializerTest {
 		}
 	}
 
+	@Test
+	void variantCaseSelfReference_includesTagPath() throws InvalidTypeException {
+		BsonSerializer bp = new BsonSerializer();
+		Bosk<VariantRoot> bosk = new Bosk<VariantRoot>(boskName(), VariantRoot.class, this::initialVariantRoot, BoskConfig.simple());
+		CodecRegistry registry = CodecRegistries.fromProviders(bp.codecProviderFor(bosk), new ValueCodecProvider());
+		Codec<VariantRoot> codec = registry.get(VariantRoot.class);
+
+		VariantRoot original = initialVariantRoot(bosk);
+		BsonDocument document = new BsonDocument();
+		codec.encode(new BsonDocumentWriter(document), original, EncoderContext.builder().build());
+		VariantRoot decoded = codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+		assertEquals(Path.parse("/variant/case1"), ((VariantCase1) decoded.variant().variant()).self().path());
+	}
+
+	private VariantRoot initialVariantRoot(Bosk<VariantRoot> bosk) throws InvalidTypeException {
+		return new VariantRoot(TaggedUnion.of(new VariantCase1(bosk.rootReference().then(VariantCase1.class, Path.parse("/variant/case1")), "hello")));
+	}
+
 	private Root initialState(Bosk<Root> bosk) throws InvalidTypeException {
 		CatalogReference<Item> catalogRef = bosk.rootReference().thenCatalog(Item.class, Path.just(Root.Fields.items));
 		return new Root(
@@ -97,5 +120,15 @@ class BsonSerializerTest {
 	public record Item(
 		Identifier id
 	) implements Entity { }
+
+	public record VariantRoot(TaggedUnion<Variant> variant) implements StateTreeNode { }
+
+	public interface Variant extends VariantCase {
+		@Override default String tag() { return "case1"; }
+		@VariantCaseMap
+		MapValue<Type> CASES = MapValue.singleton("case1", VariantCase1.class);
+	}
+
+	public record VariantCase1(@Self Reference<VariantCase1> self, String stringField) implements Variant { }
 
 }


### PR DESCRIPTION
Fixes #404: validate that the JSON member name for a `Catalog` entry matches the ID of the entity.
Fixes #394: fix the `DeserializationScope` inside a variant case to include the tag.