### PR TITLE
Register only the most-derived override of each @Hook method

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Bosk.java
+++ b/bosk-core/src/main/java/works/bosk/Bosk.java
@@ -762,6 +762,7 @@ public class Bosk<R extends StateTreeNode> implements BoskInfo<R> {
 	 *
 	 * Hook methods must not be static or private, but they can be package-private.
 	 * Inherited methods are included in the scan.
+	 * If a subclass overrides a hook method, only the most-derived override is registered.
 	 * <p>
 	 * The Hook class must have no methods inaccessible to the given {@code lookup}.
 	 * Such methods interfere with our ability to validate that the hook methods are well-formed.

--- a/bosk-core/src/main/java/works/bosk/HookScanner.java
+++ b/bosk-core/src/main/java/works/bosk/HookScanner.java
@@ -6,7 +6,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +21,7 @@ import static java.lang.reflect.Modifier.isStatic;
 
 /**
  * Finds methods annotated with {@link Hook} in the given {@code object} and registers them in the given {@link Bosk}.
+ * If a subclass overrides a hook method, only the most-derived override is registered.
  */
 final class HookScanner {
 	static <T> void registerHooks(T receiverObject, RootReference<?> rootReference, HookRegistrar hookRegistrar, MethodHandles.Lookup lookup) throws InvalidTypeException {
@@ -26,7 +29,9 @@ final class HookScanner {
 		for (Class<?> receiverClass = receiverObject.getClass(); receiverClass != Object.class; receiverClass = receiverClass.getSuperclass()) {
 			bottomUpHierarchy.add(receiverClass);
 		}
-		int hookCounter = 0;
+		// Collect hook methods from all classes in the hierarchy. If a subclass overrides a hook method,
+		// the override replaces the original, so only the most-derived version of each signature is registered.
+		Map<MethodSignature, HookMethod> hookMethodsBySignature = new LinkedHashMap<>();
 		for (Class<?> receiverClass: bottomUpHierarchy.reversed()) {
 			List<Method> methods;
 			try {
@@ -44,13 +49,16 @@ final class HookScanner {
 				} else if (isPrivate(method.getModifiers())) {
 					throw new InvalidTypeException("Hook method cannot be private: " + method);
 				}
-
-				try {
-					registerOneHookMethod(receiverObject, method, Path.parseParameterized(hookAnnotation.value()), rootReference, hookRegistrar, lookup);
-					hookCounter++;
-				} catch (InvalidTypeException e) {
-					throw new InvalidTypeException("Unable to register hook method " + receiverClass.getSimpleName() + "." + method.getName() + ": " + e.getMessage(), e);
-				}
+				hookMethodsBySignature.put(MethodSignature.of(method), new HookMethod(receiverClass, method, hookAnnotation.value()));
+			}
+		}
+		int hookCounter = 0;
+		for (HookMethod hookMethod : hookMethodsBySignature.values()) {
+			try {
+				registerOneHookMethod(receiverObject, hookMethod.method, Path.parseParameterized(hookMethod.scope), rootReference, hookRegistrar, lookup);
+				hookCounter++;
+			} catch (InvalidTypeException e) {
+				throw new InvalidTypeException("Unable to register hook method " + hookMethod.receiverClass.getSimpleName() + "." + hookMethod.method.getName() + ": " + e.getMessage(), e);
 			}
 		}
 		if (hookCounter == 0) {
@@ -116,6 +124,14 @@ final class HookScanner {
 	}
 
 	private HookScanner() {}
+
+	private record HookMethod(Class<?> receiverClass, Method method, String scope) { }
+
+	private record MethodSignature(String name, List<Class<?>> parameterTypes) {
+		static MethodSignature of(Method method) {
+			return new MethodSignature(method.getName(), List.of(method.getParameterTypes()));
+		}
+	}
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(HookScanner.class);
 }

--- a/bosk-core/src/test/java/works/bosk/HookScannerTest.java
+++ b/bosk-core/src/test/java/works/bosk/HookScannerTest.java
@@ -94,6 +94,44 @@ class HookScannerTest {
 	}
 
 	@Test
+	void overriddenHookMethod_firesOnlyOnce() throws InvalidTypeException {
+		List<String> strings = new ArrayList<>();
+		class ParentHooks {
+			@Hook("/string") void stringChanged(Reference<String> ref) {
+				strings.add("parent");
+			}
+		}
+		class ChildHooks extends ParentHooks {
+			@Override
+			@Hook("/string") void stringChanged(Reference<String> ref) {
+				strings.add("child");
+			}
+		}
+		HookScanner.registerHooks(new ChildHooks(), bosk.rootReference(), bosk.hookRegistrar(), MethodHandles.lookup());
+
+		assertEquals(List.of("child"), strings);
+	}
+
+	@Test
+	void overriddenHookMethodWithoutAnnotation_stillFiresOnlyOnce() throws InvalidTypeException {
+		List<String> strings = new ArrayList<>();
+		class ParentHooks {
+			@Hook("/string") void stringChanged(Reference<String> ref) {
+				strings.add("parent");
+			}
+		}
+		class ChildHooks extends ParentHooks {
+			@Override
+			void stringChanged(Reference<String> ref) {
+				strings.add("child");
+			}
+		}
+		HookScanner.registerHooks(new ChildHooks(), bosk.rootReference(), bosk.hookRegistrar(), MethodHandles.lookup());
+
+		assertEquals(List.of("child"), strings);
+	}
+
+	@Test
 	void objectParameter_throws() {
 		class Hooks {
 			@Hook("/string") void stringChanged(Object o) { }


### PR DESCRIPTION
A hook method overridden and re-annotated in a subclass was registered alongside its parent, so the hook fired twice on every matching update. Now the hook methods are collected from the whole hierarchy and keyed by signature, so an override replaces the method it overrides.

Fixes #399.