### PR TITLE
Run the mongo tests across three parallel JVMs

### DIFF
--- a/bosk-mongo/build.gradle
+++ b/bosk-mongo/build.gradle
@@ -13,3 +13,13 @@ dependencies {
 	testImplementation project(":bosk-logback")
 	testImplementation project(":bosk-testing")
 }
+
+tasks.named('test') {
+	// Each test JVM starts its own MongoDB and toxiproxy containers
+	// (MongoService's containers are static, hence per-JVM), so spread the
+	// tests across several JVMs. This lets the long serialized network-outage
+	// tests overlap with the rest of the suite, and keeps any single container
+	// from having to serve the whole suite at once, which is what makes the
+	// wall-clock time collapse between 1-2 forks and 3+ forks.
+	maxParallelForks = 3
+}


### PR DESCRIPTION
Each test JVM starts its own MongoDB and toxiproxy containers (MongoService's containers are static, hence per-JVM), so spreading the tests across several JVMs lets the long serialized network-outage tests overlap with the rest of the suite, and keeps any single container from having to serve the whole suite at once.

This collapses the mongo test wall clock from about 135 seconds to about 80 seconds, bringing the full `check` well under the 3-minute CI budget.