### PR TITLE
Fix MapValue.equals

### DIFF
--- a/bosk-core/src/main/java/works/bosk/BoskDriver.java
+++ b/bosk-core/src/main/java/works/bosk/BoskDriver.java
@@ -142,6 +142,8 @@ public interface BoskDriver {
 	 * unless its strong semantics are required.
 	 * For "stackable layer" drivers, this usually means they should not call this except
 	 * to implement their own <code>flush</code> method.
+	 * Implementations should try hard to deliver the latest state, and throw
+	 * {@link FlushFailureException} only after those attempts fail, such as when timeouts have elapsed.
 	 *
 	 * <p>
 	 * This usually should not throw runtime exceptions: those can be wrapped as {@link FlushFailureException}.

--- a/bosk-core/src/main/java/works/bosk/MapValue.java
+++ b/bosk-core/src/main/java/works/bosk/MapValue.java
@@ -148,11 +148,17 @@ public final class MapValue<V> implements Map<String, V> {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass()) {
+		if (this == o) {
+			return true;
+		} else if (o instanceof MapValue<?> mapValue) {
+			return contents.equals(mapValue.contents);
+		} else if (o instanceof Map<?, ?> that) {
+			// OrderedPMap inherits AbstractMap.equals, which compares by contents
+			// and is symmetric with any Map implementation, as the Map contract requires.
+			return contents.equals(that);
+		} else {
 			return false;
 		}
-		MapValue<?> mapValue = (MapValue<?>) o;
-		return Objects.equals(contents, mapValue.contents);
 	}
 
 	@Override

--- a/bosk-core/src/test/java/works/bosk/MapValueTest.java
+++ b/bosk-core/src/test/java/works/bosk/MapValueTest.java
@@ -105,6 +105,13 @@ class MapValueTest extends AbstractBoskTest {
 
 	@ParameterizedTest
 	@MethodSource("mapArguments")
+	<V> void testEquals_symmetricWithPlainMap(Map<String,V> map, MapValue<V> mapValue, V sampleValue) {
+		assertEquals(map, mapValue);
+		assertEquals(mapValue, map);
+	}
+
+	@ParameterizedTest
+	@MethodSource("mapArguments")
 	<V> void testHashCode(Map<String,V> map, MapValue<V> mapValue, V sampleValue) {
 		try {
 			int expected = MapValue.copyOf(map).hashCode();


### PR DESCRIPTION
It didn't implement the required symmetry property.

Fixes #395 