### PR TITLE
Prevent lost updates in SqlDriverImpl

### DIFF
--- a/bosk-sql/src/main/java/module-info.java
+++ b/bosk-sql/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module works.bosk.sql {
 	requires org.slf4j;
 	requires transitive works.bosk.core;
 	requires works.bosk.jackson;
+	requires static lombok;
 	requires static transitive org.jspecify;
 
 	exports works.bosk.drivers.sql;

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
@@ -79,9 +79,25 @@ class SqlDriverImpl implements SqlDriver {
 
 	private final ScheduledExecutorService listener;
 
+	/**
+	 * Records the value of {@link #TEST_PROBES} as it was
+	 * at the time of the constructor call.
+	 */
+	final TestProbes testProbes = TEST_PROBES.get();
+
 	private volatile String epoch;
 
 	private final AtomicLong lastChangeSubmittedDownstream = new AtomicLong(-1);
+
+	/**
+	 * Allows tests to install test probes controlling the driver's internals.
+	 * <p>
+	 * This works because {@code SqlDriverImpl} is instantiated on the same
+	 * thread as the {@code Bosk}: the probes are read here and captured at
+	 * construction, so they apply to every thread that later does database
+	 * work. See {@link TestProbes}.
+	 */
+	static final ThreadLocal<TestProbes> TEST_PROBES = ThreadLocal.withInitial(TestProbes::noop);
 
 	SqlDriverImpl(
 		SqlDriverSettings settings,
@@ -517,6 +533,7 @@ class SqlDriverImpl implements SqlDriver {
 		} catch (RuntimeException e) {
 			throw new IllegalStateException("Unexpected error reading state from database", e);
 		}
+		testProbes.afterStateRead().run();
 		try {
 			return mapper.readTree(json);
 		} catch (JacksonException e) {

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/SqlDriverImpl.java
@@ -528,6 +528,7 @@ class SqlDriverImpl implements SqlDriver {
 			json = using(connection)
 				.select(STATE)
 				.from(BOSK)
+				.forUpdate() // Lock the state row until commit so concurrent submissions serialize on it
 				.fetchOptional(STATE)
 				.orElseThrow(() -> new NotYetImplementedException("No state found"));
 		} catch (RuntimeException e) {

--- a/bosk-sql/src/main/java/works/bosk/drivers/sql/TestProbes.java
+++ b/bosk-sql/src/main/java/works/bosk/drivers/sql/TestProbes.java
@@ -1,0 +1,34 @@
+package works.bosk.drivers.sql;
+
+import lombok.With;
+
+/**
+ * Test probes: the test-only facilities that {@link SqlDriverImpl} consults at
+ * well-defined points, so tests can deterministically coordinate with the
+ * driver's internals.
+ * <p>
+ * All probes are no-ops by default; tests install the probes they need by
+ * starting from {@link #noop()} and using the {@code with} methods. The probes
+ * are read from {@link SqlDriverImpl#TEST_PROBES} on the thread that constructs
+ * the {@code SqlDriverImpl}, and are captured at construction time, so they
+ * apply to every thread that later does database work.
+ * <p>
+ * The probes are:
+ * <ul>
+ * <li>{@code afterStateRead}: runs after {@code SqlDriverImpl} reads the state
+ * row inside a submit operation, before it writes back. Tests can use it to
+ * block a thread between its read and its write, keeping the database
+ * transaction open, to force a specific interleaving of concurrent
+ * submissions.</li>
+ * </ul>
+ */
+@With
+record TestProbes(
+	Runnable afterStateRead
+) {
+	static TestProbes noop() {
+		return new TestProbes(NOOP);
+	}
+
+	private static final Runnable NOOP = () -> {};
+}

--- a/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConcurrencyTest.java
+++ b/bosk-sql/src/test/java/works/bosk/drivers/sql/SqlDriverConcurrencyTest.java
@@ -1,0 +1,231 @@
+package works.bosk.drivers.sql;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import works.bosk.Bosk;
+import works.bosk.BoskConfig;
+import works.bosk.DriverFactory;
+import works.bosk.Identifier;
+import works.bosk.Path;
+import works.bosk.Reference;
+import works.bosk.annotations.ReferencePath;
+import works.bosk.drivers.sql.SqlTestService.Database;
+import works.bosk.drivers.sql.schema.Schema;
+import works.bosk.exceptions.InvalidTypeException;
+import works.bosk.junit.InjectFields;
+import works.bosk.junit.InjectFrom;
+import works.bosk.junit.Injected;
+import works.bosk.testing.drivers.state.TestEntity;
+import works.bosk.testing.drivers.state.TestEntity.Fields;
+import works.bosk.testing.drivers.state.TestValues;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static works.bosk.drivers.sql.SqlTestService.sqlDriverFactory;
+import static works.bosk.testing.BoskTestUtils.boskName;
+
+/**
+ * Tests that concurrent {@code submit*} operations on two {@link SqlDriver}s
+ * sharing one database don't lose updates. The driver implements each submit as
+ * a read-modify-write of the {@code BOSK.STATE} row, so without row locking two
+ * concurrent submissions can each read the same state and the later write
+ * silently discards the earlier one.
+ * <p>
+ * The test coordinates the two submissions with the {@link TestProbes} probes so
+ * that the interleaving is deterministic: the first submission reads the state
+ * row and is then paused (holding the row lock, once the fix is in place)
+ * before it writes; the second submission is started while the first is paused.
+ * <p>
+ * Without {@code SELECT ... FOR UPDATE}, the second submission's read completes
+ * immediately, so it too is based on the initial state and one of the two
+ * updates is lost. With the lock, the second submission's read blocks until the
+ * first commits, so it reads the first's update and applies its own on top.
+ * The test waits a bounded time for the second read to complete, because the
+ * two cases cannot be told apart in any other way: waiting indefinitely for the
+ * second read would deadlock once the fix makes that read block behind the
+ * paused first submission.
+ */
+@Testcontainers
+@InjectFields
+@InjectFrom({DatabaseInjector.class})
+class SqlDriverConcurrencyTest {
+	@Injected Database database;
+
+	private final Deque<Runnable> tearDownActions = new ArrayDeque<>();
+	private final AtomicInteger dbCounter = new AtomicInteger(0);
+	private SqlDriverSettings settings;
+	private HikariDataSource dataSource;
+
+	@BeforeEach
+	void setupDriverFactory() {
+		settings = new SqlDriverSettings(50, 100);
+		String databaseName = SqlDriverConcurrencyTest.class.getSimpleName()
+			+ dbCounter.incrementAndGet();
+		dataSource = database.dataSourceFor(databaseName);
+	}
+
+	@AfterEach
+	void runTearDown() throws SQLException {
+		SqlDriverImpl.TEST_PROBES.remove();
+		tearDownActions.forEach(Runnable::run);
+		try (
+			var c = dataSource.getConnection()
+		) {
+			new Schema().dropTables(c);
+		}
+	}
+
+	@Test
+	void concurrentSubmissionsToDistinctNodes_mustNotLoseUpdates() throws InvalidTypeException, IOException {
+		CountDownLatch firstReadDone = new CountDownLatch(1);
+		CountDownLatch firstRelease = new CountDownLatch(1);
+		CountDownLatch secondReadDone = new CountDownLatch(1);
+		CountDownLatch secondRelease = new CountDownLatch(1);
+
+		// The drivers are built when the Bosks are constructed, on this thread,
+		// so each captures the hooks appropriate to it.
+		SqlDriverImpl.TEST_PROBES.set(TestProbes.noop()
+			.withAfterStateRead(() -> {
+				firstReadDone.countDown();
+				await(firstRelease, Duration.ofSeconds(30));
+			}));
+		Bosk<TestEntity> firstBosk = createBosk("first");
+		SqlDriverImpl.TEST_PROBES.set(TestProbes.noop()
+			.withAfterStateRead(() -> {
+				secondReadDone.countDown();
+				await(secondRelease, Duration.ofSeconds(30));
+			}));
+		Bosk<TestEntity> secondBosk = createBosk("second");
+		SqlDriverImpl.TEST_PROBES.remove();
+
+		Refs firstRefs = firstBosk.buildReferences(Refs.class);
+		Refs secondRefs = secondBosk.buildReferences(Refs.class);
+
+		// First submission: reads the state, then pauses before writing.
+		Submission first = Submission.start(firstBosk, () -> firstBosk.driver().submitReplacement(firstRefs.string(), "first write"));
+		await(firstReadDone, Duration.ofSeconds(30));
+
+		// Second submission: started while the first is paused. Without row
+		// locking its read completes immediately (seeing the same initial state);
+		// with SELECT ... FOR UPDATE it blocks until the first submission commits.
+		Submission second = Submission.start(secondBosk, () -> secondBosk.driver().submitReplacement(secondRefs.valuesString(), "second write"));
+		boolean secondReadWhileFirstPaused = tryAwait(secondReadDone, Duration.ofSeconds(5));
+
+		// Let the first submission write and commit.
+		firstRelease.countDown();
+		join(first.thread());
+
+		// If the second submission's read was blocked, it can proceed now.
+		if (!secondReadWhileFirstPaused) {
+			await(secondReadDone, Duration.ofSeconds(30));
+		}
+		secondRelease.countDown();
+		join(second.thread());
+
+		assertNoError(first.error());
+		assertNoError(second.error());
+
+		// The in-memory state of firstBosk and secondBosk is updated by their
+		// listeners asynchronously, so verify the database contents directly.
+		Bosk<TestEntity> checkBosk = createBosk("check");
+		Refs checkRefs = checkBosk.buildReferences(Refs.class);
+		try (var _ = checkBosk.readSession()) {
+			assertEquals("first write", checkRefs.string().value());
+			assertEquals("second write", checkRefs.valuesString().value());
+		}
+	}
+
+	public interface Refs {
+		@ReferencePath("/string") Reference<String> string();
+		@ReferencePath("/values/string") Reference<String> valuesString();
+	}
+
+	private TestEntity initialState(Bosk<TestEntity> bosk) throws InvalidTypeException {
+		return TestEntity.empty(Identifier.from("root"), bosk.rootReference().thenCatalog(TestEntity.class, Path.just(Fields.catalog)))
+			.withValues(Optional.of(TestValues.blank()));
+	}
+
+	private Bosk<TestEntity> createBosk(String prefix) {
+		return new Bosk<>(
+			boskName(prefix),
+			TestEntity.class,
+			this::initialState,
+			BoskConfig.<TestEntity>builder()
+				.driverFactory(driverFactory())
+				.build());
+	}
+
+	private DriverFactory<TestEntity> driverFactory() {
+		return (boskInfo, downstream) -> {
+			var driver = sqlDriverFactory(settings, dataSource).build(boskInfo, downstream);
+			tearDownActions.addFirst(driver::close);
+			return driver;
+		};
+	}
+
+	private record Submission(Thread thread, AtomicReference<Throwable> error) {
+		static Submission start(Bosk<TestEntity> bosk, Runnable submit) {
+			AtomicReference<Throwable> error = new AtomicReference<>();
+			Thread thread = new Thread(() -> {
+				try {
+					submit.run();
+				} catch (Throwable e) {
+					error.set(e);
+				}
+			}, "submitter for " + bosk.name());
+			thread.start();
+			return new Submission(thread, error);
+		}
+	}
+
+	private static void await(CountDownLatch latch, Duration timeout) {
+		try {
+			if (!latch.await(timeout.toMillis(), MILLISECONDS)) {
+				throw new AssertionError("Timed out waiting for coordination signal");
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new AssertionError("Interrupted while waiting for coordination signal", e);
+		}
+	}
+
+	private static boolean tryAwait(CountDownLatch latch, Duration timeout) {
+		try {
+			return latch.await(timeout.toMillis(), MILLISECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new AssertionError("Interrupted while waiting for coordination signal", e);
+		}
+	}
+
+	private static void join(Thread thread) {
+		try {
+			thread.join(SECONDS.toMillis(60));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new AssertionError("Interrupted while waiting for " + thread.getName(), e);
+		}
+		if (thread.isAlive()) {
+			throw new AssertionError(thread.getName() + " should have finished");
+		}
+	}
+
+	private static void assertNoError(AtomicReference<Throwable> error) {
+		if (error.get() != null) {
+			throw new AssertionError("Submission failed", error.get());
+		}
+	}
+}


### PR DESCRIPTION
Fixes #397

SqlDriverImpl's submit operations read, mutate, and rewrite the state row with no locking, so concurrent submissions can silently overwrite each other. The state read now uses SELECT ... FOR UPDATE to serialize writers, with a deterministic concurrency test.