### PR TITLE
Fix the reconnect-count race in recoveredDriver_survivesStaleDisconnect

### DIFF
--- a/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
+++ b/bosk-mongo/src/test/java/works/bosk/drivers/mongo/internal/MongoDriverSpecialTest.java
@@ -1181,8 +1181,8 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 
 		setLogging(ERROR, ChangeReceiver.class, MainDriver.class);
 
-		AtomicBoolean initializationDone = new AtomicBoolean(false);
 		AtomicBoolean armed = new AtomicBoolean(false);
+		AtomicInteger connectCount = new AtomicInteger();
 		AtomicInteger reconnects = new AtomicInteger();
 		CountDownLatch reconnected = new CountDownLatch(1);
 
@@ -1201,7 +1201,10 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 				@Override
 				public void onConnectionSucceeded() throws UnrecognizedFormatException, FailedMongoClientSessionException, InterruptedException, IOException, TimeoutException, InvalidCollectionContentsException, InitialStateException {
 					super.onConnectionSucceeded();
-					if (initializationDone.get()) {
+					// The first connection is the initial one; only subsequent connections are reconnects.
+					// We can't tell them apart using a flag set by the main thread, because this
+					// callback runs on the ChangeReceiver thread and races with the flag being set.
+					if (connectCount.incrementAndGet() > 1) {
 						LOGGER.debug("onConnectionSucceeded after initialization; count = {}", reconnects.incrementAndGet());
 						reconnected.countDown();
 					}
@@ -1236,7 +1239,6 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 				AbstractMongoDriverTest::initialState,
 				BoskConfig.<TestEntity>builder().driverFactory(driverFactory).build());
 			Refs refs = bosk.buildReferences(Refs.class);
-			initializationDone.set(true);
 
 			// Fail the operation only after the receiver has recovered from the disconnect
 			// that the interceptor forces. The stale failure must not cause another reconnect.
@@ -1283,8 +1285,8 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 				).build(info, downstream)
 		);
 
-		AtomicBoolean initializationDone = new AtomicBoolean(false);
 		AtomicBoolean armed = new AtomicBoolean(false);
+		AtomicInteger connectCount = new AtomicInteger();
 		AtomicInteger reconnects = new AtomicInteger();
 		BlockingGate eventGate = new BlockingGate("the change event for the interrupted flush");
 
@@ -1303,7 +1305,10 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 				@Override
 				public void onConnectionSucceeded() throws UnrecognizedFormatException, FailedMongoClientSessionException, InterruptedException, IOException, TimeoutException, InvalidCollectionContentsException, InitialStateException {
 					super.onConnectionSucceeded();
-					if (initializationDone.get()) {
+					// The first connection is the initial one; only subsequent connections are reconnects.
+					// We can't tell them apart using a flag set by the main thread, because this
+					// callback runs on the ChangeReceiver thread and races with the flag being set.
+					if (connectCount.incrementAndGet() > 1) {
 						LOGGER.debug("onConnectionSucceeded after initialization; count = {}", reconnects.incrementAndGet());
 					}
 				}
@@ -1319,7 +1324,6 @@ class MongoDriverSpecialTest extends AbstractMongoDriverTest {
 			BoskDriver driver = bosk.driver();
 			Refs refs = bosk.buildReferences(Refs.class);
 			driver.flush();
-			initializationDone.set(true);
 
 			// Gate the next change event so the flush below has to wait for it
 			armed.set(true);


### PR DESCRIPTION
## Summary

The `recoveredDriver_survivesStaleDisconnect` test in `MongoDriverSpecialTest` is flaky: in a recent CI run on `main` it failed with `AssertionFailedError` at `MongoDriverSpecialTest.java:1250`, expecting `reconnects == 1` but getting `2`.

## Root cause

The test distinguished the initial connection from reconnects using an `initializationDone` flag set by the main thread *after* Bosk construction. But the ChangeReceiver thread's initial `onConnectionSucceeded` completes at essentially the same moment (its `initialStateTask` finishes when construction finishes), so the two threads race:

- When the receiver read the flag after it was set, the *initial* connection was counted as a reconnect, and—worse—counted down the `reconnected` latch early.
- The write interceptor's `await(reconnected)` therefore returned immediately, so the forced `MongoException` was thrown *before* the disconnect/recovery happened.
- `doRetryableDriverOperation` then legitimately disconnected the healthy driver (its `driverInUse` snapshot still matched), causing an extra reconnect cycle → `reconnects == 2`.

The production code behaved correctly given the actual event ordering; only the test's synchronization was wrong.

## Fix

Count genuine reconnects on the ChangeReceiver thread itself instead of racing on a main-thread flag: the first `onConnectionSucceeded` is by construction the initial connection, and only subsequent ones are reconnects (`connectCount.incrementAndGet() > 1`). This removes the cross-thread race entirely.

Applied to `recoveredDriver_survivesStaleDisconnect` and its sibling `interruptedFlush_doesNotDisconnectHealthyDriver`, which shared the identical race.

## Verification

- Reverting the `driverInUse` mechanism (commit `0b361ada`) makes the test **fail**, confirming it still guards the regression it was written for.
- Full `:bosk-mongo:test` suite passes; both changed tests pass across repeated stress runs; `:bosk-mongo:spotlessCheck` passes.