### PR TITLE
Misc diagnostics and documentation fixes

### DIFF
--- a/bosk-core/src/main/java/works/bosk/Path.java
+++ b/bosk-core/src/main/java/works/bosk/Path.java
@@ -57,13 +57,14 @@ public abstract class Path implements Iterable<String> {
 	 * @param urlEncoded A string representation of the path with the segments
 	 * URLEncoded and separated by slashes.
 	 *
-	 * @return A Path with one segment for each (possibly empty) string before,
-	 * between, and after the slashes.  As a special case, for a blank string,
-	 * we return {@link Path#empty()}.  (Otherwise, a blank string would refer
-	 * to the illegal path with a single blank segment.)
+	 * @return A Path with one segment for each string before, between, and
+	 * after the slashes, for a string that begins with a slash.  As a special
+	 * case, the single slash {@code "/"} denotes the empty path.  Any string
+	 * that does not begin with a slash, including a blank string, is invalid.
 	 *
-	 * @throws MalformedPathException if the given string contains any
-	 * segments that are invalid according to {@link #validParsedSegment(String)}.
+	 * @throws MalformedPathException if the given string does not begin with
+	 * a slash, or if it contains any segments that are invalid according to
+	 * {@link #validParsedSegment(String)}.
 	 */
 	public static Path parse(String urlEncoded) {
 		return parseAndValidateSegments(urlEncoded, Path::validParsedSegment);

--- a/bosk-core/src/main/java/works/bosk/TypeValidation.java
+++ b/bosk-core/src/main/java/works/bosk/TypeValidation.java
@@ -86,13 +86,13 @@ public final class TypeValidation {
 				Class<?> entryClass = rawClass(entryType);
 				// Exclude specific anti-patterns
 				if (Optional.class.isAssignableFrom(entryClass)) {
-					throw new InvalidTypeException("Optional is not allowed in a " + ListValue.class.getSimpleName());
+					throw new InvalidTypeException("Optional is not allowed in a " + genericClass.getSimpleName());
 				} else if (Phantom.class.isAssignableFrom(entryClass)) {
-					throw new InvalidTypeException("Phantom is not allowed in a " + ListValue.class.getSimpleName());
+					throw new InvalidTypeException("Phantom is not allowed in a " + genericClass.getSimpleName());
 				} else if (Entity.class.isAssignableFrom(entryClass)) {
-					throw new InvalidTypeException(entryClass.getSimpleName() + " Entity is not allowed in a " + ListValue.class.getSimpleName() + "; use Catalog");
+					throw new InvalidTypeException(entryClass.getSimpleName() + " Entity is not allowed in a " + genericClass.getSimpleName() + "; use Catalog");
 				} else if (Identifier.class.isAssignableFrom(entryClass) || Reference.class.isAssignableFrom(entryClass)) {
-					throw new InvalidTypeException(entryClass.getSimpleName() + " is not allowed in a " + ListValue.class.getSimpleName() + "; use Listing");
+					throw new InvalidTypeException(entryClass.getSimpleName() + " is not allowed in a " + genericClass.getSimpleName() + "; use Listing");
 				}
 				// Otherwise, any valid entryType is ok
 				validateType(entryType, alreadyValidated);

--- a/bosk-core/src/main/java/works/bosk/bytecode/ClassBuilder.java
+++ b/bosk-core/src/main/java/works/bosk/bytecode/ClassBuilder.java
@@ -168,8 +168,14 @@ public final class ClassBuilder<T> {
 	}
 
 	/**
-	 * @return a {@link LocalVariable} representing a reference parameter at the
-	 * given position, which is zero-based. Assumes all parameters are single-slot types.
+	 * @param index the JVM local-variable slot for the desired parameter.
+	 * For instance methods, slot 0 is the receiver ({@code this}), so the
+	 * first parameter is at slot 1. This method assumes all parameters are
+	 * single-slot types; it does not account for {@code long} or
+	 * {@code double} parameters, which occupy two slots.
+	 *
+	 * @return a {@link LocalVariable} representing the reference-typed
+	 * parameter at the given slot.
 	 */
 	public LocalVariable parameter(int index) {
 		if (0 <= index && index < currentMethod.numParameters) {

--- a/bosk-core/src/test/java/works/bosk/TypeValidationTest.java
+++ b/bosk-core/src/test/java/works/bosk/TypeValidationTest.java
@@ -70,6 +70,10 @@ class TypeValidationTest {
 		ListValueSubclassWithMutableField.class,
 		ListValueSubclassWithTwoConstructors.class,
 		ListValueSubclassWithWrongConstructor.class,
+		MapValueOfEntity.class,
+		MapValueOfIdentifier.class,
+		MapValueOfOptional.class,
+		MapValueOfReference.class,
 		ParameterizedFieldRoot.class,
 		ReferenceToReference.class,
 		SelfNonReference.class,
@@ -450,6 +454,50 @@ class TypeValidationTest {
 	) implements Entity {
 		public static void testException(InvalidTypeException e) {
 			assertThat(e.getMessage(), containsString("ListValueOfOptional.badField"));
+		}
+	}
+
+	public record MapValueOfIdentifier(
+		Identifier id,
+		MapValue<Identifier> badField
+	) implements Entity {
+		public static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsString("MapValueOfIdentifier.badField"));
+			assertThat(e.getMessage(), containsString("MapValue"));
+			assertThat(e.getMessage(), not(containsString("ListValue")));
+		}
+	}
+
+	public record MapValueOfReference(
+		Identifier id,
+		MapValue<Reference<String>> badField
+	) implements Entity {
+		public static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsString("MapValueOfReference.badField"));
+			assertThat(e.getMessage(), containsString("MapValue"));
+			assertThat(e.getMessage(), not(containsString("ListValue")));
+		}
+	}
+
+	public record MapValueOfEntity(
+		Identifier id,
+		MapValue<SimpleTypes> badField
+	) implements Entity {
+		public static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsString("MapValueOfEntity.badField"));
+			assertThat(e.getMessage(), containsString("MapValue"));
+			assertThat(e.getMessage(), not(containsString("ListValue")));
+		}
+	}
+
+	public record MapValueOfOptional(
+		Identifier id,
+		MapValue<Optional<SimpleTypes>> badField
+	) implements Entity {
+		public static void testException(InvalidTypeException e) {
+			assertThat(e.getMessage(), containsString("MapValueOfOptional.badField"));
+			assertThat(e.getMessage(), containsString("MapValue"));
+			assertThat(e.getMessage(), not(containsString("ListValue")));
 		}
 	}
 

--- a/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
+++ b/bosk-mongo/src/main/java/works/bosk/drivers/mongo/internal/MainDriver.java
@@ -744,6 +744,7 @@ public final class MainDriver<R extends StateTreeNode> implements MongoDriver {
 			Object[] argsWithContext = new Object[args.length + 2];
 			System.arraycopy(args, 0, argsWithContext, 0, args.length);
 			argsWithContext[args.length] = boskInfo.name();
+			argsWithContext[args.length + 1] = boskInfo.instanceID();
 			LOGGER.debug(description + " w/{}@{}", argsWithContext);
 		}
 		if (driverSettings.testing().eventDelayMS() < 0) {


### PR DESCRIPTION
Fixes #398
Fixes #401
Fixes #402
Fixes #403

Four small diagnostics/doc defects: the Mongo debug log dropped the instance ID, the Path.parse javadoc contradicted its behavior, TypeValidation messages hardcoded "ListValue" for MapValue containers, and ClassBuilder.parameter's javadoc said zero-based when indexing is slot-based. Each is fixed as its own commit.