### PR TITLE
Make Identifier.unique validate its prefix

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Identifier.java
+++ b/bosk-core/src/main/java/works/bosk/Identifier.java
@@ -18,11 +18,7 @@ public final class Identifier {
 
 	// TODO: Intern these.  No need to have several Identifier objects for the same value
 	public static Identifier from(String value) {
-		if (value.isEmpty()) {
-			throw new IllegalArgumentException("Identifier can't be empty");
-		} else if (value.startsWith("-") || value.endsWith("-")) {
-			throw new IllegalArgumentException("Identifier can't start or end with a hyphen");
-		}
+		validate(value);
 		// TODO: We probably ought to outlaw some characters like NUL (\u0000) but
 		//  that's O(n) in the length of the string, so it's not clear that's worth the overhead.
 		return new Identifier(value);
@@ -32,7 +28,16 @@ public final class Identifier {
 	 * I'm going to regret adding this.
 	 */
 	public static Identifier unique(String prefix) {
+		validate(prefix);
 		return new Identifier(prefix + (uniqueIdCounter.incrementAndGet()));
+	}
+
+	private static void validate(String value) {
+		if (value.isEmpty()) {
+			throw new IllegalArgumentException("Identifier can't be empty");
+		} else if (value.startsWith("-") || value.endsWith("-")) {
+			throw new IllegalArgumentException("Identifier can't start or end with a hyphen");
+		}
 	}
 
 	private static final AtomicLong uniqueIdCounter = new AtomicLong(1000);

--- a/bosk-core/src/test/java/works/bosk/IdentifierTest.java
+++ b/bosk-core/src/test/java/works/bosk/IdentifierTest.java
@@ -12,6 +12,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @InjectFrom({IdentifierTest.ValidInjector.class, IdentifierTest.InvalidInjector.class})
 class IdentifierTest {
@@ -24,6 +25,18 @@ class IdentifierTest {
 	@InjectedTest
 	void invalidString_throws(@Invalid String invalidString) {
 		assertThrows(IllegalArgumentException.class, () -> Identifier.from(invalidString));
+	}
+
+	@InjectedTest
+	void unique_withValidPrefix_survivesRoundTrip(String validPrefix) {
+		Identifier id = Identifier.unique(validPrefix);
+		assertEquals(id, Identifier.from(id.toString()));
+		assertTrue(id.toString().startsWith(validPrefix));
+	}
+
+	@InjectedTest
+	void unique_withInvalidPrefix_throws(@Invalid String invalidPrefix) {
+		assertThrows(IllegalArgumentException.class, () -> Identifier.unique(invalidPrefix));
 	}
 
 	@Retention(RUNTIME)
@@ -54,6 +67,7 @@ class IdentifierTest {
 		public List<String> values() {
 			return List.of(
 				"",
+				"-",
 				"-startsWithDash",
 				"endsWithDash-",
 				"-startsAndEndsWithDash-"


### PR DESCRIPTION
Fixes #391

`Identifier.unique(prefix)` bypassed the validation `Identifier.from` enforces, so prefixes like "-" produced identifiers that corrupt path segments. It now validates the prefix via a shared helper and throws `IllegalArgumentException` on invalid input.