### PR TITLE
Suppress expected disconnect warnings in the reconnect flush test

### DIFF
--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -1402,15 +1402,18 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 		MongoDriverSettings longTimescaleSettings = driverSettings.toBuilder()
 			.timescaleMS(10 * SHORT_TIMESCALE)
 			.build();
-		DriverFactory<TestEntity> longTimescaleFactory = (b, d) -> {
-			var driver = MongoDriver.<TestEntity>factory(
-				mongoService.clientSettings(testInfo),
-				longTimescaleSettings,
-				new BsonSerializer()
-			).build(b, d);
-			tearDownActions.addFirst(driver::close);
-			return driver;
-		};
+		DriverFactory<TestEntity> longTimescaleFactory = DriverStack.of(
+			BoskLogFilter.withController(logController),
+			(b, d) -> {
+				var driver = MongoDriver.<TestEntity>factory(
+					mongoService.clientSettings(testInfo),
+					longTimescaleSettings,
+					new BsonSerializer()
+				).build(b, d);
+				tearDownActions.addFirst(driver::close);
+				return driver;
+			}
+		);
 
 		AtomicBoolean initializationDone = new AtomicBoolean(false);
 		AtomicBoolean armed = new AtomicBoolean(false);


### PR DESCRIPTION
Follow-up to #417: the `flush_duringReconnect_waitsForFreshState` test built its bosk with a custom driver factory that omitted `BoskLogFilter.withController`, so the forced-disconnect `ChangeReceiver` WARN leaked into test output despite the `setLogging(ERROR, ...)` call. Wrapping the factory in the `BoskLogFilter` layer (as the sibling custom-factory tests do) makes the suppression take effect.